### PR TITLE
feat(install): allowlist reviewer MCP — глобальный ~/.claude/settings.json (PRI-98)

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,9 +169,11 @@ uvx --from rag-reviewer reviewer update
 > "rag-reviewer@latest", "reviewer-mcp"]` directly.
 
 > **Claude Code: tools work out of the box.** `reviewer install claude-code` also
-> writes an allowlist rule `mcp__reviewer__*` into the project's
-> `.claude/settings.json` (`permissions.allow`), so the reviewer MCP tools run
-> without hitting the `auto`-mode safety classifier — no manual settings edits.
+> writes an allowlist rule `mcp__reviewer__*` into your global
+> `~/.claude/settings.json` (`permissions.allow`), so the reviewer MCP tools run in
+> **every** project without hitting the `auto`-mode safety classifier — no manual
+> settings edits. Being global, it also covers the plugin (marketplace) install,
+> where the server is available everywhere but ships no permission grants.
 
 > **Where keys are read from.** The reviewer resolves its `.env` from a fixed
 > location, **not** the current working directory — MCP clients launch the server

--- a/README.ru.md
+++ b/README.ru.md
@@ -204,6 +204,13 @@ uvx --from rag-reviewer reviewer update
 > `bash -lc` только для macOS/Linux; на Windows используйте `reviewer install` или указывайте
 > `"command": "uvx"` с `"args": ["--from", "rag-reviewer@latest", "reviewer-mcp"]` напрямую.
 
+> **Claude Code: тулы работают из коробки.** `reviewer install claude-code` дополнительно
+> прописывает allowlist-правило `mcp__reviewer__*` в **глобальный** `~/.claude/settings.json`
+> (`permissions.allow`), поэтому тулы reviewer MCP работают **во всех проектах** без обращения
+> к safety-classifier `auto`-режима — без ручного редактирования настроек. Глобальное правило
+> покрывает и установку плагином (marketplace): там сервер доступен везде, но плагин не раздаёт
+> разрешений.
+
 Где взять ключи:
 - **Voyage** (`VOYAGE_API_KEY`): https://dashboard.voyageai.com/ — есть бесплатный пул; привяжите карту, чтобы снять лимит 3 RPM / 10K TPM.
 - **GitHub** (`GITHUB_TOKEN`): PAT с правами *Pull requests: Read and write* + *Contents: Read* (fine-grained) или scope `repo` (classic). Быстрый вариант: `gh auth token`.

--- a/reviewer/entrypoints/cli.py
+++ b/reviewer/entrypoints/cli.py
@@ -300,8 +300,8 @@ def install(client: str | None, all_clients: bool, list_clients: bool,
             click.echo(f"# {c.label} → {plan.path}")
             click.echo(plan.content)
             if c.key == "claude-code":
-                al_plan = inst.build_allowlist_plan(plan.path.parent / ".claude" / "settings.json")
-                click.echo(f"# {c.label} allowlist → {al_plan.path}")
+                al_plan = inst.build_allowlist_plan(inst.claude_user_settings_path())
+                click.echo(f"# {c.label} allowlist (глобально, для всех проектов) → {al_plan.path}")
                 click.echo(al_plan.content)
             if c.skills_fn and not no_skills:
                 click.echo(f"# {c.label} скилы → {c.skills_fn(_platform.system())}")
@@ -321,7 +321,7 @@ def install(client: str | None, all_clients: bool, list_clients: bool,
         if c.note:
             click.echo(f"  прим.: {c.note}")
         if c.key == "claude-code":
-            al_plan = inst.build_allowlist_plan(plan.path.parent / ".claude" / "settings.json")
+            al_plan = inst.build_allowlist_plan(inst.claude_user_settings_path())
             al_backup = inst.apply_allowlist_plan(al_plan)
             if al_plan.already:
                 al_status = "правило уже есть"
@@ -329,8 +329,8 @@ def install(client: str | None, all_clients: bool, list_clients: bool,
                 al_status = "создан settings.json"
             else:
                 al_status = "добавлено правило"
-            click.echo(f"  allowlist: {al_status} → {al_plan.path} "
-                       f"({inst.REVIEWER_PERMISSION_RULE})")
+            click.echo(f"  allowlist (глобально, для всех проектов): {al_status} → "
+                       f"{al_plan.path} ({inst.REVIEWER_PERMISSION_RULE})")
             if al_backup:
                 click.echo(f"  бэкап: {al_backup}")
         _ensure_skills(c)

--- a/reviewer/install.py
+++ b/reviewer/install.py
@@ -74,6 +74,17 @@ def claude_settings_path() -> Path:
     return Path(".claude") / "settings.json"
 
 
+def claude_user_settings_path() -> Path:
+    """Глобальный (user-scope) settings.json Claude Code: ~/.claude/settings.json.
+
+    Allowlist-правило reviewer пишем сюда, а не в проект: тогда оно действует во
+    ВСЕХ проектах сразу — и при проектной установке (.mcp.json в CWD), и при
+    установке плагином через marketplace (сервер глобален, но плагин не раздаёт
+    разрешений). Где reviewer не подключён — правило инертно (сервера нет).
+    """
+    return _home() / ".claude" / "settings.json"
+
+
 # --------------------------------------------------------------------------- #
 # команда запуска
 # --------------------------------------------------------------------------- #

--- a/tests/install/test_install.py
+++ b/tests/install/test_install.py
@@ -257,22 +257,34 @@ def test_apply_allowlist_plan_no_write_when_unchanged(tmp_path):
     assert inst.apply_allowlist_plan(plan2) is None
 
 
-def test_cli_install_claude_code_writes_allowlist(monkeypatch):
+def test_claude_user_settings_path_is_global():
+    # allowlist пишется в ГЛОБАЛЬНЫЙ user-конфиг (~/.claude/settings.json),
+    # чтобы правило действовало во всех проектах (вкл. установку плагином).
+    p = inst.claude_user_settings_path()
+    assert p == inst._home() / ".claude" / "settings.json"
+
+
+def test_cli_install_claude_code_writes_global_allowlist(monkeypatch, tmp_path):
     from click.testing import CliRunner
 
     from reviewer.entrypoints.cli import cli
 
+    home = tmp_path / "home"
+    monkeypatch.setattr(inst, "_home", lambda: home)
     monkeypatch.setattr(inst.shutil, "which",
                         lambda name: "/fake/bin/uvx" if name == "uvx" else None)
     runner = CliRunner()
     with runner.isolated_filesystem():
         result = runner.invoke(cli, ["install", "claude-code"])
         assert result.exit_code == 0, result.output
+        # .mcp.json остаётся проектным (в CWD), allowlist — глобальным (в HOME)
         assert Path(".mcp.json").exists()
-        settings = json.loads(Path(".claude/settings.json").read_text())
+        assert not Path(".claude/settings.json").exists()
+        global_settings = home / ".claude" / "settings.json"
+        settings = json.loads(global_settings.read_text())
         assert "mcp__reviewer__*" in settings["permissions"]["allow"]
         # идемпотентность: повторный запуск не плодит дубли
         result2 = runner.invoke(cli, ["install", "claude-code"])
         assert result2.exit_code == 0, result2.output
-        settings2 = json.loads(Path(".claude/settings.json").read_text())
+        settings2 = json.loads(global_settings.read_text())
         assert settings2["permissions"]["allow"].count("mcp__reviewer__*") == 1


### PR DESCRIPTION
## Контекст

Доводка PRI-98. После мерджа #16 `reviewer install claude-code` прописывал allowlist-правило `mcp__reviewer__*` в **проектный** `.claude/settings.json` (рядом с `.mcp.json` в CWD).

## Проблема

Проектный allowlist не покрывал **установку плагином** (`/plugin marketplace add mimfort/rag_for_git`): при ней reviewer-сервер доступен во **всех** проектах глобально, но плагины **не раздают разрешений** — поэтому в `auto`-режиме тулы в каждом проекте упирались в safety-classifier. Пользователю это «не из коробки».

(Для проектной установки бага не было: `.mcp.json` и `.claude/settings.json` пишутся вместе в CWD и консистентны.)

## Фикс

`reviewer install claude-code` теперь мёрджит правило в **глобальный** user-scope `~/.claude/settings.json` — тот же приём, что уже используется для Gemini (`~/.gemini/settings.json`). Правило действует во всех проектах сразу и покрывает обе схемы установки; где reviewer не подключён — инертно. `.mcp.json` остаётся проектным.

## Изменения

- `reviewer/install.py`: новый `claude_user_settings_path()` → `~/.claude/settings.json` (с обоснованием в докстринге).
- `reviewer/entrypoints/cli.py`: обе ветки install (`--dry-run` и обычная) строят allowlist-план против глобального пути; вывод помечен «глобально, для всех проектов».
- `tests/install/test_install.py`: `test_claude_user_settings_path_is_global` + переписанный CLI-тест (`test_cli_install_claude_code_writes_global_allowlist`) — монкипатчит HOME, проверяет, что allowlist уходит в глобальный `~/.claude/settings.json`, а `.mcp.json` остаётся проектным; идемпотентность.
- `README.md` / `README.ru.md`: заметки про allowlist синхронизированы под глобальное поведение (RU-заметка восстановлена — потерялась при мердже #16).

## Проверка

- `pytest -q --ignore=tests/web` → **361 passed** (`tests/web` требует extra `[web]`).
- `tests/install/test_install.py` → **29 passed**.
- `ruff check` по затронутым файлам — чисто.
- E2E с фейковым HOME: `reviewer install claude-code` → `.mcp.json` в проекте, `~/.claude/settings.json` с `mcp__reviewer__*` в HOME; повтор → «правило уже есть» (идемпотентно).
