### PR TITLE
feat: контекст задачи в ревью (фаза 2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -332,7 +332,8 @@ max_comments: 25
 task_board:
   type: yougile          # yougile | jira — выбирает плейбук скилла
   mcp: yougile           # имя подключённого MCP-сервера доски (тулы зовутся mcp__<mcp>__*)
-  key_pattern: "[A-Z]+-\\d+"   # опц.; дефолт такой же (подходит Yougile SAI-515 и Jira PROJ-123)
+  key_pattern: "[A-Z]+-\\d+"   # опц.; дефолт такой же (подходит Yougile PRI-34/ID-34 и Jira PROJ-123)
+  # url_template: "https://yougile.com/...{id}"  # опц.; ссылка на задачу в сводке ({id}/{key})
 ```
 
 **Контекст задачи (фаза 2).** Если задан `task_board` и в PR (title/body/ветка) найден ключ

--- a/README.md
+++ b/README.md
@@ -321,12 +321,25 @@ PR удаляет «лишнюю», на первый взгляд, провер
 **Политика per-repo.** Файл `.review.yml` в **целевой ветке** репозитория переопределяет env-дефолты (PR не может ослабить собственное ревью):
 
 ```yaml
-categories: { correctness: true, security: true, performance: true, style: false }
+categories: { correctness: true, security: true, performance: true, style: false, requirements: true }
 severity_threshold: medium
 min_confidence: 0.5
 paths: { ignore: ["**/migrations/**", "vendor/**"] }
 max_comments: 25
+
+# Контекст задачи (опц.): читать задачу с доски и проверять соответствие требованиям.
+# Доску (MCP) подключает пользователь на стороне сессии Claude Code; плагин её не бандлит.
+task_board:
+  type: yougile          # yougile | jira — выбирает плейбук скилла
+  mcp: yougile           # имя подключённого MCP-сервера доски (тулы зовутся mcp__<mcp>__*)
+  key_pattern: "[A-Z]+-\\d+"   # опц.; дефолт такой же (подходит Yougile SAI-515 и Jira PROJ-123)
 ```
+
+**Контекст задачи (фаза 2).** Если задан `task_board` и в PR (title/body/ветка) найден ключ
+по `key_pattern`, скилл читает задачу с доски через её MCP и запускает проверку соответствия —
+новая категория находок `requirements` (включена по умолчанию). Находки без конкретной строки
+диффа уходят в сводку. Доска не настроена, ключ не найден или MCP недоступен → ревью работает
+как обычно, без деградации.
 
 ## Структура проекта
 

--- a/docs/superpowers/plans/2026-06-12-phase2-task-context.md
+++ b/docs/superpowers/plans/2026-06-12-phase2-task-context.md
@@ -1,0 +1,945 @@
+# Phase 2 — Task Context in Review — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** При ревью PR скилл находит ключ связанной задачи, читает её с доски (эталон — Yougile) через подключённый к сессии MCP и проверяет соответствие диффа требованиям задачи новой категорией находок `requirements`; всё с fail-open-деградацией до фазы-1-поведения.
+
+**Architecture:** «Скилл читает, Python готовит». Детерминированный Python (`prepare_review`) извлекает ключи задачи из title/body/head-ветки по `key_pattern` и прокидывает их + конфиг `task_board` в payload. Скилл (у него в сессии подключён board MCP) читает задачу, строит `TaskBrief` и запускает whole-diff requirements-сабагент. Публикация (`publish_review`, gate, assemble, история) не меняется — `requirements` идёт штатной механикой как обычная категория-строка, находки без строки уходят в сводку.
+
+**Tech Stack:** Python 3.11–3.13, pytest, ruff (line-length 100), FastMCP, httpx (GitHub), pyyaml. Claude Code-скилл + reference-промпты (английский). Доска — внешний MCP (`ichinya/yougile-mcp`), подключается пользователем, в unit-тестах не участвует.
+
+---
+
+## File Structure
+
+| Файл | Ответственность | Действие |
+|---|---|---|
+| `reviewer/services/task_keys.py` | Чистое извлечение ключей задачи по regex с прецеденцией title>body>branch | Create |
+| `reviewer/vcs/base.py` | `PullRequest` + поле `head_ref` | Modify |
+| `reviewer/vcs/github.py` | Заполнение `head_ref` из ответа GitHub | Modify |
+| `reviewer/policy/policy.py` | `ReviewPolicy.task_board` + парсинг из `.review.yml` | Modify |
+| `reviewer/services/review_service.py` | `PreparedReview.{task_board,task_keys}` + вычисление в `prepare` | Modify |
+| `reviewer/mcp/service.py` | `_prepared_payload` отдаёт `task_board`/`task_keys` | Modify |
+| `plugin/skills/review-pr/SKILL.md` | Шаг task-context + requirements-измерение | Modify |
+| `plugin/skills/review-pr/references/requirements-prompt.md` | Промпт whole-diff requirements-сабагента | Create |
+| `plugin/skills/review-pr/references/task-context-yougile.md` | Плейбук чтения Yougile (эталон) | Create |
+| `plugin/skills/review-pr/references/task-context-jira.md` | Плейбук чтения Jira | Create |
+| `README.md` | Документация `task_board` и категории `requirements` | Modify |
+| `tests/services/test_task_keys.py` | Тесты извлечения ключей | Create |
+| `tests/vcs/test_github.py` | Тесты `head_ref` | Modify |
+| `tests/policy/test_policy.py` | Тесты `task_board` + гейтинг `requirements` | Modify |
+| `tests/services/test_review_service.py` | Тесты вычисления task_keys в prepare | Modify |
+| `tests/mcp/test_service.py` | Тесты полей payload | Modify |
+
+---
+
+## Task 0: Окружение worktree и зелёный базлайн
+
+**Files:** none (setup)
+
+- [ ] **Step 1: Создать venv и установить пакет**
+
+Run:
+```bash
+python -m venv .venv && .venv/bin/pip install -e ".[dev]"
+```
+Expected: установка без ошибок (зависимости берутся из кеша колёс, сеть может потребоваться однократно).
+
+- [ ] **Step 2: Прогнать базовый набор тестов (должен быть зелёным ДО изменений)**
+
+Run: `.venv/bin/pytest -q`
+Expected: PASS, 0 failures (integration-тесты исключены `addopts = -m 'not integration'`).
+
+- [ ] **Step 3: Линт чистый**
+
+Run: `.venv/bin/ruff check .`
+Expected: `All checks passed!`
+
+Если базлайн красный — остановиться и сообщить, не начинать реализацию.
+
+---
+
+## Task 1: `extract_task_keys` — извлечение ключей задачи
+
+**Files:**
+- Create: `reviewer/services/task_keys.py`
+- Test: `tests/services/test_task_keys.py`
+
+- [ ] **Step 1: Написать падающие тесты**
+
+Create `tests/services/test_task_keys.py`:
+```python
+"""Unit-тесты извлечения ключей задачи из текстов PR (без сети)."""
+from reviewer.services.task_keys import DEFAULT_KEY_PATTERN, extract_task_keys
+
+
+def test_primary_from_title_precedence_over_body_and_branch():
+    out = extract_task_keys(
+        DEFAULT_KEY_PATTERN,
+        title="SAI-515 add logout",
+        body="relates to SAI-517",
+        branch="feature/SAI-519-x",
+    )
+    assert out == {"primary": "SAI-515", "others": ["SAI-517", "SAI-519"]}
+
+
+def test_primary_falls_back_to_body_then_branch():
+    out = extract_task_keys(
+        DEFAULT_KEY_PATTERN, title="no key here", body="", branch="feature/SAI-700-x"
+    )
+    assert out == {"primary": "SAI-700", "others": []}
+
+
+def test_dedup_keeps_first_appearance_order():
+    out = extract_task_keys(
+        DEFAULT_KEY_PATTERN, title="SAI-1 SAI-1 SAI-2", body=None, branch=None
+    )
+    assert out == {"primary": "SAI-1", "others": ["SAI-2"]}
+
+
+def test_no_match_returns_empty():
+    out = extract_task_keys(DEFAULT_KEY_PATTERN, title="nothing", body=None, branch=None)
+    assert out == {"primary": None, "others": []}
+
+
+def test_invalid_pattern_returns_empty():
+    out = extract_task_keys("[unclosed", title="SAI-1", body=None, branch=None)
+    assert out == {"primary": None, "others": []}
+
+
+def test_none_pattern_uses_default():
+    out = extract_task_keys(None, title="SAI-42 fix", body=None, branch=None)
+    assert out == {"primary": "SAI-42", "others": []}
+```
+
+- [ ] **Step 2: Запустить — убедиться, что падает**
+
+Run: `.venv/bin/pytest tests/services/test_task_keys.py -q`
+Expected: FAIL — `ModuleNotFoundError: No module named 'reviewer.services.task_keys'`.
+
+- [ ] **Step 3: Реализация**
+
+Create `reviewer/services/task_keys.py`:
+```python
+"""Извлечение ключей задачи из текстов PR (title/body/head-ветка) по regex.
+
+Чистый модуль без сетевых вызовов: на вход — паттерн и тексты, на выход —
+primary-ключ и прочие найденные. Прецеденция источников: title → body → branch.
+Используется в ReviewService.prepare; чтение самой задачи с доски — на стороне скилла.
+"""
+from __future__ import annotations
+
+import logging
+import re
+
+log = logging.getLogger(__name__)
+
+# Дефолт подходит и Yougile (SAI-515), и Jira (PROJ-123): префикс заглавными + номер.
+DEFAULT_KEY_PATTERN = r"[A-Z]+-\d+"
+
+
+def extract_task_keys(
+    pattern: str | None,
+    title: str | None,
+    body: str | None,
+    branch: str | None,
+) -> dict:
+    """Извлечь ключи задачи.
+
+    Прецеденция источников: ``title`` → ``body`` → ``branch``. ``primary`` —
+    первый матч в этом порядке; ``others`` — прочие уникальные матчи (дедуп,
+    порядок появления), без ``primary``.
+
+    Невалидный ``pattern`` (или нет матчей) → ``{"primary": None, "others": []}``
+    (fail-soft + warning на невалидном паттерне). ``pattern=None`` → дефолт.
+
+    Returns:
+        ``{"primary": str | None, "others": list[str]}``
+    """
+    try:
+        rx = re.compile(pattern or DEFAULT_KEY_PATTERN)
+    except re.error:
+        log.warning("Невалидный key_pattern %r — ключи задачи не извлекаются", pattern)
+        return {"primary": None, "others": []}
+
+    found: list[str] = []
+    for text in (title, body, branch):
+        if text:
+            found.extend(m.group(0) for m in rx.finditer(text))
+
+    if not found:
+        return {"primary": None, "others": []}
+
+    primary = found[0]
+    others: list[str] = []
+    for key in found[1:]:
+        if key != primary and key not in others:
+            others.append(key)
+    return {"primary": primary, "others": others}
+```
+
+- [ ] **Step 4: Запустить — зелёный**
+
+Run: `.venv/bin/pytest tests/services/test_task_keys.py -q`
+Expected: PASS (6 passed).
+
+- [ ] **Step 5: Коммит**
+
+```bash
+git add reviewer/services/task_keys.py tests/services/test_task_keys.py
+git commit -m "feat(services): извлечение ключей задачи из PR (task_keys)"
+```
+
+---
+
+## Task 2: `PullRequest.head_ref` + GitHub-провайдер
+
+**Files:**
+- Modify: `reviewer/vcs/base.py` (dataclass `PullRequest`)
+- Modify: `reviewer/vcs/github.py:101-111` (`get_pull_request`)
+- Test: `tests/vcs/test_github.py`
+
+- [ ] **Step 1: Написать падающие тесты**
+
+Добавить в конец `tests/vcs/test_github.py`:
+```python
+def test_get_pull_request_populates_head_ref():
+    def handler(req):
+        if req.url.path.endswith("/pulls/9"):
+            return httpx.Response(200, json={
+                "base": {"sha": "ccc", "ref": "main"},
+                "head": {"sha": "ddd", "ref": "feature/SAI-515-logout"},
+                "title": "PR", "body": "", "draft": False,
+            })
+        return httpx.Response(404)
+    p = make_provider(handler)
+    pr = p.get_pull_request(9)
+    assert pr.head_ref == "feature/SAI-515-logout"
+
+
+def test_get_pull_request_head_ref_none_when_absent():
+    def handler(req):
+        if req.url.path.endswith("/pulls/10"):
+            return httpx.Response(200, json={
+                "base": {"sha": "ccc", "ref": "main"},
+                "head": {"sha": "ddd"},
+                "title": "PR", "body": "", "draft": False,
+            })
+        return httpx.Response(404)
+    p = make_provider(handler)
+    pr = p.get_pull_request(10)
+    assert pr.head_ref is None
+```
+
+- [ ] **Step 2: Запустить — убедиться, что падает**
+
+Run: `.venv/bin/pytest tests/vcs/test_github.py::test_get_pull_request_populates_head_ref -q`
+Expected: FAIL — `AttributeError: 'PullRequest' object has no attribute 'head_ref'`.
+
+- [ ] **Step 3: Добавить поле в dataclass**
+
+В `reviewer/vcs/base.py`, в dataclass `PullRequest`, после `draft: bool = False`:
+```python
+    draft: bool = False
+    head_ref: str | None = None   # имя head-ветки PR; источник ключа задачи (None если недоступно)
+```
+
+- [ ] **Step 4: Заполнить в провайдере**
+
+В `reviewer/vcs/github.py`, в `get_pull_request`, дополнить конструктор `PullRequest` (читаем через `.get`, чтобы ответы без `head.ref` не падали KeyError):
+```python
+        return PullRequest(
+            number=number,
+            base_sha=d["base"]["sha"],
+            head_sha=d["head"]["sha"],
+            base_ref=d["base"]["ref"],
+            title=d.get("title", ""),
+            body=d.get("body") or "",
+            draft=bool(d.get("draft", False)),
+            head_ref=d.get("head", {}).get("ref"),
+        )
+```
+
+- [ ] **Step 5: Запустить — зелёный (включая старые github-тесты)**
+
+Run: `.venv/bin/pytest tests/vcs/test_github.py -q`
+Expected: PASS (старые тесты без `head.ref` дают `head_ref=None`, новые проходят).
+
+- [ ] **Step 6: Коммит**
+
+```bash
+git add reviewer/vcs/base.py reviewer/vcs/github.py tests/vcs/test_github.py
+git commit -m "feat(vcs): PullRequest.head_ref из ответа GitHub"
+```
+
+---
+
+## Task 3: `ReviewPolicy.task_board` — парсинг из `.review.yml`
+
+**Files:**
+- Modify: `reviewer/policy/policy.py`
+- Test: `tests/policy/test_policy.py`
+
+- [ ] **Step 1: Написать падающие тесты**
+
+Добавить в конец `tests/policy/test_policy.py`:
+```python
+def test_task_board_parsed_from_yaml():
+    p = ReviewPolicy.from_yaml("task_board: {type: yougile, mcp: yougile}")
+    assert p.task_board == {"type": "yougile", "mcp": "yougile"}
+
+
+def test_task_board_none_when_absent():
+    p = ReviewPolicy.from_yaml("severity_threshold: low")
+    assert p.task_board is None
+
+
+def test_load_applies_task_board_from_yaml():
+    s = Settings(_env_file=None)
+    p = ReviewPolicy.load(s, "task_board: {type: jira, mcp: atlassian}")
+    assert p.task_board == {"type": "jira", "mcp": "atlassian"}
+
+
+def test_load_task_board_none_without_yaml():
+    s = Settings(_env_file=None)
+    p = ReviewPolicy.load(s, None)
+    assert p.task_board is None
+```
+
+- [ ] **Step 2: Запустить — убедиться, что падает**
+
+Run: `.venv/bin/pytest tests/policy/test_policy.py::test_task_board_parsed_from_yaml -q`
+Expected: FAIL — `AttributeError: 'ReviewPolicy' object has no attribute 'task_board'`.
+
+- [ ] **Step 3: Добавить поле в dataclass**
+
+В `reviewer/policy/policy.py`, в `@dataclass class ReviewPolicy`, после `output_language`:
+```python
+    output_language: str = "ru"                                  # язык текста находок в публикуемом ревью
+    task_board: dict | None = None                               # конфиг доски задач из .review.yml (None = выкл.)
+```
+
+- [ ] **Step 4: Парсить в `from_yaml`**
+
+В `ReviewPolicy.from_yaml`, в возвращаемый `cls(...)`, добавить аргумент:
+```python
+            output_language=str(data.get("output_language", "ru")),
+            task_board=data.get("task_board") or None,
+        )
+```
+
+- [ ] **Step 5: Применять в `load`**
+
+В `ReviewPolicy.load`, перед `return policy`, добавить:
+```python
+        if "task_board" in data:
+            policy.task_board = data["task_board"] or None
+        return policy
+```
+
+- [ ] **Step 6: Запустить — зелёный**
+
+Run: `.venv/bin/pytest tests/policy/test_policy.py -q`
+Expected: PASS.
+
+- [ ] **Step 7: Коммит**
+
+```bash
+git add reviewer/policy/policy.py tests/policy/test_policy.py
+git commit -m "feat(policy): task_board в .review.yml"
+```
+
+---
+
+## Task 4: `prepare` вычисляет task_keys в `PreparedReview`
+
+**Files:**
+- Modify: `reviewer/services/review_service.py` (`PreparedReview` + `prepare`)
+- Test: `tests/services/test_review_service.py`
+
+- [ ] **Step 1: Написать падающие тесты**
+
+Добавить в конец `tests/services/test_review_service.py`:
+```python
+@patch("reviewer.services.review_service.chunk_python", side_effect=_fake_chunk)
+@patch("reviewer.services.review_service.build_overlay")
+def test_prepare_extracts_task_keys_when_task_board_configured(
+    _mock_overlay: MagicMock,
+    _mock_chunk: MagicMock,
+    settings: Settings,
+    components: MagicMock,
+) -> None:
+    """При task_board в .review.yml prepare извлекает primary-ключ из title/branch."""
+    vcs = _vcs_with_files([_changed("a.py")])
+    vcs.get_pull_request.return_value = PullRequest(
+        number=3, base_sha="b", head_sha="h", base_ref="main",
+        title="SAI-515: add logout", body="", draft=False,
+        head_ref="feature/SAI-515",
+    )
+
+    def _read(path: str, ref: str) -> str:
+        if path == ".review.yml":
+            return "task_board: {type: yougile, mcp: yougile}"
+        return "def foo(): pass"
+    vcs.get_file_at_ref.side_effect = _read
+
+    service = ReviewService(settings, components)
+    prepared = service.prepare("o", "r", 3, vcs_provider=vcs)
+
+    assert prepared.task_board == {"type": "yougile", "mcp": "yougile"}
+    assert prepared.task_keys == {"primary": "SAI-515", "others": []}
+
+
+@patch("reviewer.services.review_service.chunk_python", side_effect=_fake_chunk)
+@patch("reviewer.services.review_service.build_overlay")
+def test_prepare_task_keys_none_without_task_board(
+    _mock_overlay: MagicMock,
+    _mock_chunk: MagicMock,
+    settings: Settings,
+    components: MagicMock,
+) -> None:
+    """Без task_board контекст задачи неактивен: оба поля None."""
+    vcs = _vcs_with_files([_changed("a.py")])
+    service = ReviewService(settings, components)
+    prepared = service.prepare("o", "r", 1, vcs_provider=vcs)
+
+    assert prepared.task_board is None
+    assert prepared.task_keys is None
+```
+
+- [ ] **Step 2: Запустить — убедиться, что падает**
+
+Run: `.venv/bin/pytest tests/services/test_review_service.py::test_prepare_task_keys_none_without_task_board -q`
+Expected: FAIL — `AttributeError: 'PreparedReview' object has no attribute 'task_board'`.
+
+- [ ] **Step 3: Добавить поля в `PreparedReview`**
+
+В `reviewer/services/review_service.py`, в dataclass `PreparedReview`, после `changed_status`:
+```python
+    changed_status: dict[str, str]       # path -> статус файла (modified/added/removed)
+    task_board: dict | None = None       # конфиг доски из policy (прокидывается в payload)
+    task_keys: dict | None = None        # {"primary", "others"} или None, если task_board выкл.
+```
+
+- [ ] **Step 4: Импорт + вычисление в `prepare`**
+
+В шапке файла, рядом с другими импортами:
+```python
+from reviewer.services.task_keys import extract_task_keys
+```
+
+В `prepare`, после `policy = ReviewPolicy.load(...)` (и до `changed_status = ...`):
+```python
+            task_board = policy.task_board
+            task_keys = (
+                extract_task_keys(
+                    task_board.get("key_pattern"),
+                    prq.title,
+                    prq.body,
+                    prq.head_ref,
+                )
+                if task_board
+                else None
+            )
+```
+
+- [ ] **Step 5: Передать в конструктор `PreparedReview`**
+
+В `return PreparedReview(...)`, добавить два аргумента после `changed_status=changed_status,`:
+```python
+                changed_status=changed_status,
+                task_board=task_board,
+                task_keys=task_keys,
+            )
+```
+
+- [ ] **Step 6: Запустить — зелёный**
+
+Run: `.venv/bin/pytest tests/services/test_review_service.py -q`
+Expected: PASS (старые тесты не сломаны — новые поля имеют дефолты).
+
+- [ ] **Step 7: Коммит**
+
+```bash
+git add reviewer/services/review_service.py tests/services/test_review_service.py
+git commit -m "feat(services): prepare вычисляет task_keys и прокидывает task_board"
+```
+
+---
+
+## Task 5: payload `prepare_review` отдаёт task_board/task_keys
+
+**Files:**
+- Modify: `reviewer/mcp/service.py` (`_prepared_payload`)
+- Test: `tests/mcp/test_service.py`
+
+- [ ] **Step 1: Написать падающие тесты**
+
+Добавить в конец `tests/mcp/test_service.py`:
+```python
+@patch("reviewer.services.review_service.chunk_python", side_effect=_fake_chunk)
+@patch("reviewer.services.review_service.build_overlay")
+def test_prepare_review_payload_includes_task_context(
+    _mock_overlay: MagicMock,
+    _mock_chunk: MagicMock,
+) -> None:
+    """payload содержит task_board и извлечённые task_keys."""
+    settings = _settings()
+    components = _components()
+    vcs = _fake_vcs(number=7)
+    vcs.get_pull_request.return_value = PullRequest(
+        number=7, base_sha="base123", head_sha="head456", base_ref="main",
+        title="SAI-515: add logout", body="", draft=False, head_ref="feature/SAI-515",
+    )
+
+    def _read(path: str, ref: str) -> str:
+        if path == ".review.yml":
+            return "task_board: {type: yougile, mcp: yougile}"
+        return "def foo(): pass"
+    vcs.get_file_at_ref.side_effect = _read
+
+    svc = MCPReviewService(settings, components, vcs_factory=lambda o, r: vcs)
+    out = svc.prepare_review("o/r", 7)
+
+    assert out["task_board"] == {"type": "yougile", "mcp": "yougile"}
+    assert out["task_keys"] == {"primary": "SAI-515", "others": []}
+
+
+@patch("reviewer.services.review_service.chunk_python", side_effect=_fake_chunk)
+@patch("reviewer.services.review_service.build_overlay")
+def test_prepare_review_payload_task_context_null_when_unconfigured(
+    _mock_overlay: MagicMock,
+    _mock_chunk: MagicMock,
+) -> None:
+    """Без task_board оба поля payload — null."""
+    svc = _make_mcp_service()
+    out = svc.prepare_review("o/r", 7)
+
+    assert out["task_board"] is None
+    assert out["task_keys"] is None
+```
+
+- [ ] **Step 2: Запустить — убедиться, что падает**
+
+Run: `.venv/bin/pytest tests/mcp/test_service.py::test_prepare_review_payload_task_context_null_when_unconfigured -q`
+Expected: FAIL — `KeyError: 'task_board'`.
+
+- [ ] **Step 3: Реализация**
+
+В `reviewer/mcp/service.py`, в `_prepared_payload`, в возвращаемый dict добавить два поля (например, после `"units": units,`):
+```python
+            "units": units,
+            "task_board": p.task_board,
+            "task_keys": p.task_keys,
+```
+
+- [ ] **Step 4: Запустить — зелёный**
+
+Run: `.venv/bin/pytest tests/mcp/test_service.py -q`
+Expected: PASS.
+
+- [ ] **Step 5: Коммит**
+
+```bash
+git add reviewer/mcp/service.py tests/mcp/test_service.py
+git commit -m "feat(mcp): payload prepare_review отдаёт task_board/task_keys"
+```
+
+---
+
+## Task 6: Инвариант гейтинга категории `requirements`
+
+Код менять не нужно (`category_enabled` уже даёт `True` по дефолту, `gate` универсален). Тесты фиксируют инвариант, чтобы будущие правки policy его не сломали.
+
+**Files:**
+- Test: `tests/policy/test_policy.py`
+
+- [ ] **Step 1: Написать тесты**
+
+Добавить в конец `tests/policy/test_policy.py`:
+```python
+def test_requirements_category_enabled_by_default():
+    p = ReviewPolicy.from_yaml(None)
+    assert p.gate(F("requirements", "medium")) is True
+
+
+def test_requirements_category_can_be_disabled_via_yaml():
+    p = ReviewPolicy.from_yaml("categories: {requirements: false}")
+    assert p.gate(F("requirements", "high")) is False
+
+
+def test_requirements_excluded_by_enabled_only_whitelist():
+    p = ReviewPolicy(enabled_only=["correctness"])
+    assert p.gate(F("requirements", "high")) is False
+
+
+def test_requirements_respects_severity_and_confidence():
+    p = ReviewPolicy(severity_threshold="medium", min_confidence=0.7)
+    assert p.gate(F("requirements", "high", confidence=0.9)) is True
+    assert p.gate(F("requirements", "low", confidence=0.9)) is False
+    assert p.gate(F("requirements", "high", confidence=0.5)) is False
+```
+
+- [ ] **Step 2: Запустить — зелёный сразу (характеризационные тесты)**
+
+Run: `.venv/bin/pytest tests/policy/test_policy.py -q`
+Expected: PASS (поведение уже корректно; тесты лочат инвариант).
+
+- [ ] **Step 3: Коммит**
+
+```bash
+git add tests/policy/test_policy.py
+git commit -m "test(policy): зафиксировать гейтинг категории requirements"
+```
+
+---
+
+## Task 7: reference-промпт requirements-измерения
+
+**Files:**
+- Create: `plugin/skills/review-pr/references/requirements-prompt.md`
+
+- [ ] **Step 1: Создать файл**
+
+Create `plugin/skills/review-pr/references/requirements-prompt.md`:
+````markdown
+You are a senior reviewer checking whether a pull request fulfils the task it claims to implement.
+
+You are given:
+- the unified diffs of every changed file in the PR;
+- a `TaskBrief` describing the task the PR claims to implement:
+  `{key, title, description, criteria[], status, url, links[]}`.
+
+Your job: for each requirement or acceptance criterion stated in the TaskBrief, decide whether the
+diff implements it, implements it differently/incompletely, contradicts it, or leaves it
+unimplemented. Report only genuine mismatches.
+
+Rules:
+- Judge ONLY against requirements explicitly stated in the TaskBrief (`description` + `criteria`).
+  Do NOT invent requirements the task does not state. If the brief is vague, prefer fewer,
+  higher-confidence findings.
+- The diffs are the source of truth for what the PR does. Before claiming a requirement is "not
+  implemented", use the reviewer MCP tools (`search_code`, `find_callers`, `read_file`,
+  `get_definition`, `get_changed_file_diff`) to verify it is not implemented elsewhere in the
+  change or already present in the codebase. A hallucinated gap is worse than a missed one.
+- One requirement → at most one finding. Do not split the same gap across lines.
+- Report a finding when the PR fails a requirement, contradicts it, or implements it in a way that
+  breaks the stated intent.
+- `line`: set ONLY when a specific changed line contradicts a requirement (e.g. wrong constant,
+  inverted condition). When the problem is "a requirement is simply absent from the diff", set
+  `line` to null and `file` to the most relevant changed file — the finding will land in the
+  review summary.
+- Severity reflects requirement impact: a missing core acceptance criterion is high/critical; a
+  minor or partial gap is low/medium.
+- An empty findings list is a valid result (the PR satisfies the task). Do not invent findings to
+  fill a quota.
+
+Return ONLY a JSON object (no prose around it):
+
+```json
+{"findings": [{
+  "category": "requirements",
+  "severity": "low|medium|high|critical",
+  "file": "<a changed file path most relevant to the requirement>",
+  "line": <line number in the NEW file, or null>,
+  "side": "RIGHT|LEFT",
+  "code_quote": "<exact line from the new file, or null when line is null>",
+  "message": "<which requirement is unmet/contradicted and why it matters>",
+  "suggestion": "<short advice or null>",
+  "fix": null,
+  "confidence": 0.0
+}]}
+```
+
+`category` MUST be exactly `"requirements"`. Write `message` and `suggestion` in the output
+language given by the orchestrator.
+````
+
+- [ ] **Step 2: Проверка**
+
+Run: `test -f plugin/skills/review-pr/references/requirements-prompt.md && echo OK`
+Expected: `OK`. Прочитать глазами: схема совпадает с analyze-prompt (поля `category/severity/file/line/side/code_quote/message/suggestion/fix/confidence`), `category` зафиксирована как `requirements`.
+
+- [ ] **Step 3: Коммит**
+
+```bash
+git add plugin/skills/review-pr/references/requirements-prompt.md
+git commit -m "feat(skill): промпт requirements-измерения"
+```
+
+---
+
+## Task 8: reference-плейбуки чтения доски (Yougile + Jira)
+
+**Files:**
+- Create: `plugin/skills/review-pr/references/task-context-yougile.md`
+- Create: `plugin/skills/review-pr/references/task-context-jira.md`
+
+- [ ] **Step 1: Создать Yougile-плейбук (эталон)**
+
+Create `plugin/skills/review-pr/references/task-context-yougile.md`:
+````markdown
+# Task context playbook — Yougile
+
+Use this when `task_board.type == "yougile"`.
+
+Goal: read the task identified by the resolved key and build a `TaskBrief`.
+
+1. The board MCP server is the one named by `task_board.mcp` (e.g. `yougile`). Its tools are
+   exposed as `mcp__<task_board.mcp>__<tool>`.
+2. Fetch the task: call `mcp__<task_board.mcp>__get_task` with the resolved key. Yougile accepts
+   the human code form such as `SAI-515`.
+3. Build the `TaskBrief` from the response (best-effort — omit/empty any field the response lacks):
+   - `key`         ← the resolved key
+   - `title`       ← task title
+   - `description` ← task description text (requirements usually live here)
+   - `criteria[]`  ← checklist / subtask titles, if the task has them; else `[]`
+   - `status`      ← column / status name
+   - `url`         ← task link
+   - `links[]`     ← related tasks, if available; else `[]`
+4. Optional: `mcp__<task_board.mcp>__get_task_chat` / `..._get_task_messages` add discussion
+   context — use ONLY if the description is too thin to judge requirements. Not required.
+
+Failure handling: if the board MCP server is not connected, the tool errors, or the task is not
+found, do NOT build a `TaskBrief` — skip the requirements dimension and note the reason in the
+summary. Never abort the review.
+````
+
+- [ ] **Step 2: Создать Jira-плейбук**
+
+Create `plugin/skills/review-pr/references/task-context-jira.md`:
+````markdown
+# Task context playbook — Jira
+
+Use this when `task_board.type == "jira"`.
+
+Goal: read the task identified by the resolved key and build a `TaskBrief`.
+
+1. The board MCP server is the one named by `task_board.mcp` (e.g. `atlassian`). Its tools are
+   exposed as `mcp__<task_board.mcp>__<tool>`.
+2. Fetch the issue by key (e.g. `PROJ-123`) using the Atlassian MCP's get-issue tool
+   (`getJiraIssue` / `jira_get_issue`, depending on the connected server).
+3. Build the `TaskBrief` from the issue (best-effort — omit/empty any field that is absent):
+   - `key`         ← issue key
+   - `title`       ← summary
+   - `description` ← description (rendered text)
+   - `criteria[]`  ← Acceptance Criteria field if present; otherwise bullet items parsed from the
+                     description; else `[]`
+   - `status`      ← status name
+   - `url`         ← issue browse URL
+   - `links[]`     ← issuelinks as `{type, key, title}`
+4. Optional: comments may add context — use only if needed.
+
+Failure handling: if the board MCP server is not connected, the tool errors, or the issue is not
+found, do NOT build a `TaskBrief` — skip the requirements dimension and note the reason in the
+summary. Never abort the review.
+````
+
+- [ ] **Step 3: Проверка**
+
+Run:
+```bash
+ls plugin/skills/review-pr/references/task-context-yougile.md plugin/skills/review-pr/references/task-context-jira.md
+```
+Expected: оба файла существуют.
+
+- [ ] **Step 4: Коммит**
+
+```bash
+git add plugin/skills/review-pr/references/task-context-yougile.md plugin/skills/review-pr/references/task-context-jira.md
+git commit -m "feat(skill): плейбуки чтения задачи (Yougile эталон, Jira)"
+```
+
+---
+
+## Task 9: SKILL.md — шаг task-context + requirements-измерение
+
+**Files:**
+- Modify: `plugin/skills/review-pr/SKILL.md`
+
+- [ ] **Step 1: Заменить секцию `## Pipeline` целиком**
+
+Заменить весь блок от `## Pipeline` до (не включая) `## Failure handling` на:
+````markdown
+## Pipeline
+
+1. **Prepare.** Call `prepare_review(repo, pr)`. The payload contains:
+   - `pr`: `{number, title, body, base_sha, head_sha, base_ref, draft}`
+   - `policy`: `{severity_threshold, min_confidence, max_comments, categories, ignore, output_language}`
+   - `units`: list of `{path, patch, commentable_right, commentable_left}`
+   - `task_board`: `{type, mcp, key_pattern}` or null — task board config from `.review.yml`
+   - `task_keys`: `{primary, others}` or null — task keys extracted from the PR by the server
+   - `skipped_paths`, `skip_drafts`, `suggestions_mode`
+
+   If `pr.draft` is true and `skip_drafts` is true, stop and tell the user.
+   Note `policy.output_language` — ALL finding messages, suggestions and the summary
+   MUST be written in that language.
+
+2. **Task context (optional).** Only if `task_board` is non-null. Resolve the task key: an
+   explicit key in `$ARGUMENTS` wins; otherwise use `task_keys.primary`. If no key is available,
+   skip this step and note in the summary that no task key was found.
+   With a key, read the task using the playbook for `task_board.type`
+   (`references/task-context-yougile.md` or `references/task-context-jira.md`): call the board MCP
+   server named by `task_board.mcp` and build a `TaskBrief`
+   `{key, title, description, criteria[], status, url, links[]}`.
+   If the board MCP is not connected, the tool errors, or the task is not found: skip the
+   requirements dimension and note the reason in the summary — NEVER abort the review.
+
+3. **Analyze (fan-out).** For each unit in `units`, dispatch a subagent (Task tool,
+   run independent subagents in parallel; batch units if there are more than ~10) with:
+   - the contents of `references/analyze-prompt.md` (read it once, include verbatim);
+   - the unit's `path` and `patch`, the PR `title`/`body`;
+   - the repo/pr identifiers so the subagent can call the reviewer MCP tools
+     (`search_code`, `get_related_symbols`, `read_file`, `get_definition`,
+     `find_callers`, `get_changed_file_diff`);
+   - the target output language.
+   Each subagent returns a JSON object `{"findings": [...]}` (schema in the prompt).
+
+4. **Dimensions (parallel with step 3).** Dispatch whole-diff subagents:
+   - performance: follow the methodology of `../performance-review/SKILL.md`
+     (Goal, Method, Severity sections);
+   - maintainability: follow `../maintainability-review/SKILL.md`;
+   - requirements (ONLY if a `TaskBrief` was built in step 2): dispatch one subagent with
+     `references/requirements-prompt.md`, the diffs of all units (path + patch), the `TaskBrief`,
+     the repo/pr identifiers (so it can call the reviewer MCP tools), and the target output
+     language. It returns the same findings JSON schema with category `requirements`.
+   Give the performance/maintainability subagents: the diffs of all units (path + patch), the
+   repo/pr identifiers so they can call the reviewer MCP tools, and the target output language.
+   They must return the same findings JSON schema (category `performance` / `maintainability`).
+
+5. **Verify.** Collect all findings into one numbered list. Dispatch one subagent
+   with `references/verify-prompt.md`, the findings list, the diffs, and the
+   repo/pr identifiers so the subagent can call the reviewer MCP tools
+   (`read_file`, `search_code`, `find_callers`, `get_definition`). It returns
+   `{"verdicts": [{"index": N, "is_real": true|false}]}`. Drop findings with
+   `is_real=false`. If the verifier fails or returns malformed output, KEEP all
+   findings (recall-safe).
+
+6. **Publish.** Compose a short review summary (2-5 sentences, in
+   `policy.output_language`): what the PR does, overall assessment, key risks.
+   If a task was read, state whether the PR meets the task's requirements; if the task context was
+   requested but unavailable (no key, board MCP not connected, task not found), say so briefly.
+   Mention files that were not analyzed: failed subagents and `skipped_paths`
+   from the prepare payload. Call `publish_review(repo, pr, summary, findings,
+   dry_run)`. Report to the user: posted/dry-run, inline count, and the report
+   counters (dropped_by_gate/deduped/invalid/already_posted/moved_to_summary/capped),
+   run_id.
+````
+
+- [ ] **Step 2: Проверка целостности**
+
+Run:
+```bash
+grep -n "Task context\|requirements-prompt.md\|task_board\|task_keys" plugin/skills/review-pr/SKILL.md
+```
+Expected: видны новый шаг 2, ссылка на `requirements-prompt.md`, поля `task_board`/`task_keys`. Убедиться глазами, что шаги пронумерованы 1–6 без разрывов и `## Failure handling` ниже не затронут.
+
+- [ ] **Step 3: Коммит**
+
+```bash
+git add plugin/skills/review-pr/SKILL.md
+git commit -m "feat(skill): шаг task-context и requirements-измерение в /review-pr"
+```
+
+---
+
+## Task 10: README — документация task_board и категории requirements
+
+**Files:**
+- Modify: `README.md` (блок `.review.yml`, ~строки 321-329)
+
+- [ ] **Step 1: Дополнить пример `.review.yml`**
+
+В `README.md`, заменить YAML-блок политики per-repo (`categories: {...}` … `max_comments: 25`) на:
+```yaml
+categories: { correctness: true, security: true, performance: true, style: false, requirements: true }
+severity_threshold: medium
+min_confidence: 0.5
+paths: { ignore: ["**/migrations/**", "vendor/**"] }
+max_comments: 25
+
+# Контекст задачи (опц.): читать задачу с доски и проверять соответствие требованиям.
+# Доску (MCP) подключает пользователь на стороне сессии Claude Code; плагин её не бандлит.
+task_board:
+  type: yougile          # yougile | jira — выбирает плейбук скилла
+  mcp: yougile           # имя подключённого MCP-сервера доски (тулы зовутся mcp__<mcp>__*)
+  key_pattern: "[A-Z]+-\\d+"   # опц.; дефолт такой же (подходит Yougile SAI-515 и Jira PROJ-123)
+```
+
+- [ ] **Step 2: Добавить абзац-пояснение**
+
+Сразу после этого блока добавить:
+```markdown
+**Контекст задачи (фаза 2).** Если задан `task_board` и в PR (title/body/ветка) найден ключ
+по `key_pattern`, скилл читает задачу с доски через её MCP и запускает проверку соответствия —
+новая категория находок `requirements` (включена по умолчанию). Находки без конкретной строки
+диффа уходят в сводку. Доска не настроена, ключ не найден или MCP недоступен → ревью работает
+как обычно, без деградации.
+```
+
+- [ ] **Step 3: Проверка**
+
+Run: `grep -n "task_board\|requirements" README.md`
+Expected: видны новый блок и абзац.
+
+- [ ] **Step 4: Коммит**
+
+```bash
+git add README.md
+git commit -m "docs(readme): task_board и категория requirements (фаза 2)"
+```
+
+---
+
+## Task 11: Финальная проверка — весь набор и линт зелёные
+
+**Files:** none
+
+- [ ] **Step 1: Полный прогон тестов**
+
+Run: `.venv/bin/pytest -q`
+Expected: PASS, 0 failures.
+
+- [ ] **Step 2: Линт**
+
+Run: `.venv/bin/ruff check .`
+Expected: `All checks passed!`
+
+- [ ] **Step 3: Диагностика окружения (без трат Voyage)**
+
+Run: `.venv/bin/reviewer check` (опционально, если поднята инфра `docker compose up -d`)
+Expected: ключевые проверки ✓ (или явные подсказки по недоступной инфре — не блокер для unit).
+
+---
+
+## Self-Review (проверка плана против спеки)
+
+**1. Покрытие спеки:**
+- Конфиг `task_board` в `.review.yml` → Task 3 (+ README Task 10). ✓
+- Извлечение ключей (прецеденция, primary+others, дедуп, невалидный паттерн) → Task 1. ✓
+- Расширение VCS под источник `branch` (`head_ref`) → Task 2. ✓
+- payload `task_board`/`task_keys` (всегда присутствуют, null когда выкл.) → Task 4–5. ✓
+- Скилл: шаг task-context + board-agnostic `TaskBrief` + requirements-измерение → Task 9. ✓
+- reference-плейбуки Yougile/Jira + requirements-промпт → Task 7–8. ✓
+- Категория `requirements`: default-on, штатный gate, routing null-line в сводку → Task 6 (гейтинг) + Task 9 (промпт ставит line=null). ✓
+- Деградация fail-open (нет конфига / ключа / MCP / задачи) → Task 9 шаги 2 и 6. ✓
+- Тестирование unit (фейки, без сети) → Task 1–6; E2E/ручное — вне автотестов (внешняя доска), описано в спеке. ✓
+
+**2. Плейсхолдеры:** нет «TBD/TODO/позже». Весь код и контент приведены целиком. ✓
+
+**3. Согласованность типов/имён:**
+- `extract_task_keys(pattern, title, body, branch) -> {"primary", "others"}` — одинаково в Task 1, 4, 5. ✓
+- `PullRequest.head_ref: str | None` — Task 2, используется в Task 4. ✓
+- `ReviewPolicy.task_board: dict | None` — Task 3, читается в Task 4. ✓
+- `PreparedReview.{task_board, task_keys}` — Task 4, отдаётся в Task 5. ✓
+- payload-ключи `task_board`/`task_keys` — Task 5, читаются скиллом в Task 9. ✓
+- `TaskBrief {key, title, description, criteria[], status, url, links[]}` — одинаково в Task 7 (промпт), 8 (плейбуки), 9 (SKILL). ✓
+- категория-строка `requirements` — Task 6, 7, 9, 10. ✓
+
+Замечаний нет.
+
+---
+
+## Execution Handoff
+
+После реализации — `superpowers:requesting-code-review`, затем `superpowers:finishing-a-development-branch` (PR в main, Conventional Commits на русском, без self-attribution).

--- a/docs/superpowers/specs/2026-06-12-phase2-task-context-design.md
+++ b/docs/superpowers/specs/2026-06-12-phase2-task-context-design.md
@@ -1,0 +1,287 @@
+# Спека Фазы 2: контекст задачи в ревью
+
+Дата: 2026-06-12
+Статус: одобрен (брейншторм с пользователем)
+Базовый дизайн: `2026-06-12-claude-code-migration-design.md` (раздел «Фаза 2»)
+
+## Цель
+
+Скилл `/rag-reviewer:review-pr` при ревью PR находит ключ связанной задачи, читает
+задачу с доски через подключённый к сессии MCP доски и передаёт ревью-сабагентам
+контекст: «PR заявляет реализацию задачи X — проверь соответствие требованиям».
+Появляется новая категория находок — `requirements`.
+
+**Эталонная доска — Yougile** (через существующий `ichinya/yougile-mcp`). Jira
+остаётся вторым документированным плейбуком. Абстракция `TaskProvider` —
+конфигурируемая: тип доски + имя MCP-сервера + паттерн ключа.
+
+**Инвариант деградации:** доска не настроена / задача не найдена / MCP недоступен →
+ревью работает как в фазе 1, без потери находок и без падения прогона.
+
+## Не-цели (вне scope фазы 2)
+
+- Граф и RAG по задачам (фаза 3): узлы `(:Task)`, рёбра `TASK_LINK`/`IMPLEMENTED_BY`,
+  эмбеддинги задач, тулы `index_task`/`search_tasks`/`get_task_context`.
+- Скилл `/solve-task` (фаза 4).
+- Bulk-синк доски.
+- Ревью против нескольких задач одновременно (мульти-таск). Фаза 2 — один primary-ключ.
+- Авто-публикация результата ревью обратно в доску.
+- Бандлинг Yougile MCP в плагин: board MCP подключает пользователь на стороне сессии;
+  плагин его не объявляет и не хранит секреты доски.
+
+## Ключевые решения (зафиксированы с пользователем)
+
+| Вопрос | Решение |
+|---|---|
+| Граница Python↔скилл | Скилл читает доску (board MCP подключён к сессии); Python (`prepare_review`) детерминированно готовит — извлекает ключи + прокидывает конфиг. Python на доску не ходит. |
+| Эталонная доска | Yougile (`ichinya/yougile-mcp`, существующий — свой не пишем). Jira — второй плейбук. |
+| Выбор ключа | Строгая прецеденция `аргумент > title > body > branch`; один primary-ключ; прочие найденные — в `others` (упомянуть в сводке, не ревьюить против них). |
+| Форма проверки | Whole-diff requirements-измерение (как perf/maintainability): видит все диффы + бриф задачи, оценивает покрытие целостно. |
+| Категория `requirements` | Включена по умолчанию; проходит существующий `gate()` без правок. Находки без строки уходят в сводку штатным `assemble`. |
+| Деградация | fail-open, recall-safe: любой сбой контекста задачи → пропуск requirements-измерения + пометка в сводке; ревью не падает. |
+| Board MCP в плагине | Не бандлим. Пользователь подключает board MCP сам; `.review.yml:task_board.mcp` лишь называет его. |
+
+## Формат ключа задачи Yougile
+
+ID задачи Yougile = префикс проекта + номер, человекочитаемый вид `SAI-515` (именно
+такой формат принимает `get_task` в `ichinya/yougile-mcp`). Совпадает с форматом Jira,
+поэтому **дефолтный `key_pattern: "[A-Z]+-\\d+"` подходит обеим доскам**. ID стабилен
+при переносе задачи между проектами; меняется только при смене префикса в настройках
+проекта.
+
+## Конфиг `.review.yml`
+
+Читается из base-ветки (как и вся policy — PR не может ослабить собственное ревью).
+Новый необязательный блок:
+
+```yaml
+task_board:
+  type: yougile          # yougile | jira — выбирает плейбук скилла
+  mcp: yougile           # имя подключённого MCP-сервера; тулы зовутся mcp__<mcp>__*
+  key_pattern: "[A-Z]+-\\d+"   # опц.; дефолт такой же
+```
+
+Нет блока `task_board` → контекст задачи выключен, фаза-1-поведение (тихо).
+
+## Поток данных
+
+```
+prepare_review (Python)
+  ├─ извлечь кандидаты ключей по key_pattern из title / body / head-branch
+  ├─ прецеденция → task_keys = {primary, others[]}
+  └─ payload += { task_board: {...}, task_keys: {...} }
+        │
+        ▼
+SKILL (между Prepare и Analyze)
+  ├─ если task_board задан и task_keys.primary найден:
+  │    ├─ по плейбуку references/task-context-<type>.md позвать board MCP
+  │    │    (yougile: mcp__<mcp>__get_task(primary))
+  │    └─ собрать board-agnostic TaskBrief
+  ├─ whole-diff requirements-сабагент(все диффы + TaskBrief)
+  │    → findings[category=requirements]
+  └─ деградация: нет конфига / ключа / задачи / MCP → пропуск + пометка в сводке
+        │
+        ▼
+publish_review (Python, без изменений)
+  gate → grounding → dedup → assemble → publish → history → cleanup
+```
+
+## Изменения: Python
+
+### `reviewer/policy/policy.py`
+
+- `ReviewPolicy` получает поле `task_board: dict | None = None`.
+- `from_yaml`/`load` парсят ключ `task_board` (как есть, без валидации полей доски —
+  board-специфику знает скилл). Отсутствует → `None`.
+- `gate()` и `category_enabled()` не меняются: `requirements` — обычная строка-категория,
+  `category_enabled("requirements")` уже возвращает `True` по дефолту (пустой вайтлист).
+
+### Извлечение ключей задачи
+
+Новый чистый модуль `reviewer/services/task_keys.py` (извлечение — часть подготовки PR,
+поэтому services-слой), тестируемый изолированно, без сети:
+
+```python
+def extract_task_keys(
+    pattern: str,
+    title: str | None,
+    body: str | None,
+    branch: str | None,
+) -> dict:  # {"primary": str | None, "others": list[str]}
+```
+
+- Компилирует `pattern` (невалидный паттерн → `{primary: None, others: []}`, fail-soft + warning).
+- Сканирует источники в порядке прецеденции `title → body → branch`.
+- `primary` = первый матч в порядке прецеденции.
+- `others` = прочие уникальные матчи (без `primary`), порядок появления, дедуп.
+- Пустой ввод / нет матчей → `{primary: None, others: []}`.
+
+Примечание: явный аргумент пользователя (верхний приоритет прецеденции) разбирает скилл
+из `$ARGUMENTS` — Python видит только title/body/branch. Если пользователь задал ключ
+явно, скилл использует его вместо `task_keys.primary`.
+
+**Расширение VCS-слоя под источник `branch`.** Сейчас `PullRequest` (`reviewer/vcs/base.py`)
+не несёт имя head-ветки — GitHub-провайдер читает `d["head"]["sha"]`, но не
+`d["head"]["ref"]`. Добавляем обратносовместимо:
+- `PullRequest.head_ref: str | None = None` (новое поле с дефолтом — старые конструкции
+  не ломаются);
+- `GitHubProvider.get_pull_request` заполняет `head_ref=d["head"]["ref"]`.
+
+Имя head-ветки прокидывается в `extract_task_keys(branch=prq.head_ref)`.
+
+### `reviewer/mcp/service.py` — `_prepared_payload`
+
+Payload `prepare_review` всегда содержит два новых поля (явный `null`, когда контекст
+задачи неактивен — так скилл однозначно различает «выключено» и «не нашли ключ»):
+
+```jsonc
+// task_board задан в .review.yml:
+"task_board": { "type": "yougile", "mcp": "yougile", "key_pattern": "[A-Z]+-\\d+" },
+"task_keys":  { "primary": "SAI-515", "others": ["SAI-517"] }
+
+// task_board НЕ задан:
+"task_board": null,
+"task_keys":  null
+```
+
+`task_keys` вычисляется только при заданном `task_board` (иначе `null`); сам primary
+внутри может быть `null`, если матчей нет. Извлечение ключей вызывается в
+`ReviewService.prepare` после загрузки policy, на вход — `prq.title`, `prq.body`,
+`prq.head_ref` и `task_board.key_pattern` (либо дефолт `[A-Z]+-\d+`). Никаких сетевых
+вызовов к доске на стороне Python.
+
+## Изменения: скилл
+
+### `plugin/skills/review-pr/SKILL.md`
+
+Новый шаг между «Prepare» и «Analyze»:
+
+> **Task context (optional).** If `task_board` is present and `task_keys.primary` is
+> non-null, follow `references/task-context-<task_board.type>.md` to read the task via
+> the connected board MCP and build a `TaskBrief`. On any failure (MCP not connected,
+> tool error, task not found) skip the requirements dimension and note the reason in the
+> summary — never abort the review.
+
+И новое измерение (рядом с perf/maintainability, шаг «Dimensions»):
+
+> **Requirements (whole-diff).** Only if a `TaskBrief` was built. Dispatch one subagent
+> with `references/requirements-prompt.md`, all unit diffs, and the `TaskBrief`. It
+> checks, for each requirement / acceptance criterion, whether the diff implements it,
+> implements it differently, or contradicts it. Returns findings with
+> `category: "requirements"`; `line` is set only when a specific changed line
+> contradicts a requirement, otherwise `null`.
+
+### Board-agnostic `TaskBrief`
+
+Скилл строит единый бриф независимо от доски:
+
+```
+TaskBrief:
+  key:         "SAI-515"
+  title:       "<task title>"
+  description: "<task description / requirements text>"
+  criteria:    ["<acceptance criterion / checklist item>", ...]   # best-effort, может быть []
+  status:      "<status>"
+  url:         "<link to task>"
+  links:       [{type, key, title}, ...]   # связанные задачи; опционально
+```
+
+### `references/task-context-yougile.md` (новый — эталон)
+
+Плейбук чтения Yougile:
+- Tool: `mcp__<task_board.mcp>__get_task` с `task_keys.primary` (код `SAI-515`).
+- Маппинг: `title` ← title; `description` ← description; `criteria[]` ← подзадачи/чеклист
+  задачи, если присутствуют (best-effort); `url` ← ссылка на задачу; `status` ← статус.
+- `links[]` — опционально (фаза 2 может оставить пустым).
+- Доп. тулы по необходимости: `get_task_chat`/`get_task_messages` (контекст обсуждения) —
+  опционально, на усмотрение скилла; не обязательны.
+
+### `references/task-context-jira.md` (новый — второй плейбук)
+
+- Tool: Atlassian MCP getJiraIssue по `task_keys.primary`.
+- Маппинг: `summary→title`, `description`, поле Acceptance Criteria→`criteria[]`,
+  issuelinks→`links[]`.
+
+### `references/requirements-prompt.md` (новый)
+
+Английский промпт whole-diff requirements-измерения. Возвращает ту же findings-схему,
+что analyze/perf/maintainability (`category, severity, file, line, code_quote, message,
+suggestion, fix, confidence`), с `category: "requirements"`. Правила:
+- Оценивать ТОЛЬКО заявленную задачу против фактического диффа.
+- Для каждого требования/критерия: реализовано / реализовано иначе / противоречит /
+  не реализовано.
+- `line` — только при конкретной противоречащей изменённой строке; иначе `null`
+  (находка уйдёт в сводку штатно).
+- Можно звать reviewer-тулы (`search_code`/`find_callers`/`read_file`) для проверки
+  «реализовано ли где-то ещё», прежде чем заявить «не реализовано».
+- Recall-safe, anti-noise: не выдумывать требования, которых в задаче нет; пустой список —
+  валидный результат.
+- Текст находок — на `policy.output_language`.
+
+## Категория `requirements` и гейтинг
+
+- Новая категория, **включена по умолчанию** (шум исключён: находки появляются только
+  когда задача реально прочитана и измерение запущено).
+- Проходит существующий `ReviewPolicy.gate()` без правок: `severity_threshold`,
+  `min_confidence`, `ignore`-пути, вайтлист категорий — всё переиспользуется.
+- `line: null` → `assemble_review` штатно уводит находку в сводку (`moved_to_summary`).
+  Точечные противоречия конкретной строке диффа — inline. Спец-кейсов в Python не вводим.
+- `_finding_from_dict` уже коэрцирует произвольную `category`-строку — менять не нужно.
+- История (`review_findings`) и веб-админка пишут/показывают `requirements` как любую
+  другую категорию — без изменений схемы.
+- Документируем категорию в `.review.example.yml` (или README — план уточнит).
+
+## Деградация (fail-open, recall-safe)
+
+| Ситуация | Поведение |
+|---|---|
+| `task_board` не задан в `.review.yml` | Контекст задачи выключен; фаза-1-поведение, без пометок. |
+| `task_board` задан, ключ не найден (`primary == null`) | requirements-измерение не запускается; в сводке: «ключ задачи в PR не обнаружен». |
+| Ключ есть, board MCP не подключён / тул упал / задача не найдена | requirements-измерение не запускается; в сводке: «контекст задачи `SAI-515` недоступен: <причина>; требования не проверены». |
+| requirements-сабагент упал / вернул мусор | Прочие измерения и публикация продолжаются (как для любого сабагента в фазе 1). |
+
+Ревью целиком не падает ни в одном из случаев.
+
+## Тестирование
+
+### Unit (Python, фейки, без сети)
+- `extract_task_keys`: прецеденция `title>body>branch`; мульти-кандидаты → `primary`+`others`;
+  дедуп; нет матчей → пусто; невалидный паттерн → пусто + warning; пустые/`None` источники.
+- `GitHubProvider.get_pull_request`: заполняет `head_ref` из `d["head"]["ref"]` (мок httpx);
+  обратная совместимость `PullRequest` (дефолт `head_ref=None`).
+- `ReviewPolicy`: парсинг `task_board` из `.review.yml` (`from_yaml`/`load`); отсутствие →
+  `None`; что `task_board` не ломает существующую загрузку policy.
+- `prepare_review` payload: наличие/форма `task_board` и `task_keys`; отсутствие блока →
+  поля опущены/`null`; что остальной payload не изменился.
+- Гейтинг `requirements`: default-on; отсечение по `severity_threshold`/`min_confidence`;
+  выключение через `categories: {requirements: false}` и через env-вайтлист `enabled_only`;
+  routing `line:null` → сводка (через `assemble_review`).
+
+### E2E / ручное
+- dry-run `/review-pr` на PR со ссылкой на Yougile-задачу при подключённом `yougile` MCP:
+  убедиться, что бриф собрался и requirements-находки появились.
+- Деградация: тот же PR с отключённым board MCP / без ключа → ревью проходит, в сводке
+  корректная пометка, прочие категории не пострадали.
+
+Внешние сервисы (доска) — только в E2E/ручном, по конвенции проекта (unit мокает/фейкает).
+
+## Влияние на существующий код
+
+- `publish_review`, `assemble_review`, `dedup`, grounding, gate-механика, история,
+  веб-админка — **без изменений** (категория — строка, `line:null` уже поддержан).
+- Меняются:
+  - `ReviewPolicy` (+поле `task_board` + парсинг);
+  - новый модуль `reviewer/services/task_keys.py` (извлечение ключей);
+  - `PullRequest` (+`head_ref`) и `GitHubProvider.get_pull_request` (заполнение `head_ref`);
+  - `ReviewService.prepare` (вызов извлечения ключей) и `_prepared_payload` (+2 поля);
+  - `SKILL.md` (+шаг task-context +requirements-измерение);
+  - 3 новых reference-файла (`task-context-yougile.md`, `task-context-jira.md`,
+    `requirements-prompt.md`);
+  - `.review.example.yml`/README (документация `task_board` и категории `requirements`).
+
+## Источники
+
+- `ichinya/yougile-mcp` — MCP-сервер Yougile (тулы `get_task`, `get_projects`,
+  `get_boards`, `get_task_chat`/`get_task_messages`); конфиг через `YOUGILE_API_KEY`.
+- `ra53n/yougile-mcp` — альтернативная реализация.
+- YouGile REST API v2; справка «ID задач» (формат `SAI-515`: префикс + номер).

--- a/plugin/skills/review-pr/SKILL.md
+++ b/plugin/skills/review-pr/SKILL.md
@@ -20,13 +20,25 @@ of posting.
    - `pr`: `{number, title, body, base_sha, head_sha, base_ref, draft}`
    - `policy`: `{severity_threshold, min_confidence, max_comments, categories, ignore, output_language}`
    - `units`: list of `{path, patch, commentable_right, commentable_left}`
+   - `task_board`: `{type, mcp, key_pattern}` or null — task board config from `.review.yml`
+   - `task_keys`: `{primary, others}` or null — task keys extracted from the PR by the server
    - `skipped_paths`, `skip_drafts`, `suggestions_mode`
 
    If `pr.draft` is true and `skip_drafts` is true, stop and tell the user.
    Note `policy.output_language` — ALL finding messages, suggestions and the summary
    MUST be written in that language.
 
-2. **Analyze (fan-out).** For each unit in `units`, dispatch a subagent (Task tool,
+2. **Task context (optional).** Only if `task_board` is non-null. Resolve the task key: an
+   explicit key in `$ARGUMENTS` wins; otherwise use `task_keys.primary`. If no key is available,
+   skip this step and note in the summary that no task key was found.
+   With a key, read the task using the playbook for `task_board.type`
+   (`references/task-context-yougile.md` or `references/task-context-jira.md`): call the board MCP
+   server named by `task_board.mcp` and build a `TaskBrief`
+   `{key, title, description, criteria[], status, url, links[]}`.
+   If the board MCP is not connected, the tool errors, or the task is not found: skip the
+   requirements dimension and note the reason in the summary — NEVER abort the review.
+
+3. **Analyze (fan-out).** For each unit in `units`, dispatch a subagent (Task tool,
    run independent subagents in parallel; batch units if there are more than ~10) with:
    - the contents of `references/analyze-prompt.md` (read it once, include verbatim);
    - the unit's `path` and `patch`, the PR `title`/`body`;
@@ -36,16 +48,19 @@ of posting.
    - the target output language.
    Each subagent returns a JSON object `{"findings": [...]}` (schema in the prompt).
 
-3. **Dimensions (parallel with step 2).** Dispatch two whole-diff subagents:
+4. **Dimensions (parallel with step 3).** Dispatch whole-diff subagents:
    - performance: follow the methodology of `../performance-review/SKILL.md`
      (Goal, Method, Severity sections);
-   - maintainability: follow `../maintainability-review/SKILL.md`.
-   Give each: the diffs of all units (path + patch), the repo/pr identifiers so
-   they can call the reviewer MCP tools, and the target output language.
-   Both must return the same findings JSON schema (category `performance` /
-   `maintainability`).
+   - maintainability: follow `../maintainability-review/SKILL.md`;
+   - requirements (ONLY if a `TaskBrief` was built in step 2): dispatch one subagent with
+     `references/requirements-prompt.md`, the diffs of all units (path + patch), the `TaskBrief`,
+     the repo/pr identifiers (so it can call the reviewer MCP tools), and the target output
+     language. It returns the same findings JSON schema with category `requirements`.
+   Give the performance/maintainability subagents: the diffs of all units (path + patch), the
+   repo/pr identifiers so they can call the reviewer MCP tools, and the target output language.
+   They must return the same findings JSON schema (category `performance` / `maintainability`).
 
-4. **Verify.** Collect all findings into one numbered list. Dispatch one subagent
+5. **Verify.** Collect all findings into one numbered list. Dispatch one subagent
    with `references/verify-prompt.md`, the findings list, the diffs, and the
    repo/pr identifiers so the subagent can call the reviewer MCP tools
    (`read_file`, `search_code`, `find_callers`, `get_definition`). It returns
@@ -53,8 +68,10 @@ of posting.
    `is_real=false`. If the verifier fails or returns malformed output, KEEP all
    findings (recall-safe).
 
-5. **Publish.** Compose a short review summary (2-5 sentences, in
+6. **Publish.** Compose a short review summary (2-5 sentences, in
    `policy.output_language`): what the PR does, overall assessment, key risks.
+   If a task was read, state whether the PR meets the task's requirements; if the task context was
+   requested but unavailable (no key, board MCP not connected, task not found), say so briefly.
    Mention files that were not analyzed: failed subagents and `skipped_paths`
    from the prepare payload. Call `publish_review(repo, pr, summary, findings,
    dry_run)`. Report to the user: posted/dry-run, inline count, and the report

--- a/plugin/skills/review-pr/references/requirements-prompt.md
+++ b/plugin/skills/review-pr/references/requirements-prompt.md
@@ -1,0 +1,50 @@
+You are a senior reviewer checking whether a pull request fulfils the task it claims to implement.
+
+You are given:
+- the unified diffs of every changed file in the PR;
+- a `TaskBrief` describing the task the PR claims to implement:
+  `{key, title, description, criteria[], status, url, links[]}`.
+
+Your job: for each requirement or acceptance criterion stated in the TaskBrief, decide whether the
+diff implements it, implements it differently/incompletely, contradicts it, or leaves it
+unimplemented. Report only genuine mismatches.
+
+Rules:
+- Judge ONLY against requirements explicitly stated in the TaskBrief (`description` + `criteria`).
+  Do NOT invent requirements the task does not state. If the brief is vague, prefer fewer,
+  higher-confidence findings.
+- The diffs are the source of truth for what the PR does. Before claiming a requirement is "not
+  implemented", use the reviewer MCP tools (`search_code`, `find_callers`, `read_file`,
+  `get_definition`, `get_changed_file_diff`) to verify it is not implemented elsewhere in the
+  change or already present in the codebase. A hallucinated gap is worse than a missed one.
+- One requirement → at most one finding. Do not split the same gap across lines.
+- Report a finding when the PR fails a requirement, contradicts it, or implements it in a way that
+  breaks the stated intent.
+- `line`: set ONLY when a specific changed line contradicts a requirement (e.g. wrong constant,
+  inverted condition). When the problem is "a requirement is simply absent from the diff", set
+  `line` to null and `file` to the most relevant changed file — the finding will land in the
+  review summary.
+- Severity reflects requirement impact: a missing core acceptance criterion is high/critical; a
+  minor or partial gap is low/medium.
+- An empty findings list is a valid result (the PR satisfies the task). Do not invent findings to
+  fill a quota.
+
+Return ONLY a JSON object (no prose around it):
+
+```json
+{"findings": [{
+  "category": "requirements",
+  "severity": "low|medium|high|critical",
+  "file": "<a changed file path most relevant to the requirement>",
+  "line": <line number in the NEW file, or null>,
+  "side": "RIGHT|LEFT",
+  "code_quote": "<exact line from the new file, or null when line is null>",
+  "message": "<which requirement is unmet/contradicted and why it matters>",
+  "suggestion": "<short advice or null>",
+  "fix": null,
+  "confidence": 0.0
+}]}
+```
+
+`category` MUST be exactly `"requirements"`. Write `message` and `suggestion` in the output
+language given by the orchestrator.

--- a/plugin/skills/review-pr/references/task-context-jira.md
+++ b/plugin/skills/review-pr/references/task-context-jira.md
@@ -1,0 +1,24 @@
+# Task context playbook — Jira
+
+Use this when `task_board.type == "jira"`.
+
+Goal: read the task identified by the resolved key and build a `TaskBrief`.
+
+1. The board MCP server is the one named by `task_board.mcp` (e.g. `atlassian`). Its tools are
+   exposed as `mcp__<task_board.mcp>__<tool>`.
+2. Fetch the issue by key (e.g. `PROJ-123`) using the Atlassian MCP's get-issue tool
+   (`getJiraIssue` / `jira_get_issue`, depending on the connected server).
+3. Build the `TaskBrief` from the issue (best-effort — omit/empty any field that is absent):
+   - `key`         ← issue key
+   - `title`       ← summary
+   - `description` ← description (rendered text)
+   - `criteria[]`  ← Acceptance Criteria field if present; otherwise bullet items parsed from the
+                     description; else `[]`
+   - `status`      ← status name
+   - `url`         ← issue browse URL
+   - `links[]`     ← issuelinks as `{type, key, title}`
+4. Optional: comments may add context — use only if needed.
+
+Failure handling: if the board MCP server is not connected, the tool errors, or the issue is not
+found, do NOT build a `TaskBrief` — skip the requirements dimension and note the reason in the
+summary. Never abort the review.

--- a/plugin/skills/review-pr/references/task-context-yougile.md
+++ b/plugin/skills/review-pr/references/task-context-yougile.md
@@ -1,0 +1,24 @@
+# Task context playbook — Yougile
+
+Use this when `task_board.type == "yougile"`.
+
+Goal: read the task identified by the resolved key and build a `TaskBrief`.
+
+1. The board MCP server is the one named by `task_board.mcp` (e.g. `yougile`). Its tools are
+   exposed as `mcp__<task_board.mcp>__<tool>`.
+2. Fetch the task: call `mcp__<task_board.mcp>__get_task` with the resolved key. Yougile accepts
+   the human code form such as `SAI-515`.
+3. Build the `TaskBrief` from the response (best-effort — omit/empty any field the response lacks):
+   - `key`         ← the resolved key
+   - `title`       ← task title
+   - `description` ← task description text (requirements usually live here)
+   - `criteria[]`  ← checklist / subtask titles, if the task has them; else `[]`
+   - `status`      ← column / status name
+   - `url`         ← task link
+   - `links[]`     ← related tasks, if available; else `[]`
+4. Optional: `mcp__<task_board.mcp>__get_task_chat` / `..._get_task_messages` add discussion
+   context — use ONLY if the description is too thin to judge requirements. Not required.
+
+Failure handling: if the board MCP server is not connected, the tool errors, or the task is not
+found, do NOT build a `TaskBrief` — skip the requirements dimension and note the reason in the
+summary. Never abort the review.

--- a/plugin/skills/review-pr/references/task-context-yougile.md
+++ b/plugin/skills/review-pr/references/task-context-yougile.md
@@ -2,23 +2,57 @@
 
 Use this when `task_board.type == "yougile"`.
 
-Goal: read the task identified by the resolved key and build a `TaskBrief`.
+Goal: read the task identified by the resolved key and build a `TaskBrief`. Build it best-effort —
+omit or empty any field you cannot resolve. A partial brief is fine; a wrong one is not.
 
-1. The board MCP server is the one named by `task_board.mcp` (e.g. `yougile`). Its tools are
-   exposed as `mcp__<task_board.mcp>__<tool>`.
-2. Fetch the task: call `mcp__<task_board.mcp>__get_task` with the resolved key. Yougile accepts
-   the human code form such as `SAI-515`.
-3. Build the `TaskBrief` from the response (best-effort — omit/empty any field the response lacks):
-   - `key`         ← the resolved key
-   - `title`       ← task title
-   - `description` ← task description text (requirements usually live here)
-   - `criteria[]`  ← checklist / subtask titles, if the task has them; else `[]`
-   - `status`      ← column / status name
-   - `url`         ← task link
-   - `links[]`     ← related tasks, if available; else `[]`
-4. Optional: `mcp__<task_board.mcp>__get_task_chat` / `..._get_task_messages` add discussion
-   context — use ONLY if the description is too thin to judge requirements. Not required.
+Tools are exposed as `mcp__<task_board.mcp>__<tool>`, where `<task_board.mcp>` is the server named
+in config (e.g. `yougile`). The steps below use that prefix implicitly.
 
-Failure handling: if the board MCP server is not connected, the tool errors, or the task is not
-found, do NOT build a `TaskBrief` — skip the requirements dimension and note the reason in the
-summary. Never abort the review.
+## 1. Fetch the task
+
+Call `get_task` with the resolved key. Yougile resolves three `id` forms, so the key from the PR
+works directly:
+
+- the task UUID;
+- the project code `idTaskProject` — e.g. `PRI-34` (per-project counter);
+- the company code `idTaskCommon` — e.g. `ID-34` (company-wide counter).
+
+The default `key_pattern` (`[A-Z]+-\d+`) matches both code forms, so a PR may reference either.
+If `get_task` errors or returns nothing, treat the task as not found (see Failure handling).
+
+## 2. Map the response to TaskBrief
+
+`get_task` returns identifiers, not display names, for status and subtasks — resolve them. It does
+NOT return a task link:
+
+| TaskBrief field | Source in `get_task` response   | How to fill it |
+|---|---|---|
+| `key`         | the resolved key (`PRI-34` / `ID-34`) | use as-is |
+| `title`       | `title`                               | use as-is |
+| `description` | `description`                         | requirements usually live here |
+| `status`      | `columnId` — a UUID, NOT a name       | call `get_column` with that id → its `title`; on error omit |
+| `criteria[]`  | `subtasks[]` — UUIDs, NOT titles      | optional: `get_task` each id → its `title` (see note); else `[]` |
+| `url`         | absent from the response              | see URL note; default `null` |
+| `links[]`     | absent from the response              | `[]` |
+
+**Criteria note.** Each subtask is itself a task; resolving its title costs one `get_task` call
+per subtask. Do this only when `description` is thin on acceptance criteria. When criteria are
+written inline in `description` (a bulleted / checklist section), leave `criteria[]` as `[]` — the
+requirements prompt reads `description` anyway, so nothing is lost.
+
+**URL note.** The Yougile API does not expose a task link, so `url` is `null` by default. If config
+provides `task_board.url_template` (a string with `{id}` and/or `{key}` placeholders), substitute
+the task UUID / resolved key into it and use the result. A missing `url` only drops the hyperlink
+in the summary — the task is still named by `key` + `title`.
+
+## 3. Optional discussion context
+
+`get_task_chat` / `get_task_messages` add discussion context. Use ONLY when `description` is too
+thin to judge requirements. Not required.
+
+## Failure handling (fail-open)
+
+If the board MCP server is not connected, any tool errors, or the task is not found, do NOT build a
+`TaskBrief` — skip the requirements dimension and note the reason in the summary. A failure in a
+secondary step (e.g. `get_column` for status, or a subtask fetch) must NOT abort brief-building:
+keep the fields you already have and move on with a partial brief. Never abort the review.

--- a/reviewer/mcp/service.py
+++ b/reviewer/mcp/service.py
@@ -437,6 +437,8 @@ class MCPReviewService:
                 "output_language": p.policy.output_language,
             },
             "units": units,
+            "task_board": p.task_board,
+            "task_keys": p.task_keys,
             "skipped_paths": p.skipped_paths,
             "skip_drafts": self.settings.review_skip_drafts,
             "suggestions_mode": self._suggestions_mode(),

--- a/reviewer/policy/policy.py
+++ b/reviewer/policy/policy.py
@@ -17,6 +17,7 @@ class ReviewPolicy:
     max_comments: int = 25
     min_confidence: float = 0.0
     output_language: str = "ru"                                  # язык текста находок в публикуемом ревью
+    task_board: dict | None = None                               # конфиг доски задач из .review.yml (None = выкл.)
 
     @classmethod
     def from_yaml(cls, text: str | None) -> "ReviewPolicy":
@@ -33,6 +34,7 @@ class ReviewPolicy:
             max_comments=data.get("max_comments", 25),
             min_confidence=data.get("min_confidence", 0.0),
             output_language=str(data.get("output_language", "ru")),
+            task_board=data.get("task_board") or None,
         )
 
     @classmethod
@@ -69,6 +71,8 @@ class ReviewPolicy:
             policy.ignore = ignore
         if "output_language" in data:
             policy.output_language = str(data["output_language"])
+        if "task_board" in data:
+            policy.task_board = data["task_board"] or None
         return policy
 
     def category_enabled(self, category: str) -> bool:

--- a/reviewer/services/review_service.py
+++ b/reviewer/services/review_service.py
@@ -23,6 +23,7 @@ from reviewer.index.chunker import chunk_python
 from reviewer.index.freshness import build_overlay, update_base
 from reviewer.web.history import ReviewHistory
 from reviewer.agent.state import ReviewUnit
+from reviewer.services.task_keys import extract_task_keys
 
 log = logging.getLogger(__name__)
 
@@ -63,6 +64,8 @@ class PreparedReview:
     overlay_ref: str                     # "pr:<n>"
     vcs: VCSProvider
     changed_status: dict[str, str]       # path -> статус файла (modified/added/removed)
+    task_board: dict | None = None       # конфиг доски из policy (прокидывается в payload)
+    task_keys: dict | None = None        # {"primary", "others"} или None, если task_board выкл.
 
 
 class ReviewService:
@@ -212,6 +215,18 @@ class ReviewService:
                 vcs.get_file_at_ref(".review.yml", prq.base_ref),
             )
 
+            task_board = policy.task_board
+            task_keys = (
+                extract_task_keys(
+                    task_board.get("key_pattern"),
+                    prq.title,
+                    prq.body,
+                    prq.head_ref,
+                )
+                if task_board
+                else None
+            )
+
             changed_status = {f.path: f.status for f in files}
 
             return PreparedReview(
@@ -226,6 +241,8 @@ class ReviewService:
                 overlay_ref=f"pr:{pr_number}",
                 vcs=vcs,
                 changed_status=changed_status,
+                task_board=task_board,
+                task_keys=task_keys,
             )
         except Exception:
             # При сбое подготовки чистим возможный недостроенный overlay pr:N —

--- a/reviewer/services/review_service.py
+++ b/reviewer/services/review_service.py
@@ -65,7 +65,7 @@ class PreparedReview:
     vcs: VCSProvider
     changed_status: dict[str, str]       # path -> статус файла (modified/added/removed)
     task_board: dict | None = None       # конфиг доски из policy (прокидывается в payload)
-    task_keys: dict | None = None        # {"primary", "others"} или None, если task_board выкл.
+    task_keys: dict | None = None        # {"primary": str|None, "others": [...]}; None только когда task_board выкл.
 
 
 class ReviewService:

--- a/reviewer/services/task_keys.py
+++ b/reviewer/services/task_keys.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import logging
 import re
+from typing import TypedDict
 
 log = logging.getLogger(__name__)
 
@@ -15,12 +16,17 @@ log = logging.getLogger(__name__)
 DEFAULT_KEY_PATTERN = r"[A-Z]+-\d+"
 
 
+class TaskKeys(TypedDict):
+    primary: str | None
+    others: list[str]
+
+
 def extract_task_keys(
     pattern: str | None,
     title: str | None,
     body: str | None,
     branch: str | None,
-) -> dict:
+) -> TaskKeys:
     """Извлечь ключи задачи.
 
     Прецеденция источников: ``title`` → ``body`` → ``branch``. ``primary`` —

--- a/reviewer/services/task_keys.py
+++ b/reviewer/services/task_keys.py
@@ -1,0 +1,55 @@
+"""Извлечение ключей задачи из текстов PR (title/body/head-ветка) по regex.
+
+Чистый модуль без сетевых вызовов: на вход — паттерн и тексты, на выход —
+primary-ключ и прочие найденные. Прецеденция источников: title → body → branch.
+Используется в ReviewService.prepare; чтение самой задачи с доски — на стороне скилла.
+"""
+from __future__ import annotations
+
+import logging
+import re
+
+log = logging.getLogger(__name__)
+
+# Дефолт подходит и Yougile (SAI-515), и Jira (PROJ-123): префикс заглавными + номер.
+DEFAULT_KEY_PATTERN = r"[A-Z]+-\d+"
+
+
+def extract_task_keys(
+    pattern: str | None,
+    title: str | None,
+    body: str | None,
+    branch: str | None,
+) -> dict:
+    """Извлечь ключи задачи.
+
+    Прецеденция источников: ``title`` → ``body`` → ``branch``. ``primary`` —
+    первый матч в этом порядке; ``others`` — прочие уникальные матчи (дедуп,
+    порядок появления), без ``primary``.
+
+    Невалидный ``pattern`` (или нет матчей) → ``{"primary": None, "others": []}``
+    (fail-soft + warning на невалидном паттерне). ``pattern=None`` → дефолт.
+
+    Returns:
+        ``{"primary": str | None, "others": list[str]}``
+    """
+    try:
+        rx = re.compile(pattern or DEFAULT_KEY_PATTERN)
+    except re.error:
+        log.warning("Невалидный key_pattern %r — ключи задачи не извлекаются", pattern)
+        return {"primary": None, "others": []}
+
+    found: list[str] = []
+    for text in (title, body, branch):
+        if text:
+            found.extend(m.group(0) for m in rx.finditer(text))
+
+    if not found:
+        return {"primary": None, "others": []}
+
+    primary = found[0]
+    others: list[str] = []
+    for key in found[1:]:
+        if key != primary and key not in others:
+            others.append(key)
+    return {"primary": primary, "others": others}

--- a/reviewer/vcs/base.py
+++ b/reviewer/vcs/base.py
@@ -10,6 +10,7 @@ class PullRequest:
     title: str
     body: str
     draft: bool = False
+    head_ref: str | None = None   # имя head-ветки PR; источник ключа задачи (None если недоступно)
 
 @dataclass
 class ChangedFile:

--- a/reviewer/vcs/github.py
+++ b/reviewer/vcs/github.py
@@ -108,6 +108,7 @@ class GitHubProvider:
             title=d.get("title", ""),
             body=d.get("body") or "",
             draft=bool(d.get("draft", False)),
+            head_ref=d.get("head", {}).get("ref"),
         )
 
     def get_changed_files(self, number: int) -> list[ChangedFile]:

--- a/tests/mcp/test_service.py
+++ b/tests/mcp/test_service.py
@@ -323,3 +323,45 @@ def test_search_code_repeated_call_returns_result_not_stub(
     # Реальный cache-hit: источник дёрнут ровно один раз (prepare_review retriever
     # не трогает) — без этого ассерта регрессия «кэш живёт сессию» не ловится
     assert svc.components.retriever.retrieve.call_count == 1
+
+
+@patch("reviewer.services.review_service.chunk_python", side_effect=_fake_chunk)
+@patch("reviewer.services.review_service.build_overlay")
+def test_prepare_review_payload_includes_task_context(
+    _mock_overlay: MagicMock,
+    _mock_chunk: MagicMock,
+) -> None:
+    """payload содержит task_board и извлечённые task_keys."""
+    settings = _settings()
+    components = _components()
+    vcs = _fake_vcs(number=7)
+    vcs.get_pull_request.return_value = PullRequest(
+        number=7, base_sha="base123", head_sha="head456", base_ref="main",
+        title="SAI-515: add logout", body="", draft=False, head_ref="feature/SAI-515",
+    )
+
+    def _read(path: str, ref: str) -> str:
+        if path == ".review.yml":
+            return "task_board: {type: yougile, mcp: yougile}"
+        return "def foo(): pass"
+    vcs.get_file_at_ref.side_effect = _read
+
+    svc = MCPReviewService(settings, components, vcs_factory=lambda o, r: vcs)
+    out = svc.prepare_review("o/r", 7)
+
+    assert out["task_board"] == {"type": "yougile", "mcp": "yougile"}
+    assert out["task_keys"] == {"primary": "SAI-515", "others": []}
+
+
+@patch("reviewer.services.review_service.chunk_python", side_effect=_fake_chunk)
+@patch("reviewer.services.review_service.build_overlay")
+def test_prepare_review_payload_task_context_null_when_unconfigured(
+    _mock_overlay: MagicMock,
+    _mock_chunk: MagicMock,
+) -> None:
+    """Без task_board оба поля payload — null."""
+    svc = _make_mcp_service()
+    out = svc.prepare_review("o/r", 7)
+
+    assert out["task_board"] is None
+    assert out["task_keys"] is None

--- a/tests/mcp/test_service.py
+++ b/tests/mcp/test_service.py
@@ -355,6 +355,34 @@ def test_prepare_review_payload_includes_task_context(
 
 @patch("reviewer.services.review_service.chunk_python", side_effect=_fake_chunk)
 @patch("reviewer.services.review_service.build_overlay")
+def test_prepare_review_payload_task_keys_empty_when_no_key_in_pr(
+    _mock_overlay: MagicMock,
+    _mock_chunk: MagicMock,
+) -> None:
+    """task_board задан, но в PR нет ключа → task_keys пустой (не None)."""
+    settings = _settings()
+    components = _components()
+    vcs = _fake_vcs(number=7)
+    vcs.get_pull_request.return_value = PullRequest(
+        number=7, base_sha="base123", head_sha="head456", base_ref="main",
+        title="no key here", body="", draft=False, head_ref="feature/cleanup",
+    )
+
+    def _read(path: str, ref: str) -> str:
+        if path == ".review.yml":
+            return "task_board: {type: yougile, mcp: yougile}"
+        return "def foo(): pass"
+    vcs.get_file_at_ref.side_effect = _read
+
+    svc = MCPReviewService(settings, components, vcs_factory=lambda o, r: vcs)
+    out = svc.prepare_review("o/r", 7)
+
+    assert out["task_board"] == {"type": "yougile", "mcp": "yougile"}
+    assert out["task_keys"] == {"primary": None, "others": []}
+
+
+@patch("reviewer.services.review_service.chunk_python", side_effect=_fake_chunk)
+@patch("reviewer.services.review_service.build_overlay")
 def test_prepare_review_payload_task_context_null_when_unconfigured(
     _mock_overlay: MagicMock,
     _mock_chunk: MagicMock,

--- a/tests/policy/test_policy.py
+++ b/tests/policy/test_policy.py
@@ -82,3 +82,25 @@ def test_load_task_board_none_without_yaml():
     s = Settings(_env_file=None)
     p = ReviewPolicy.load(s, None)
     assert p.task_board is None
+
+
+def test_requirements_category_enabled_by_default():
+    p = ReviewPolicy.from_yaml(None)
+    assert p.gate(F("requirements", "medium")) is True
+
+
+def test_requirements_category_can_be_disabled_via_yaml():
+    p = ReviewPolicy.from_yaml("categories: {requirements: false}")
+    assert p.gate(F("requirements", "high")) is False
+
+
+def test_requirements_excluded_by_enabled_only_whitelist():
+    p = ReviewPolicy(enabled_only=["correctness"])
+    assert p.gate(F("requirements", "high")) is False
+
+
+def test_requirements_respects_severity_and_confidence():
+    p = ReviewPolicy(severity_threshold="medium", min_confidence=0.7)
+    assert p.gate(F("requirements", "high", confidence=0.9)) is True
+    assert p.gate(F("requirements", "low", confidence=0.9)) is False
+    assert p.gate(F("requirements", "high", confidence=0.5)) is False

--- a/tests/policy/test_policy.py
+++ b/tests/policy/test_policy.py
@@ -60,3 +60,25 @@ def test_output_language_default_and_yaml_override():
 
     p2 = ReviewPolicy.from_yaml("output_language: en")
     assert p2.output_language == "en"
+
+
+def test_task_board_parsed_from_yaml():
+    p = ReviewPolicy.from_yaml("task_board: {type: yougile, mcp: yougile}")
+    assert p.task_board == {"type": "yougile", "mcp": "yougile"}
+
+
+def test_task_board_none_when_absent():
+    p = ReviewPolicy.from_yaml("severity_threshold: low")
+    assert p.task_board is None
+
+
+def test_load_applies_task_board_from_yaml():
+    s = Settings(_env_file=None)
+    p = ReviewPolicy.load(s, "task_board: {type: jira, mcp: atlassian}")
+    assert p.task_board == {"type": "jira", "mcp": "atlassian"}
+
+
+def test_load_task_board_none_without_yaml():
+    s = Settings(_env_file=None)
+    p = ReviewPolicy.load(s, None)
+    assert p.task_board is None

--- a/tests/services/test_review_service.py
+++ b/tests/services/test_review_service.py
@@ -228,3 +228,49 @@ def test_prepare_does_not_close_external_vcs_on_failure(
         service.prepare("owner", "repo", 1, vcs_provider=vcs)
 
     vcs.close.assert_not_called()
+
+
+@patch("reviewer.services.review_service.chunk_python", side_effect=_fake_chunk)
+@patch("reviewer.services.review_service.build_overlay")
+def test_prepare_extracts_task_keys_when_task_board_configured(
+    _mock_overlay: MagicMock,
+    _mock_chunk: MagicMock,
+    settings: Settings,
+    components: MagicMock,
+) -> None:
+    """При task_board в .review.yml prepare извлекает primary-ключ из title/branch."""
+    vcs = _vcs_with_files([_changed("a.py")])
+    vcs.get_pull_request.return_value = PullRequest(
+        number=3, base_sha="b", head_sha="h", base_ref="main",
+        title="SAI-515: add logout", body="", draft=False,
+        head_ref="feature/SAI-515",
+    )
+
+    def _read(path: str, ref: str) -> str:
+        if path == ".review.yml":
+            return "task_board: {type: yougile, mcp: yougile}"
+        return "def foo(): pass"
+    vcs.get_file_at_ref.side_effect = _read
+
+    service = ReviewService(settings, components)
+    prepared = service.prepare("o", "r", 3, vcs_provider=vcs)
+
+    assert prepared.task_board == {"type": "yougile", "mcp": "yougile"}
+    assert prepared.task_keys == {"primary": "SAI-515", "others": []}
+
+
+@patch("reviewer.services.review_service.chunk_python", side_effect=_fake_chunk)
+@patch("reviewer.services.review_service.build_overlay")
+def test_prepare_task_keys_none_without_task_board(
+    _mock_overlay: MagicMock,
+    _mock_chunk: MagicMock,
+    settings: Settings,
+    components: MagicMock,
+) -> None:
+    """Без task_board контекст задачи неактивен: оба поля None."""
+    vcs = _vcs_with_files([_changed("a.py")])
+    service = ReviewService(settings, components)
+    prepared = service.prepare("o", "r", 1, vcs_provider=vcs)
+
+    assert prepared.task_board is None
+    assert prepared.task_keys is None

--- a/tests/services/test_task_keys.py
+++ b/tests/services/test_task_keys.py
@@ -1,0 +1,41 @@
+"""Unit-тесты извлечения ключей задачи из текстов PR (без сети)."""
+from reviewer.services.task_keys import DEFAULT_KEY_PATTERN, extract_task_keys
+
+
+def test_primary_from_title_precedence_over_body_and_branch():
+    out = extract_task_keys(
+        DEFAULT_KEY_PATTERN,
+        title="SAI-515 add logout",
+        body="relates to SAI-517",
+        branch="feature/SAI-519-x",
+    )
+    assert out == {"primary": "SAI-515", "others": ["SAI-517", "SAI-519"]}
+
+
+def test_primary_falls_back_to_body_then_branch():
+    out = extract_task_keys(
+        DEFAULT_KEY_PATTERN, title="no key here", body="", branch="feature/SAI-700-x"
+    )
+    assert out == {"primary": "SAI-700", "others": []}
+
+
+def test_dedup_keeps_first_appearance_order():
+    out = extract_task_keys(
+        DEFAULT_KEY_PATTERN, title="SAI-1 SAI-1 SAI-2", body=None, branch=None
+    )
+    assert out == {"primary": "SAI-1", "others": ["SAI-2"]}
+
+
+def test_no_match_returns_empty():
+    out = extract_task_keys(DEFAULT_KEY_PATTERN, title="nothing", body=None, branch=None)
+    assert out == {"primary": None, "others": []}
+
+
+def test_invalid_pattern_returns_empty():
+    out = extract_task_keys("[unclosed", title="SAI-1", body=None, branch=None)
+    assert out == {"primary": None, "others": []}
+
+
+def test_none_pattern_uses_default():
+    out = extract_task_keys(None, title="SAI-42 fix", body=None, branch=None)
+    assert out == {"primary": "SAI-42", "others": []}

--- a/tests/vcs/test_github.py
+++ b/tests/vcs/test_github.py
@@ -232,3 +232,31 @@ def test_retry_504_then_success():
     assert pr.title == "PR"
     assert len(calls) == 2
     assert sleeps == [1.0]
+
+
+def test_get_pull_request_populates_head_ref():
+    def handler(req):
+        if req.url.path.endswith("/pulls/9"):
+            return httpx.Response(200, json={
+                "base": {"sha": "ccc", "ref": "main"},
+                "head": {"sha": "ddd", "ref": "feature/SAI-515-logout"},
+                "title": "PR", "body": "", "draft": False,
+            })
+        return httpx.Response(404)
+    p = make_provider(handler)
+    pr = p.get_pull_request(9)
+    assert pr.head_ref == "feature/SAI-515-logout"
+
+
+def test_get_pull_request_head_ref_none_when_absent():
+    def handler(req):
+        if req.url.path.endswith("/pulls/10"):
+            return httpx.Response(200, json={
+                "base": {"sha": "ccc", "ref": "main"},
+                "head": {"sha": "ddd"},
+                "title": "PR", "body": "", "draft": False,
+            })
+        return httpx.Response(404)
+    p = make_provider(handler)
+    pr = p.get_pull_request(10)
+    assert pr.head_ref is None


### PR DESCRIPTION
## Что это

Фаза 2 миграции на Claude Code — «контекст задачи в ревью». Скилл `/rag-reviewer:review-pr` находит ключ связанной задачи, читает её с доски через подключённый к сессии MCP (эталон — **Yougile**, второй плейбук — Jira) и проверяет соответствие диффа требованиям задачи новой категорией находок `requirements`. Доска не настроена / ключ не найден / MCP недоступен → ревью работает как в фазе 1, **без деградации**.

## Граница Python ↔ скилл

- **Python** (`prepare_review`) детерминированно извлекает ключи задачи (`title→body→head-ветка` по `key_pattern`) и прокидывает `task_board` + `task_keys` в payload. На доску не ходит.
- **Скилл** (board MCP подключён к сессии) читает задачу, строит board-agnostic `TaskBrief` и запускает whole-diff requirements-сабагент.

## Изменения

- `reviewer/services/task_keys.py` — извлечение ключей (прецеденция, primary+others, fail-soft на невалидном паттерне).
- `PullRequest.head_ref` (+ GitHub-провайдер) — источник ключа из имени head-ветки.
- `ReviewPolicy.task_board` из `.review.yml`; вычисление `task_keys` в `ReviewService.prepare`; поля `task_board`/`task_keys` в payload `prepare_review`.
- Скилл: шаг task-context + requirements-измерение; reference-промпт + плейбуки Yougile/Jira.
- Категория `requirements` (включена по умолчанию, штатный `gate`; находки без строки → в сводку).
- README: документация `task_board` и категории.
- Спека и план — `docs/superpowers/`.

## Тесты

- +21 unit-тест (извлечение ключей, парсинг `task_board`, вычисление в `prepare`, поля payload, гейтинг `requirements`, `head_ref`). Полный набор: **230 passed, 1 skipped**. Ruff чист на всех изменённых файлах.
- E2E/доска — вне автотестов (внешний MCP), по конвенции проекта.

## План тестирования

- [ ] dry-run `/review-pr` на PR со ссылкой на Yougile-задачу при подключённом `yougile` MCP → бриф собрался, requirements-находки появились.
- [ ] Деградация: тот же PR без ключа / без board MCP → ревью проходит, в сводке пометка, прочие категории не пострадали.