### PR TITLE
feat(vcs): jitter в бэкоффе _RetryTransport (PRI-36)

### DIFF
--- a/reviewer/vcs/github.py
+++ b/reviewer/vcs/github.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 import base64
+import random
 import re
 import time
 
@@ -21,12 +22,14 @@ class _RetryTransport:
         attempts: int = 3,
         backoff_base: float = 1.0,
         max_wait: float = 8.0,
+        jitter: float = 1.0,
         _sleep=time.sleep,
     ):
         self._wrapped = wrapped
         self._attempts = attempts
         self._backoff_base = backoff_base
         self._max_wait = max_wait
+        self._jitter = jitter
         self._sleep = _sleep
 
     def handle_request(self, request: httpx.Request) -> httpx.Response:
@@ -44,9 +47,11 @@ class _RetryTransport:
                         wait = self._backoff_base * (2 ** attempt)
                 else:
                     wait = self._backoff_base * (2 ** attempt)
+                # jitter разводит синхронные ретраи (как в with_voyage_retry, PRI-35)
+                wait = min(wait, self._max_wait) + random.uniform(0, self._jitter)
                 # max(0, …): невалидный/отрицательный Retry-After (напр. "-1")
                 # не должен уводить sleep в минус — time.sleep(<0) бросает ValueError.
-                self._sleep(max(0.0, min(wait, self._max_wait)))
+                self._sleep(max(0.0, wait))
         # Исчерпаны попытки — возвращаем последний ответ (raise_for_status сделает своё дело)
         assert response is not None
         return response


### PR DESCRIPTION
Реализует задачу **PRI-36** (GitHub retry: добавить jitter в _RetryTransport).

## Проблема
`_RetryTransport` ретраит 429/502/503/504 с экспоненциальным бэкоффом, но без jitter — при всплеске запросы ретраятся синхронно одним фронтом.

## Решение
К вычисленному интервалу добавлен `random.uniform(0, jitter)`; новый параметр `jitter` (по умолчанию 1с).

## Связь
Продолжает **PRI-35** / #8 (Voyage retry jitter) — единый подход к retry внешних API.

## Проверка
- [ ] тесты `_RetryTransport` проходят
- [ ] Retry-After и cap max_wait соблюдены

_(Тестовый PR для проверки RAG-ревью; в main не вливать.)_