### PR TITLE
feat: allowlist reviewer MCP из коробки (PRI-98)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,7 @@
+{
+  "permissions": {
+    "allow": [
+      "mcp__reviewer__*"
+    ]
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,10 @@ htmlcov/
 .vscode/
 .DS_Store
 
+# Claude Code: личное/транзиентное игнорируем, общий settings.json коммитим
+.claude/*
+!.claude/settings.json
+
 # Data / artifacts
 *.scip
 data/

--- a/README.md
+++ b/README.md
@@ -168,6 +168,11 @@ uvx --from rag-reviewer reviewer update
 > `reviewer install` or set `"command": "uvx"` with `"args": ["--from",
 > "rag-reviewer@latest", "reviewer-mcp"]` directly.
 
+> **Claude Code: tools work out of the box.** `reviewer install claude-code` also
+> writes an allowlist rule `mcp__reviewer__*` into the project's
+> `.claude/settings.json` (`permissions.allow`), so the reviewer MCP tools run
+> without hitting the `auto`-mode safety classifier — no manual settings edits.
+
 > **Where keys are read from.** The reviewer resolves its `.env` from a fixed
 > location, **not** the current working directory — MCP clients launch the server
 > with an arbitrary CWD, so a project-local `.env` is unreliable. Lookup order:

--- a/docs/superpowers/plans/2026-06-16-pri-98-mcp-allowlist.md
+++ b/docs/superpowers/plans/2026-06-16-pri-98-mcp-allowlist.md
@@ -1,0 +1,482 @@
+# PRI-98 — Auto-allowlist reviewer MCP — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Сделать так, чтобы тулы `mcp__reviewer__*` работали в Claude Code «из коробки» — через committed `.claude/settings.json` и через `reviewer install`, который мёрджит allow-правило в settings целевого репо.
+
+**Architecture:** Одно anchored-glob правило `mcp__reviewer__*` в `permissions.allow`. `reviewer/install.py` получает функции построения/применения allowlist-плана (по образцу `InstallPlan`/`apply_plan`, с общим `_write_with_backup`). CLI-команда `install` для клиента `claude-code` дополнительно пишет `.claude/settings.json`. Плюс committed settings-файлы, `plugin/GEMINI.md`, фикс докстринга.
+
+**Tech Stack:** Python 3.11, Click CLI, pytest, ruff (line-length 100). Тесты — на фейках/`tmp_path`, без сети/БД.
+
+---
+
+## Контекст для исполнителя (прочитать перед началом)
+
+- `reviewer/install.py` — кроссплатформенная установка MCP-сервера в конфиги клиентов.
+  Паттерн: `build_plan()` готовит `InstallPlan(path, content, …)`, `apply_plan()`
+  пишет на диск с `.bak`-бэкапом и идемпотентностью (не пишет, если контент совпал).
+- `apply_plan` (строки ~242–258) и наш новый `apply_allowlist_plan` должны делить
+  общую запись-с-бэкапом — выделяем `_write_with_backup(path, content)`.
+- CLI-команда `install` — `reviewer/entrypoints/cli.py:234-322`. Внутри `for c in targets:`
+  есть ветка `if dry_run:` (печать + `continue`) и обычная ветка с `apply_plan`.
+  Клиент `claude-code` пишет MCP-конфиг в `Path(".mcp.json")` (CWD), скилы НЕ тянет
+  (`skills_fn=None`), поэтому сети в тесте не будет.
+- Правильная схема Claude Code (сверено с docs): `{"permissions":{"allow":[...]}}`,
+  правило `mcp__reviewer__*` разрешает весь сервер. НЕ `allowedTools`.
+- Стиль тестов — `tests/install/test_install.py` (фикстура `fake_uvx`, `tmp_path`,
+  проверка `plan.content` через `json.loads`). Комментарии/докстринги — на русском.
+- 15 тулов сервера: prepare_review, search_code, get_related_symbols, read_file,
+  get_definition, find_callers, get_changed_file_diff, index_task, index_tasks_batch,
+  purge_orphaned_tasks, search_tasks, get_task_context, get_board_config,
+  search_codebase, publish_review.
+
+Запуск тестов: `.venv/bin/pytest tests/install/test_install.py -q`. Линт:
+`.venv/bin/ruff check reviewer/install.py tests/install/test_install.py`.
+
+---
+
+## Task 1: allowlist-план в `reviewer/install.py`
+
+**Files:**
+- Modify: `reviewer/install.py` (добавить константу, `claude_settings_path`,
+  `AllowlistPlan`, `build_allowlist_plan`, `_write_with_backup`, `apply_allowlist_plan`;
+  отрефакторить `apply_plan`)
+- Test: `tests/install/test_install.py`
+
+- [ ] **Step 1: Написать падающие тесты**
+
+В конец `tests/install/test_install.py` добавить (вверху файла уже есть `import json`,
+`import pytest`, `from reviewer import install as inst`; добавить `from pathlib import Path`):
+
+```python
+# --------------------------------------------------------------------------- #
+# allowlist (permissions.allow в .claude/settings.json)
+# --------------------------------------------------------------------------- #
+def test_allowlist_plan_creates_file(tmp_path):
+    cfg = tmp_path / ".claude" / "settings.json"
+    plan = inst.build_allowlist_plan(cfg)
+    assert plan.created is True and plan.already is False
+    data = json.loads(plan.content)
+    assert data["permissions"]["allow"] == ["mcp__reviewer__*"]
+
+
+def test_allowlist_plan_preserves_existing(tmp_path):
+    cfg = tmp_path / ".claude" / "settings.json"
+    cfg.parent.mkdir(parents=True)
+    cfg.write_text(json.dumps({
+        "permissions": {"allow": ["Bash(ls:*)"], "deny": ["mcp__evil"]},
+        "model": "opus",
+    }))
+    plan = inst.build_allowlist_plan(cfg)
+    data = json.loads(plan.content)
+    assert data["model"] == "opus"                                # чужой ключ сохранён
+    assert data["permissions"]["deny"] == ["mcp__evil"]           # чужое правило сохранено
+    assert data["permissions"]["allow"] == ["Bash(ls:*)", "mcp__reviewer__*"]
+    assert plan.already is False
+
+
+def test_allowlist_plan_idempotent(tmp_path):
+    cfg = tmp_path / ".claude" / "settings.json"
+    cfg.parent.mkdir(parents=True)
+    cfg.write_text(json.dumps({"permissions": {"allow": ["mcp__reviewer__*"]}}))
+    plan = inst.build_allowlist_plan(cfg)
+    assert plan.already is True
+    assert json.loads(plan.content)["permissions"]["allow"].count("mcp__reviewer__*") == 1
+
+
+def test_apply_allowlist_plan_writes_and_backs_up(tmp_path):
+    cfg = tmp_path / ".claude" / "settings.json"
+    cfg.parent.mkdir(parents=True)
+    cfg.write_text(json.dumps({"permissions": {"allow": ["Bash(ls:*)"]}}))
+    plan = inst.build_allowlist_plan(cfg)
+    backup = inst.apply_allowlist_plan(plan)
+    assert backup is not None and backup.exists()
+    written = json.loads(cfg.read_text())
+    assert "mcp__reviewer__*" in written["permissions"]["allow"]
+
+
+def test_apply_allowlist_plan_no_write_when_unchanged(tmp_path):
+    cfg = tmp_path / ".claude" / "settings.json"
+    inst.apply_allowlist_plan(inst.build_allowlist_plan(cfg))     # создаём
+    plan2 = inst.build_allowlist_plan(cfg)
+    assert plan2.already is True
+    assert inst.apply_allowlist_plan(plan2) is None               # без изменений — без .bak
+```
+
+- [ ] **Step 2: Запустить — убедиться, что падают**
+
+Run: `.venv/bin/pytest tests/install/test_install.py -q -k allowlist`
+Expected: FAIL — `AttributeError: module 'reviewer.install' has no attribute 'build_allowlist_plan'`.
+
+- [ ] **Step 3: Реализовать в `reviewer/install.py`**
+
+Сразу после строки `SERVER_NAME = "reviewer"` (около строки 24) добавить:
+
+```python
+# anchored-glob правило, разрешающее ВЕСЬ сервер reviewer в Claude Code
+# (permissions.allow). Wildcard покрывает новые тулы автоматически — список
+# тулов синхронизировать не нужно.
+REVIEWER_PERMISSION_RULE = "mcp__reviewer__*"
+```
+
+Добавить функции (рядом с `default_env_path`, до или после — не важно):
+
+```python
+def claude_settings_path() -> Path:
+    """Проектный settings.json Claude Code (рядом с .mcp.json в корне проекта)."""
+    return Path(".claude") / "settings.json"
+```
+
+Рядом с `InstallPlan` добавить датакласс и билдер:
+
+```python
+@dataclass
+class AllowlistPlan:
+    path: Path
+    content: str          # что будет записано в файл целиком
+    created: bool         # файла не было — создаём
+    already: bool         # правило уже было в permissions.allow
+
+
+def build_allowlist_plan(
+    path: Path | None = None, rule: str = REVIEWER_PERMISSION_RULE
+) -> AllowlistPlan:
+    """План мёрджа allow-правила reviewer в permissions.allow Claude Code settings.
+
+    Сохраняет чужие ключи и существующие правила; идемпотентен (already=True,
+    если правило уже присутствует). Запись на диск — apply_allowlist_plan.
+    """
+    path = path or claude_settings_path()
+    existed = path.exists()
+    raw = path.read_text(encoding="utf-8") if existed else ""
+    cfg = json.loads(raw) if raw.strip() else {}
+    if not isinstance(cfg, dict):
+        raise ValueError(f"{path}: ожидался JSON-объект на верхнем уровне")
+    perms = cfg.get("permissions")
+    if not isinstance(perms, dict):
+        perms = {}
+    allow = perms.get("allow")
+    if not isinstance(allow, list):
+        allow = []
+    already = rule in allow
+    if not already:
+        allow = [*allow, rule]
+    perms["allow"] = allow
+    cfg["permissions"] = perms
+    content = json.dumps(cfg, indent=2, ensure_ascii=False) + "\n"
+    return AllowlistPlan(path, content, not existed, already)
+```
+
+Заменить тело `apply_plan` (строки ~242–258) — выделить общий хелпер и делегировать:
+
+```python
+def _write_with_backup(path: Path, content: str) -> Path | None:
+    """Записать content в path; при изменении существующего файла сделать .bak.
+
+    Возвращает путь к .bak (если был бэкап) или None. Ничего не пишет и не
+    бэкапит, если содержимое не изменилось.
+    """
+    path.parent.mkdir(parents=True, exist_ok=True)
+    if path.exists():
+        existing = path.read_text(encoding="utf-8")
+        if existing == content:
+            return None
+        backup = path.with_suffix(path.suffix + ".bak")
+        backup.write_text(existing, encoding="utf-8")
+        path.write_text(content, encoding="utf-8")
+        return backup
+    path.write_text(content, encoding="utf-8")
+    return None
+
+
+def apply_plan(plan: InstallPlan) -> Path | None:
+    """Записать MCP-план на диск. Возвращает путь к .bak (если был бэкап)."""
+    return _write_with_backup(plan.path, plan.content)
+
+
+def apply_allowlist_plan(plan: AllowlistPlan) -> Path | None:
+    """Записать allowlist-план на диск. Возвращает путь к .bak (если был бэкап)."""
+    return _write_with_backup(plan.path, plan.content)
+```
+
+- [ ] **Step 4: Запустить — убедиться, что проходят**
+
+Run: `.venv/bin/pytest tests/install/test_install.py -q`
+Expected: PASS (новые allowlist-тесты + все старые, включая `test_apply_plan_*`).
+
+- [ ] **Step 5: Линт**
+
+Run: `.venv/bin/ruff check reviewer/install.py tests/install/test_install.py`
+Expected: чисто (на этих файлах).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add reviewer/install.py tests/install/test_install.py
+git commit -m "feat(install): allowlist-план reviewer MCP (permissions.allow)"
+```
+
+---
+
+## Task 2: CLI `install claude-code` пишет allowlist
+
+**Files:**
+- Modify: `reviewer/entrypoints/cli.py` (ветка `claude-code` в команде `install`)
+- Test: `tests/install/test_install.py`
+
+- [ ] **Step 1: Написать падающий CLI-тест**
+
+Добавить в конец `tests/install/test_install.py`:
+
+```python
+def test_cli_install_claude_code_writes_allowlist(monkeypatch):
+    from click.testing import CliRunner
+
+    from reviewer.entrypoints.cli import cli
+
+    monkeypatch.setattr(inst.shutil, "which",
+                        lambda name: "/fake/bin/uvx" if name == "uvx" else None)
+    runner = CliRunner()
+    with runner.isolated_filesystem():
+        result = runner.invoke(cli, ["install", "claude-code"])
+        assert result.exit_code == 0, result.output
+        assert Path(".mcp.json").exists()
+        settings = json.loads(Path(".claude/settings.json").read_text())
+        assert "mcp__reviewer__*" in settings["permissions"]["allow"]
+        # идемпотентность: повторный запуск не плодит дубли
+        result2 = runner.invoke(cli, ["install", "claude-code"])
+        assert result2.exit_code == 0, result2.output
+        settings2 = json.loads(Path(".claude/settings.json").read_text())
+        assert settings2["permissions"]["allow"].count("mcp__reviewer__*") == 1
+```
+
+- [ ] **Step 2: Запустить — убедиться, что падает**
+
+Run: `.venv/bin/pytest tests/install/test_install.py::test_cli_install_claude_code_writes_allowlist -q`
+Expected: FAIL — `.claude/settings.json` не создаётся (файла нет).
+
+- [ ] **Step 3: Реализовать в `reviewer/entrypoints/cli.py`**
+
+В команде `install`, внутри `for c in targets:`. В ветке `if dry_run:` — перед
+печатью скилов добавить печать allowlist для claude-code:
+
+```python
+            if c.key == "claude-code":
+                al_plan = inst.build_allowlist_plan(plan.path.parent / ".claude" / "settings.json")
+                click.echo(f"# {c.label} allowlist → {al_plan.path}")
+                click.echo(al_plan.content)
+```
+
+В обычной ветке — после блока `click.echo(f"✓ {c.label}: …")` / `if backup:` и до
+`if c.note:` (или сразу после него), но ДО `_ensure_skills(c)` — добавить:
+
+```python
+        if c.key == "claude-code":
+            al_plan = inst.build_allowlist_plan(plan.path.parent / ".claude" / "settings.json")
+            al_backup = inst.apply_allowlist_plan(al_plan)
+            if al_plan.already:
+                al_status = "правило уже есть"
+            elif al_plan.created:
+                al_status = "создан settings.json"
+            else:
+                al_status = "добавлено правило"
+            click.echo(f"  allowlist: {al_status} → {al_plan.path} "
+                       f"({inst.REVIEWER_PERMISSION_RULE})")
+            if al_backup:
+                click.echo(f"  бэкап: {al_backup}")
+```
+
+- [ ] **Step 4: Запустить — убедиться, что проходит**
+
+Run: `.venv/bin/pytest tests/install/test_install.py -q`
+Expected: PASS (включая новый CLI-тест).
+
+- [ ] **Step 5: Линт**
+
+Run: `.venv/bin/ruff check reviewer/entrypoints/cli.py`
+Expected: чисто (на этом файле).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add reviewer/entrypoints/cli.py tests/install/test_install.py
+git commit -m "feat(install): claude-code мёрджит allowlist в .claude/settings.json"
+```
+
+---
+
+## Task 3: Committed `settings.json` (plugin + корень репо)
+
+**Files:**
+- Create: `plugin/.claude/settings.json`
+- Create: `.claude/settings.json`
+
+- [ ] **Step 1: Создать `plugin/.claude/settings.json`**
+
+```json
+{
+  "permissions": {
+    "allow": [
+      "mcp__reviewer__*"
+    ]
+  }
+}
+```
+
+- [ ] **Step 2: Создать `.claude/settings.json` (корень репо)**
+
+Тот же контент:
+
+```json
+{
+  "permissions": {
+    "allow": [
+      "mcp__reviewer__*"
+    ]
+  }
+}
+```
+
+- [ ] **Step 3: Убедиться, что файлы не игнорируются git**
+
+Run: `git check-ignore .claude/settings.json plugin/.claude/settings.json; echo "exit=$?"`
+Expected: пустой вывод, `exit=1` (не игнорируются). Если `.claude/settings.json`
+игнорируется — добавить `git add -f` на следующем шаге для него.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add plugin/.claude/settings.json .claude/settings.json
+git commit -m "feat(plugin): committed allowlist settings.json (permissions.allow)"
+```
+
+---
+
+## Task 4: `plugin/GEMINI.md`
+
+**Files:**
+- Create: `plugin/GEMINI.md`
+
+- [ ] **Step 1: Создать `plugin/GEMINI.md`**
+
+```markdown
+# Gemini CLI — reviewer MCP
+
+Плагин подключает MCP-сервер `reviewer` (RAG + граф кода + публикация ревью).
+Скилы `/solve-task`, `/review-pr`, `/sync-tasks` вызывают его тулы. Чтобы они
+работали без ручного подтверждения на каждый вызов, пометьте сервер `reviewer`
+доверенным в Gemini CLI (`~/.gemini/settings.json`, поле `trust` у MCP-сервера)
+— тогда все его тулы предодобрены.
+
+## Pre-approved тулы reviewer
+
+- `mcp__reviewer__prepare_review`
+- `mcp__reviewer__search_code`
+- `mcp__reviewer__get_related_symbols`
+- `mcp__reviewer__read_file`
+- `mcp__reviewer__get_definition`
+- `mcp__reviewer__find_callers`
+- `mcp__reviewer__get_changed_file_diff`
+- `mcp__reviewer__index_task`
+- `mcp__reviewer__index_tasks_batch`
+- `mcp__reviewer__purge_orphaned_tasks`
+- `mcp__reviewer__search_tasks`
+- `mcp__reviewer__get_task_context`
+- `mcp__reviewer__get_board_config`
+- `mcp__reviewer__search_codebase`
+- `mcp__reviewer__publish_review`
+
+Эквивалент для целого сервера — доверять `reviewer` целиком; в Claude Code это
+одно правило `mcp__reviewer__*` в `permissions.allow` (см. `.claude/settings.json`).
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add plugin/GEMINI.md
+git commit -m "docs(plugin): GEMINI.md со списком pre-approved тулов reviewer"
+```
+
+---
+
+## Task 5: Фикс докстринга «14 → 15 тулов»
+
+**Files:**
+- Modify: `reviewer/entrypoints/mcp_server.py:18`
+
+- [ ] **Step 1: Заменить число в докстринге `create_server`**
+
+Было: `"""Создать и вернуть сконфигурированный FastMCP-сервер с 14 тулами.`
+Стало: `"""Создать и вернуть сконфигурированный FastMCP-сервер с 15 тулами.`
+
+- [ ] **Step 2: Проверить, что тестовый счётчик тулов согласован**
+
+Run: `.venv/bin/pytest tests/mcp -q -k "tool or count" 2>/dev/null; .venv/bin/pytest tests/mcp -q`
+Expected: PASS (тест на число тулов уже ожидает 15 — см. коммит `b9eeb8b`).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add reviewer/entrypoints/mcp_server.py
+git commit -m "docs(mcp): докстринг create_server — 15 тулов"
+```
+
+---
+
+## Task 6: Заметка в `README.md`
+
+**Files:**
+- Modify: `README.md` (секция про `reviewer install`, около строк 150–170)
+
+- [ ] **Step 1: Найти место**
+
+Run: `grep -n "reviewer install" README.md | head`
+Выбрать абзац-врезку про кроссплатформенность `reviewer install` (около строки 165).
+
+- [ ] **Step 2: Добавить предложение во врезку**
+
+После описания того, что `reviewer install` инжектит MCP-команду, добавить:
+
+```markdown
+> Для **Claude Code** `reviewer install claude-code` дополнительно прописывает
+> allowlist `mcp__reviewer__*` в `.claude/settings.json` проекта — тулы reviewer
+> работают из коробки (без обращения к safety-classifier в режиме `auto`).
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add README.md
+git commit -m "docs(readme): reviewer install прописывает allowlist для Claude Code"
+```
+
+---
+
+## Task 7: Полная проверка
+
+- [ ] **Step 1: Весь unit-набор**
+
+Run: `.venv/bin/pytest -q`
+Expected: PASS (integration исключены дефолтным маркером).
+
+- [ ] **Step 2: Линт по затронутым файлам**
+
+Run: `.venv/bin/ruff check reviewer/install.py reviewer/entrypoints/cli.py reviewer/entrypoints/mcp_server.py tests/install/test_install.py`
+Expected: чисто.
+
+- [ ] **Step 3: Финальный статус**
+
+Run: `git log --oneline -7 && git status`
+Expected: коммиты Task 1–6 на ветке `feat/pri-98-mcp-allowlist`, рабочее дерево чистое.
+
+---
+
+## Self-Review (выполнено при написании плана)
+
+- **Покрытие спеки:** wildcard-правило (Task 1,3,4), committed settings ×2 (Task 3),
+  install-мёрдж (Task 1+2), GEMINI.md (Task 4), докстринг-фикс (Task 5), README (Task 6),
+  тесты (Task 1,2). Вне scope (Copilot, Cursor/VSCode, Gemini-trust-запись) — по спеке.
+- **Плейсхолдеры:** нет — весь код приведён.
+- **Согласованность типов:** `AllowlistPlan(path, content, created, already)`,
+  `build_allowlist_plan(path, rule)`, `apply_allowlist_plan(plan)`, `_write_with_backup`,
+  `REVIEWER_PERMISSION_RULE`, `claude_settings_path()` — имена едины во всех тасках.

--- a/docs/superpowers/specs/2026-06-16-pri-98-mcp-allowlist-design.md
+++ b/docs/superpowers/specs/2026-06-16-pri-98-mcp-allowlist-design.md
@@ -1,0 +1,129 @@
+# PRI-98 — Auto-конфигурация allowlist reviewer MCP «из коробки»
+
+Дата: 2026-06-16 · Задача: PRI-98 / ID-98 (В работе) ·
+[Доска](https://ru.yougile.com/team/686c049c8af8/#PRI-98)
+
+## Проблема
+
+В Claude Code режим разрешений `auto` зовёт safety-classifier на каждый вызов
+`mcp__reviewer__*`. Если classifier недоступен — вызов отклоняется:
+
+```
+claude-sonnet-4-6 is temporarily unavailable, so auto mode cannot determine
+the safety of mcp__reviewer__get_task_context right now.
+```
+
+Тогда `/solve-task`, `/review-pr`, `/sync-tasks` вырождаются: RAG-поиск, граф задач
+и семантический поиск по коду не работают. Корневая причина — тулы reviewer не
+прописаны в разрешениях, поэтому при каждом вызове идёт обращение к classifier.
+
+## Поправка к постановке (сверено с docs Claude Code)
+
+Постановка задачи предлагала top-level `{"allowedTools": [...]}` с явным перечнем 15
+тулов. Это **некорректно** для `settings.json`. Авторитетно (docs.claude.com):
+
+- Правильный ключ — **`permissions.allow: [...]`**. `allowedTools` — это CLI-флаг
+  `--allowedTools` / SDK-опция, а **не** ключ `settings.json`.
+- Формат правила — `mcp__<server>__<tool>`. Целый сервер разрешается **одним
+  anchored-glob правилом `mcp__reviewer__*`** (документировано).
+- Явное allow-правило **обходит auto-classifier** — это корректный фикс ошибки
+  «classifier unavailable».
+- **Плагины не могут раздавать разрешения автоматически.** `plugin/.claude/settings.json`
+  применяется, только если открыть `plugin/` как проект. Поэтому основной механизм
+  для пользователей — `reviewer install`, мёрджащий правило в `.claude/settings.json`
+  их репозитория.
+
+## Ключевое решение: wildcard вместо явного списка
+
+Используем **`mcp__reviewer__*`** (одно правило), а не перечень 15 тулов. Обоснование:
+
+- Корневая боль задачи — устаревание списка тулов: *«Нет гарантии, что после
+  обновления списка тулов разработчики обновят свои конфиги»*. Wildcard **устраняет
+  этот класс багов целиком**: новый тул (как `purge_orphaned_tasks`) покрывается
+  автоматически, без правок конфигов/тестов. Это лучше закрывает критерий
+  «автообновление при добавлении новых тулов», чем явный список.
+- Wildcard `mcp__reviewer__*` — документированная, anchored-безопасная форма.
+- `mcp__reviewer__*` и есть «единый источник правды» — синхронизировать нечего.
+
+Перечень тулов в человекочитаемой документации (`plugin/GEMINI.md`) остаётся явным
+(этого требует критерий «`plugin/GEMINI.md` содержит список pre-approved тулов»).
+
+## Компоненты
+
+### 1. Чек-инутые `settings.json` (committed allowlist)
+
+Два файла, оба с содержимым `{"permissions":{"allow":["mcp__reviewer__*"]}}`:
+
+- **`plugin/.claude/settings.json`** — критерий «открыть `plugin/` как проект →
+  тулы работают без ручного редактирования settings».
+- **`.claude/settings.json`** (корень репо) — для разработки самого `rag_for_git`
+  (тут используется reviewer MCP; `.claude/settings.local.json` уже включает сервер).
+  Shared `settings.json` и personal `settings.local.json` мёрджатся, allow-правила
+  кумулятивны — конфликта нет.
+
+### 2. `reviewer install` мёрджит allowlist (`reviewer/install.py`)
+
+Новое:
+
+- `REVIEWER_PERMISSION_RULE = "mcp__reviewer__*"` — единственная константа-правило.
+- `claude_settings_path() -> Path` — `.claude/settings.json` (project scope, рядом с
+  `.mcp.json`, который `claude-code` пишет в CWD).
+- `AllowlistPlan(path, content, created, already)` — по образцу `InstallPlan`.
+- `build_allowlist_plan(path=None, rule=REVIEWER_PERMISSION_RULE) -> AllowlistPlan` —
+  читает существующий JSON (или `{}`), обеспечивает `permissions.allow` списком,
+  добавляет правило при отсутствии (dedup, `already=True` если уже есть), сохраняет
+  чужие ключи/правила. Возвращает план без записи.
+- Рефактор: общая запись с бэкапом выделяется в `_write_with_backup(path, content)
+  -> Path | None`; `apply_plan` и применение allowlist используют её (DRY). Поведение
+  `apply_plan` не меняется (идемпотентность + `.bak`).
+
+CLI (`reviewer/entrypoints/cli.py::install`): при установке клиента `claude-code`
+после записи MCP-плана дополнительно строится и применяется allowlist-план в
+`<dir>/.claude/settings.json` (dir = каталог MCP-конфига, по умолчанию CWD). При
+`--dry-run` его содержимое печатается. Идемпотентно, с `.bak`.
+
+### 3. `plugin/GEMINI.md`
+
+Документирует тулы reviewer MCP как pre-approved для Gemini CLI: явный список 15
+тулов + указание, что Gemini может доверять серверу `reviewer` целиком. Закрывает
+критерий 5. Файловую запись в `~/.gemini/settings.json` не трогаем (вне scope).
+
+### 4. Точечный фикс
+
+`reviewer/entrypoints/mcp_server.py::create_server` — докстринг «14 тулов» → «15
+тулов» (сейчас рассинхрон: тулов 15).
+
+### 5. Документация
+
+Краткая заметка в `README.md`: `reviewer install` теперь также прописывает allowlist
+(`permissions.allow: mcp__reviewer__*`) в `.claude/settings.json`, тулы работают из
+коробки без ручных шагов.
+
+## Тесты (`tests/install/test_install.py`, стиль существующих)
+
+- `build_allowlist_plan` на отсутствующем файле → создаёт
+  `{"permissions":{"allow":["mcp__reviewer__*"]}}`, `created=True`, `already=False`.
+- сохраняет чужие top-level ключи и существующие правила в `permissions.allow`.
+- идемпотентность: повторный план → `already=True`, без дублей правила.
+- merge в непустой `permissions.allow` с другими правилами.
+- CLI-интеграция: `reviewer install claude-code` в tmp-CWD пишет и `.mcp.json`, и
+  `.claude/settings.json` с правилом; повторный запуск не плодит дубли.
+
+## Вне scope (YAGNI / не в критериях приёмки)
+
+- Copilot CLI `references/copilot-tools.md` — не упомянут в критериях приёмки.
+- Cursor / VS Code / Claude Desktop — у них иные модели разрешений; проблема
+  classifier специфична для `auto`-режима Claude Code.
+- Изменение формата Gemini-записи в `~/.gemini/settings.json` (`trust: true`) —
+  риск задеть существующие тесты установки; документации в `GEMINI.md` достаточно.
+
+## Критерии приёмки → как закрываются
+
+1. Новый разработчик `reviewer install claude-code` → allow-правило в
+   `.claude/settings.json` → `/solve-task` без ошибок classifier. ✓
+2. Открыть `plugin/` как проект → `plugin/.claude/settings.json` применяется. ✓
+3. `search_codebase`/`search_tasks`/`get_task_context` проходят (allow обходит
+   classifier). ✓
+4. `reviewer install` идемпотентен (план `already`, `_write_with_backup` не пишет при
+   совпадении). ✓
+5. `plugin/GEMINI.md` содержит список pre-approved тулов. ✓

--- a/plugin/.claude/settings.json
+++ b/plugin/.claude/settings.json
@@ -1,0 +1,7 @@
+{
+  "permissions": {
+    "allow": [
+      "mcp__reviewer__*"
+    ]
+  }
+}

--- a/plugin/GEMINI.md
+++ b/plugin/GEMINI.md
@@ -1,0 +1,28 @@
+# Gemini CLI — reviewer MCP
+
+Плагин подключает MCP-сервер `reviewer` (RAG + граф кода + публикация ревью).
+Скилы `/solve-task`, `/review-pr`, `/sync-tasks` вызывают его тулы. Чтобы они
+работали без ручного подтверждения на каждый вызов, пометьте сервер `reviewer`
+доверенным в Gemini CLI (`~/.gemini/settings.json`, поле `trust` у MCP-сервера)
+— тогда все его тулы предодобрены.
+
+## Pre-approved тулы reviewer
+
+- `mcp__reviewer__prepare_review`
+- `mcp__reviewer__search_code`
+- `mcp__reviewer__get_related_symbols`
+- `mcp__reviewer__read_file`
+- `mcp__reviewer__get_definition`
+- `mcp__reviewer__find_callers`
+- `mcp__reviewer__get_changed_file_diff`
+- `mcp__reviewer__index_task`
+- `mcp__reviewer__index_tasks_batch`
+- `mcp__reviewer__purge_orphaned_tasks`
+- `mcp__reviewer__search_tasks`
+- `mcp__reviewer__get_task_context`
+- `mcp__reviewer__get_board_config`
+- `mcp__reviewer__search_codebase`
+- `mcp__reviewer__publish_review`
+
+Эквивалент для целого сервера — доверять `reviewer` целиком; в Claude Code это
+одно правило `mcp__reviewer__*` в `permissions.allow` (см. `.claude/settings.json`).

--- a/reviewer/entrypoints/cli.py
+++ b/reviewer/entrypoints/cli.py
@@ -299,6 +299,10 @@ def install(client: str | None, all_clients: bool, list_clients: bool,
         if dry_run:
             click.echo(f"# {c.label} → {plan.path}")
             click.echo(plan.content)
+            if c.key == "claude-code":
+                al_plan = inst.build_allowlist_plan(plan.path.parent / ".claude" / "settings.json")
+                click.echo(f"# {c.label} allowlist → {al_plan.path}")
+                click.echo(al_plan.content)
             if c.skills_fn and not no_skills:
                 click.echo(f"# {c.label} скилы → {c.skills_fn(_platform.system())}")
             continue
@@ -316,6 +320,19 @@ def install(client: str | None, all_clients: bool, list_clients: bool,
             click.echo(f"  бэкап: {backup}")
         if c.note:
             click.echo(f"  прим.: {c.note}")
+        if c.key == "claude-code":
+            al_plan = inst.build_allowlist_plan(plan.path.parent / ".claude" / "settings.json")
+            al_backup = inst.apply_allowlist_plan(al_plan)
+            if al_plan.already:
+                al_status = "правило уже есть"
+            elif al_plan.created:
+                al_status = "создан settings.json"
+            else:
+                al_status = "добавлено правило"
+            click.echo(f"  allowlist: {al_status} → {al_plan.path} "
+                       f"({inst.REVIEWER_PERMISSION_RULE})")
+            if al_backup:
+                click.echo(f"  бэкап: {al_backup}")
         _ensure_skills(c)
 
     if not dry_run:

--- a/reviewer/entrypoints/mcp_server.py
+++ b/reviewer/entrypoints/mcp_server.py
@@ -15,7 +15,7 @@ log = logging.getLogger(__name__)
 
 
 def create_server(service: MCPReviewService) -> FastMCP:
-    """Создать и вернуть сконфигурированный FastMCP-сервер с 14 тулами.
+    """Создать и вернуть сконфигурированный FastMCP-сервер с 15 тулами.
 
     Все тулы — обычные def (sync), а не async: сервис не потокобезопасен
     и рассчитан на последовательное исполнение sync-тулов FastMCP в event loop.

--- a/reviewer/install.py
+++ b/reviewer/install.py
@@ -23,6 +23,11 @@ from typing import Callable
 PACKAGE = "rag-reviewer"
 SERVER_NAME = "reviewer"
 
+# anchored-glob правило, разрешающее ВЕСЬ сервер reviewer в Claude Code
+# (permissions.allow). Wildcard покрывает новые тулы автоматически — список
+# тулов синхронизировать не нужно.
+REVIEWER_PERMISSION_RULE = "mcp__reviewer__*"
+
 # Скилы лежат в репозитории (plugin/skills) и в wheel не пакуются — тянем их
 # тарболом с GitHub (кроссплатформенно, без клона).
 SKILLS_TARBALL = "https://github.com/mimfort/rag_for_git/archive/refs/heads/main.tar.gz"
@@ -62,6 +67,11 @@ def default_env_path() -> Path:
     """Каноническое место .env: $XDG_CONFIG_HOME/rag-reviewer/.env."""
     xdg = os.environ.get("XDG_CONFIG_HOME") or str(_home() / ".config")
     return Path(xdg) / "rag-reviewer" / ".env"
+
+
+def claude_settings_path() -> Path:
+    """Проектный settings.json Claude Code (рядом с .mcp.json в корне проекта)."""
+    return Path(".claude") / "settings.json"
 
 
 # --------------------------------------------------------------------------- #
@@ -205,6 +215,14 @@ class InstallPlan:
     already: bool         # запись reviewer уже была (перезапишем)
 
 
+@dataclass
+class AllowlistPlan:
+    path: Path
+    content: str          # что будет записано в файл целиком
+    created: bool         # файла не было — создаём
+    already: bool         # правило уже было в permissions.allow
+
+
 def build_plan(
     client: Client,
     *,
@@ -239,23 +257,62 @@ def build_plan(
     return InstallPlan(client, path, content, command, args, not existed, already)
 
 
-def apply_plan(plan: InstallPlan) -> Path | None:
-    """Записать план на диск. Возвращает путь к .bak (если был бэкап).
+def build_allowlist_plan(
+    path: Path | None = None, rule: str = REVIEWER_PERMISSION_RULE
+) -> AllowlistPlan:
+    """План мёрджа allow-правила reviewer в permissions.allow Claude Code settings.
 
-    Если содержимое не меняется (запись уже актуальна / TOML с существующей
-    секцией), ничего не пишем и не бэкапим.
+    Сохраняет чужие ключи и существующие правила; идемпотентен (already=True,
+    если правило уже присутствует). Запись на диск — apply_allowlist_plan.
     """
-    plan.path.parent.mkdir(parents=True, exist_ok=True)
-    if plan.path.exists():
-        existing = plan.path.read_text(encoding="utf-8")
-        if existing == plan.content:
+    path = path or claude_settings_path()
+    existed = path.exists()
+    raw = path.read_text(encoding="utf-8") if existed else ""
+    cfg = json.loads(raw) if raw.strip() else {}
+    if not isinstance(cfg, dict):
+        raise ValueError(f"{path}: ожидался JSON-объект на верхнем уровне")
+    perms = cfg.get("permissions")
+    if not isinstance(perms, dict):
+        perms = {}
+    allow = perms.get("allow")
+    if not isinstance(allow, list):
+        allow = []
+    already = rule in allow
+    if not already:
+        allow = [*allow, rule]
+    perms["allow"] = allow
+    cfg["permissions"] = perms
+    content = json.dumps(cfg, indent=2, ensure_ascii=False) + "\n"
+    return AllowlistPlan(path, content, not existed, already)
+
+
+def _write_with_backup(path: Path, content: str) -> Path | None:
+    """Записать content в path; при изменении существующего файла сделать .bak.
+
+    Возвращает путь к .bak (если был бэкап) или None. Ничего не пишет и не
+    бэкапит, если содержимое не изменилось.
+    """
+    path.parent.mkdir(parents=True, exist_ok=True)
+    if path.exists():
+        existing = path.read_text(encoding="utf-8")
+        if existing == content:
             return None
-        backup = plan.path.with_suffix(plan.path.suffix + ".bak")
+        backup = path.with_suffix(path.suffix + ".bak")
         backup.write_text(existing, encoding="utf-8")
-        plan.path.write_text(plan.content, encoding="utf-8")
+        path.write_text(content, encoding="utf-8")
         return backup
-    plan.path.write_text(plan.content, encoding="utf-8")
+    path.write_text(content, encoding="utf-8")
     return None
+
+
+def apply_plan(plan: InstallPlan) -> Path | None:
+    """Записать MCP-план на диск. Возвращает путь к .bak (если был бэкап)."""
+    return _write_with_backup(plan.path, plan.content)
+
+
+def apply_allowlist_plan(plan: AllowlistPlan) -> Path | None:
+    """Записать allowlist-план на диск. Возвращает путь к .bak (если был бэкап)."""
+    return _write_with_backup(plan.path, plan.content)
 
 
 def detect_installed(system: str | None = None) -> list[Client]:

--- a/tests/install/test_install.py
+++ b/tests/install/test_install.py
@@ -1,4 +1,5 @@
 import json
+from pathlib import Path
 
 import pytest
 
@@ -254,3 +255,24 @@ def test_apply_allowlist_plan_no_write_when_unchanged(tmp_path):
     plan2 = inst.build_allowlist_plan(cfg)
     assert plan2.already is True
     assert inst.apply_allowlist_plan(plan2) is None
+
+
+def test_cli_install_claude_code_writes_allowlist(monkeypatch):
+    from click.testing import CliRunner
+
+    from reviewer.entrypoints.cli import cli
+
+    monkeypatch.setattr(inst.shutil, "which",
+                        lambda name: "/fake/bin/uvx" if name == "uvx" else None)
+    runner = CliRunner()
+    with runner.isolated_filesystem():
+        result = runner.invoke(cli, ["install", "claude-code"])
+        assert result.exit_code == 0, result.output
+        assert Path(".mcp.json").exists()
+        settings = json.loads(Path(".claude/settings.json").read_text())
+        assert "mcp__reviewer__*" in settings["permissions"]["allow"]
+        # идемпотентность: повторный запуск не плодит дубли
+        result2 = runner.invoke(cli, ["install", "claude-code"])
+        assert result2.exit_code == 0, result2.output
+        settings2 = json.loads(Path(".claude/settings.json").read_text())
+        assert settings2["permissions"]["allow"].count("mcp__reviewer__*") == 1

--- a/tests/install/test_install.py
+++ b/tests/install/test_install.py
@@ -200,3 +200,57 @@ def test_install_skills_unsupported_client(tmp_path):
 def test_skills_capable_clients_have_dirs():
     capable = {c.key for c in inst.CLIENTS.values() if c.skills_fn}
     assert capable == {"gemini", "mimo", "kimi", "opencode"}
+
+
+# --------------------------------------------------------------------------- #
+# allowlist (permissions.allow в .claude/settings.json)
+# --------------------------------------------------------------------------- #
+def test_allowlist_plan_creates_file(tmp_path):
+    cfg = tmp_path / ".claude" / "settings.json"
+    plan = inst.build_allowlist_plan(cfg)
+    assert plan.created is True and plan.already is False
+    data = json.loads(plan.content)
+    assert data["permissions"]["allow"] == ["mcp__reviewer__*"]
+
+
+def test_allowlist_plan_preserves_existing(tmp_path):
+    cfg = tmp_path / ".claude" / "settings.json"
+    cfg.parent.mkdir(parents=True)
+    cfg.write_text(json.dumps({
+        "permissions": {"allow": ["Bash(ls:*)"], "deny": ["mcp__evil"]},
+        "model": "opus",
+    }))
+    plan = inst.build_allowlist_plan(cfg)
+    data = json.loads(plan.content)
+    assert data["model"] == "opus"
+    assert data["permissions"]["deny"] == ["mcp__evil"]
+    assert data["permissions"]["allow"] == ["Bash(ls:*)", "mcp__reviewer__*"]
+    assert plan.already is False
+
+
+def test_allowlist_plan_idempotent(tmp_path):
+    cfg = tmp_path / ".claude" / "settings.json"
+    cfg.parent.mkdir(parents=True)
+    cfg.write_text(json.dumps({"permissions": {"allow": ["mcp__reviewer__*"]}}))
+    plan = inst.build_allowlist_plan(cfg)
+    assert plan.already is True
+    assert json.loads(plan.content)["permissions"]["allow"].count("mcp__reviewer__*") == 1
+
+
+def test_apply_allowlist_plan_writes_and_backs_up(tmp_path):
+    cfg = tmp_path / ".claude" / "settings.json"
+    cfg.parent.mkdir(parents=True)
+    cfg.write_text(json.dumps({"permissions": {"allow": ["Bash(ls:*)"]}}))
+    plan = inst.build_allowlist_plan(cfg)
+    backup = inst.apply_allowlist_plan(plan)
+    assert backup is not None and backup.exists()
+    written = json.loads(cfg.read_text())
+    assert "mcp__reviewer__*" in written["permissions"]["allow"]
+
+
+def test_apply_allowlist_plan_no_write_when_unchanged(tmp_path):
+    cfg = tmp_path / ".claude" / "settings.json"
+    inst.apply_allowlist_plan(inst.build_allowlist_plan(cfg))
+    plan2 = inst.build_allowlist_plan(cfg)
+    assert plan2.already is True
+    assert inst.apply_allowlist_plan(plan2) is None


### PR DESCRIPTION
## Задача

**PRI-98 / ID-98** — auto-конфигурация allowlist для reviewer MCP: тулы `mcp__reviewer__*` должны работать «из коробки» в Claude Code (и быть задокументированы для Gemini), чтобы `/solve-task`, `/review-pr`, `/sync-tasks` не падали, когда safety-classifier auto-режима недоступен.

[Доска](https://ru.yougile.com/team/686c049c8af8/#PRI-98)

## Что и почему

В auto-режиме Claude Code зовёт safety-classifier на каждый вызов `mcp__reviewer__*`. Если classifier недоступен — вызов отклоняется, и скилы вырождаются. Явное allow-правило обходит classifier и чинит это.

**Ключевое решение:** одно anchored-glob правило **`mcp__reviewer__*`**, а не явный перечень 15 тулов. Корневая боль задачи — устаревание списка при добавлении тулов; wildcard устраняет этот класс багов целиком (новый тул покрывается автоматически, без правок конфигов). Постановка предлагала top-level `allowedTools` — это некорректный ключ для `settings.json`; правильный — `permissions.allow` (сверено с docs Claude Code).

## Изменения

- **`reviewer install` мёрджит allowlist** (`reviewer/install.py`): `build_allowlist_plan`/`apply_allowlist_plan` добавляют `mcp__reviewer__*` в `permissions.allow` файла `.claude/settings.json` рядом с `.mcp.json`. Идемпотентно, с `.bak`; чужие ключи/правила сохраняются. Запись с бэкапом вынесена в общий `_write_with_backup` (DRY с `apply_plan`, поведение не изменилось).
- **CLI** (`reviewer/entrypoints/cli.py`): `install claude-code` пишет и `.mcp.json`, и `.claude/settings.json`; `--dry-run` печатает план.
- **Чек-инутые `settings.json`**: `plugin/.claude/settings.json` (тулы работают при открытии `plugin/` как проекта) и `.claude/settings.json` в корне (для разработки самого `rag_for_git`). `.gitignore` обновлён: личное/транзиентное в `.claude/` игнорируется, общий `settings.json` трекается.
- **`plugin/GEMINI.md`**: список 15 pre-approved тулов + про `trust` сервера в Gemini CLI.
- **`mcp_server.py`**: докстринг `create_server` «14 → 15 тулов» (был рассинхрон).
- **`README.md`**: заметка про allowlist при `reviewer install`.
- **Дизайн + план**: `docs/superpowers/specs/` и `docs/superpowers/plans/`.

## Критерии приёмки

1. ✅ Новый разработчик `reviewer install claude-code` → allow-правило в `.claude/settings.json` → `/solve-task` без ошибок classifier.
2. ✅ Открыть `plugin/` как проект → применяется `plugin/.claude/settings.json`.
3. ✅ `search_codebase`/`search_tasks`/`get_task_context` проходят (allow обходит classifier).
4. ✅ `reviewer install` идемпотентен (план `already`, `_write_with_backup` не пишет при совпадении).
5. ✅ `plugin/GEMINI.md` содержит список pre-approved тулов.

## Проверка

- `pytest -q --ignore=tests/web` → **360 passed** (`tests/web` требует extra `[web]`/`fastapi`, к изменениям не относится).
- `tests/install/test_install.py` → **28 passed** (5 allowlist-юнитов + CLI-интеграция в tmp-CWD: пишет оба файла, повтор не плодит дубли).
- `ruff check` по затронутым файлам — чисто.
