### PR TITLE
test(mcp): guard покрытия полей PreparedReview в to_payload (PRI-99)

### DIFF
--- a/tests/mcp/test_session_serde.py
+++ b/tests/mcp/test_session_serde.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import json
+from dataclasses import fields
 
 import pytest
 
@@ -68,6 +69,18 @@ def test_payload_roundtrip_preserves_fields() -> None:
 def test_to_payload_excludes_vcs() -> None:
     payload = to_payload(_prepared(_DummyVCS()))
     assert "vcs" not in payload
+
+
+def test_to_payload_covers_all_prepared_fields() -> None:
+    """Guard рассинхронизации: to_payload должен сериализовать каждое поле
+    PreparedReview, кроме живого ``vcs`` (восстанавливается отдельно).
+
+    Если в PreparedReview добавят поле, не попавшее в to_payload, тест упадёт
+    здесь — вместо тихой потери поля через рестарт (поле с дефолтом) или промаха
+    регидрации (поле без дефолта). См. session_serde.to_payload."""
+    expected = {f.name for f in fields(PreparedReview)} - {"vcs"}
+    payload = to_payload(_prepared(_DummyVCS()))
+    assert set(payload) == expected
 
 
 def test_from_payload_missing_key_raises() -> None:


### PR DESCRIPTION
## Follow-up к PR #18 (PRI-99)

Закрывает maintainability-замечание из авто-ревью PR #18 (run_id=54): `session_serde.to_payload` вручную перечисляет поля `PreparedReview`, и при добавлении нового поля в датакласс оно молча выпадало бы из payload (потеря значения для поля с дефолтом через рестарт; промах регидрации для поля без дефолта).

### Изменение
`tests/mcp/test_session_serde.py`: новый `test_to_payload_covers_all_prepared_fields` — сверяет ключи `to_payload(prepared)` с `{f.name for f in fields(PreparedReview)} - {'vcs'}`. Теперь новое поле `PreparedReview`, не попавшее в `to_payload`, валит unit-тест в CI с понятным сообщением, а не деградирует тихо после рестарта.

Только тест, поведение кода не меняется. Локально: `pytest tests/mcp/test_session_serde.py` — 5 passed; ruff clean.