### PR TITLE
feat: скил reviewer_ask + session-less графовые MCP-тулы (PRI-118)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -75,7 +75,7 @@ MCP-сессия (PreparedReview + ToolContext) живёт в процессе `
 | `reviewer/graph/` | `builder` (tree-sitter call-graph) · `scip` (парсер SCIP) · `backend` (оркестратор бэкенда: SCIP / tree-sitter) · `store` (Neo4j) |
 | `reviewer/retrieval/` | `Retriever`: гибрид (RRF) + graph-expansion + Voyage rerank → `ContextPack` |
 | `reviewer/llm/` | `_retry.py` (retry/backoff для Voyage) |
-| `reviewer/tools/` | инструменты MCP-агента (`search_code`, `get_related_symbols`, `read_file`, `get_definition`, `find_callers`, `get_changed_file_diff`) |
+| `reviewer/tools/` | инструменты MCP-агента PR-сессии (`search_code`, `get_related_symbols`, `read_file`, `get_definition`, `find_callers`, `get_changed_file_diff`); session-less варианты для Q&A — `search_codebase`/`related_symbols`/`callers`/`definition` в `mcp/service.py` |
 | `reviewer/agent/` | `state` (ReviewUnit) · `assemble` · `dedup` |
 | `reviewer/mcp/` | `MCPReviewService` — сервисный слой MCP (prepare/tools/publish/history) |
 | `reviewer/services/` | `ReviewService.prepare` — подготовка PR (ingest + overlay + policy + units) |

--- a/README.md
+++ b/README.md
@@ -309,6 +309,7 @@ You get:
 - **MCP server** `reviewer` exposing: `prepare_review`, `publish_review`, `search_code`,
   `get_related_symbols`, `read_file`, `get_definition`, `find_callers`, `get_changed_file_diff`,
   `index_task`, `search_tasks`, `get_task_context`, `search_codebase`.
+  Рядом с `search_codebase` доступны session-less графовые тулы `related_symbols`/`callers`/`definition` (обход графа без PR-сессии) — их использует скил `/rag-reviewer:reviewer_ask` для grounded-вопросов по кодовой базе.
 
 > Run `/plugin` to confirm `rag-reviewer` is installed and enabled.
 

--- a/README.md
+++ b/README.md
@@ -305,17 +305,17 @@ Two commands, from any project:
 You get:
 
 - **Skills:** `/rag-reviewer:reviewer_review-pr`, `/rag-reviewer:reviewer_solve-task`, `/rag-reviewer:reviewer_sync-codebase`, `/rag-reviewer:reviewer_sync-tasks`
-  (plus `/rag-reviewer:reviewer_maintainability-review` and `/rag-reviewer:reviewer_performance-review`).
+  (plus `/rag-reviewer:reviewer_maintainability-review`, `/rag-reviewer:reviewer_performance-review`, and `/rag-reviewer:reviewer_ask`).
 - **MCP server** `reviewer` exposing: `prepare_review`, `publish_review`, `search_code`,
   `get_related_symbols`, `read_file`, `get_definition`, `find_callers`, `get_changed_file_diff`,
   `index_task`, `search_tasks`, `get_task_context`, `search_codebase`.
-  Рядом с `search_codebase` доступны session-less графовые тулы `related_symbols`/`callers`/`definition` (обход графа без PR-сессии) — их использует скил `/rag-reviewer:reviewer_ask` для grounded-вопросов по кодовой базе.
+  Alongside `search_codebase`, session-less graph tools `related_symbols`/`callers`/`definition` (graph traversal without a PR session) are available — used by the `/rag-reviewer:reviewer_ask` skill for grounded codebase Q&A.
 
 > Run `/plugin` to confirm `rag-reviewer` is installed and enabled.
 
 ### 3. Install skills globally (optional)
 
-Skills (`reviewer_review-pr`, `reviewer_solve-task`, `reviewer_sync-codebase`, `reviewer_sync-tasks`, `reviewer_performance-review`, `reviewer_maintainability-review`)
+Skills (`reviewer_review-pr`, `reviewer_solve-task`, `reviewer_sync-codebase`, `reviewer_sync-tasks`, `reviewer_performance-review`, `reviewer_maintainability-review`, `reviewer_ask`)
 let you invoke the full review workflow with a single command. Without them you can still call MCP
 tools directly, but the skills wrap them into a guided flow.
 

--- a/docs/superpowers/plans/2026-06-19-ask-skill.md
+++ b/docs/superpowers/plans/2026-06-19-ask-skill.md
@@ -1,0 +1,646 @@
+# Ask Skill (grounded codebase Q&A) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Дать скил `reviewer_ask` для grounded-вопросов по кодовой базе, опираясь на три новых session-less графовых MCP-тула.
+
+**Architecture:** Path B из спеки. В `MCPReviewService` добавляются session-less методы `related_symbols`/`callers`/`definition` (зеркаля́т существующий `search_codebase`, делегируя в `components.graph`/`store`/`retriever` без PR-сессии и без затрат Voyage). Они регистрируются как MCP-тулы в `create_server`. Поверх них — скил `plugin/skills/ask/SKILL.md`: `search_codebase` → точечный граф → harness `Read` → адаптивный grounded-ответ.
+
+**Tech Stack:** Python 3.11, FastMCP, pytest + unittest.mock, Neo4j (GraphStore), pgvector/pg_search (ChunkStore), Voyage (Retriever/reranker). Skill = Markdown (Claude Code plugin).
+
+**Spec:** `docs/superpowers/specs/2026-06-19-ask-skill-design.md`. **Branch:** `feat/pri-118-ask-skill` (уже создана, spec закоммичен).
+
+## Global Constraints
+
+- Python 3.11–3.13; ruff line-length **100**, target **py311** (`.venv/bin/ruff check .`).
+- Язык: **русские комментарии**, **английские докстринги тулов**, **русские** CLI-сообщения/доки/спеки.
+- `SKILL.md` тело — **английский** (экономия токенов), но скил **инструктирует отвечать пользователю по-русски**.
+- Коммиты: **Conventional Commits на русском, БЕЗ self-attribution** (никаких `Co-Authored-By`/упоминаний Claude).
+- Тесты: unit мокают внешние сервисы (фейки graph/store/retriever); реальные вызовы — только integration. `pytest` по умолчанию исключает integration (`addopts = -m 'not integration'`).
+- Запуск тестов: `.venv/bin/pytest -q`.
+- Имена новых тулов (`related_symbols`/`callers`/`definition`) **не должны совпадать** с session-bound `get_related_symbols`/`find_callers`/`get_definition` (FastMCP требует уникальности).
+
+## Verified signatures (из текущего кода — использовать дословно)
+
+- `reviewer/mcp/service.py:326` — `MCPReviewService.search_codebase(self, repo, query, top_k=10, branch=None) -> str` (содержит inline-резолв repo/branch, переносим в хелпер).
+- `reviewer/graph/store.py` — `GraphStore.expand(repo, node_ids, hops=2, *, branch="") -> set[str]`; `GraphStore.callers(repo, node_ids, *, branch="") -> set[str]`; `GraphStore.find_symbol(repo, name, *, branch="") -> list[str]`.
+- `reviewer/index/store.py:302` — `ChunkStore.fetch_nodes(repo, node_ids, overlay_ref, changed_paths, *, base_ref="base")`. Узлы имеют `.node_id`, `.path`, `.start_line`, `.end_line`, `.text`.
+- `reviewer/retrieval/retriever.py:60` — `Retriever.search_base(repo, query, top_k=10, candidates=50, *, branch="") -> ContextPack` (с `.as_context() -> str`).
+- `reviewer/index/refs.py:10` — `base_ref(branch: str) -> str` (`'' → 'base'`, `'main' → 'base:main'`).
+- `reviewer/services/repo_id.py:9` — `normalize_repo(repo: str) -> str` (бросает `ValueError`).
+- `reviewer/config/settings.py` — `Settings.default_repo`, `Settings.review_branches_list()`, `Settings.primary_branch()`.
+- `Components` (`reviewer/app.py:15`) поля: `settings, store, graph: GraphStore | None, embedder, reranker, retriever, task_store, task_graph, task_service`. **`graph` может быть `None`** (Neo4j выключен) — учитывать.
+
+---
+
+### Task 1: Рефактор резолва repo/branch в `_resolve_repo_branch`
+
+Выделить общий резолв из `search_codebase` в приватный хелпер, чтобы переиспользовать его в новых методах. Поведение `search_codebase` не меняется.
+
+**Files:**
+- Modify: `reviewer/mcp/service.py` (метод `search_codebase` ~строки 326-351; добавить хелпер рядом)
+- Test: `tests/mcp/test_service.py`
+
+**Interfaces:**
+- Produces: `MCPReviewService._resolve_repo_branch(self, repo: str, branch: str | None) -> tuple[str, str] | str` — успех: `(normalized_repo, resolved_branch)`; ошибка: строка-заметка (например `"(repo не задан…)"`). Используется в Task 2.
+
+- [ ] **Step 1: Написать падающий тест на отклонение неотслеживаемой ветки**
+
+В `tests/mcp/test_service.py` (рядом с другими `search_codebase`-тестами):
+
+```python
+def test_search_codebase_rejects_untracked_branch() -> None:
+    """Ветка не из REVIEW_BRANCHES → понятная заметка, retriever не зовётся."""
+    svc = _make_mcp_service()
+    out = svc.search_codebase("a/b", "x", branch="release/v9")
+    assert "REVIEW_BRANCHES" in out
+    svc.components.retriever.search_base.assert_not_called()
+```
+
+- [ ] **Step 2: Прогнать — убедиться, что падает**
+
+Run: `.venv/bin/pytest tests/mcp/test_service.py::test_search_codebase_rejects_untracked_branch -q`
+Expected: FAIL (по умолчанию `review_branches="main"`; текущий код уже отклоняет ветку, но тест новый — если упадёт на отсутствии метода или иной формулировке, это и подтверждает старт). Если PASS сразу — всё равно оставляем тест как регрессионный и продолжаем рефактор.
+
+- [ ] **Step 3: Добавить хелпер и переписать `search_codebase` поверх него**
+
+В `reviewer/mcp/service.py` добавить метод (над `search_codebase`):
+
+```python
+    def _resolve_repo_branch(self, repo: str, branch: str | None) -> tuple[str, str] | str:
+        """Резолв (repo, ветка) для session-less тулов.
+
+        Возвращает (normalized_repo, resolved_branch) при успехе либо строку-заметку
+        об ошибке (её тул отдаёт пользователю как есть). Ветка валидируется по
+        REVIEW_BRANCHES; пустая ветка → первичная.
+        """
+        from reviewer.services.repo_id import normalize_repo
+        raw = repo or self.settings.default_repo
+        if not raw:
+            return "(repo не задан: передайте repo или задайте DEFAULT_REPO)"
+        try:
+            repo = normalize_repo(raw)
+        except ValueError:
+            return f"(некорректный repo: {raw!r})"
+        if branch and branch not in self.settings.review_branches_list():
+            return (f"(ветка {branch!r} не в REVIEW_BRANCHES "
+                    f"({self.settings.review_branches_list()}))")
+        return repo, branch or self.settings.primary_branch()
+```
+
+Заменить тело `search_codebase` на:
+
+```python
+    def search_codebase(self, repo: str, query: str, top_k: int = 10,
+                        branch: str | None = None) -> str:
+        """Гибрид-поиск по base-индексу репозитория (без PR-сессии) — для /solve-task.
+
+        branch — отслеживаемая ветка (allowlist REVIEW_BRANCHES); по умолчанию
+        первичная. Поиск идёт по индексу указанной ветки (base:<branch>).
+        """
+        rb = self._resolve_repo_branch(repo, branch)
+        if isinstance(rb, str):
+            return rb
+        repo, resolved = rb
+        try:
+            pack = self.components.retriever.search_base(
+                repo, query, top_k=top_k, branch=resolved)
+        except Exception:
+            log.warning("search_codebase: сбой поиска", exc_info=True)
+            return "(ничего не найдено)"
+        return pack.as_context() or "(ничего не найдено)"
+```
+
+- [ ] **Step 4: Прогнать все `search_codebase`-тесты — зелёные**
+
+Run: `.venv/bin/pytest tests/mcp/test_service.py -q -k search_codebase`
+Expected: PASS (включая новый тест и существующие `test_search_codebase_delegates_to_retriever`, `…_empty_or_error_returns_note`, `…_uses_explicit_repo`, `…_falls_back_to_default_repo`).
+
+- [ ] **Step 5: Линт**
+
+Run: `.venv/bin/ruff check reviewer/mcp/service.py`
+Expected: без новых ошибок.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add reviewer/mcp/service.py tests/mcp/test_service.py
+git commit -m "refactor(mcp): вынести резолв repo/branch в _resolve_repo_branch"
+```
+
+---
+
+### Task 2: Session-less сервисные методы `related_symbols`/`callers`/`definition`
+
+**Files:**
+- Modify: `reviewer/mcp/service.py` (импорт `base_ref`; 3 новых метода после `search_codebase`)
+- Test: `tests/mcp/test_service.py`
+
+**Interfaces:**
+- Consumes: `_resolve_repo_branch` (Task 1); `components.graph.expand/callers/find_symbol`, `components.store.fetch_nodes`, `components.retriever.search_base`.
+- Produces:
+  - `related_symbols(self, repo: str, node_id: str, branch: str | None = None) -> str`
+  - `callers(self, repo: str, node_id: str, branch: str | None = None) -> str`
+  - `definition(self, repo: str, symbol: str, branch: str | None = None) -> str`
+  (используются в Task 3)
+
+- [ ] **Step 1: Написать падающие тесты**
+
+В `tests/mcp/test_service.py` добавить (фейки `graph`/`store`/`retriever` уже есть в `_components()`):
+
+```python
+def test_related_symbols_delegates_to_graph() -> None:
+    """related_symbols зовёт graph.expand(repo, [node_id], hops=2, branch=primary)."""
+    svc = _make_mcp_service()
+    svc.components.graph.expand.return_value = {"a.py#bar", "a.py#baz"}
+    out = svc.related_symbols("a/b", "a.py#foo")
+    assert "a.py#bar" in out and "a.py#baz" in out
+    svc.components.graph.expand.assert_called_once_with(
+        "a/b", ["a.py#foo"], hops=2, branch=svc.settings.primary_branch())
+
+
+def test_related_symbols_empty_and_failsoft() -> None:
+    """Пусто → '(нет связей)'; исключение графа → тоже заглушка, не падаем."""
+    svc = _make_mcp_service()
+    svc.components.graph.expand.return_value = set()
+    assert svc.related_symbols("a/b", "a.py#foo") == "(нет связей)"
+    svc.components.graph.expand.side_effect = RuntimeError("neo4j down")
+    assert svc.related_symbols("a/b", "a.py#foo") == "(нет связей)"
+
+
+def test_related_symbols_graph_none() -> None:
+    """graph=None (Neo4j выключен) → '(граф недоступен)'."""
+    svc = _make_mcp_service()
+    svc.components.graph = None
+    assert svc.related_symbols("a/b", "a.py#foo") == "(граф недоступен)"
+
+
+def test_related_symbols_invalid_branch() -> None:
+    """Невалидная ветка → заметка из _resolve_repo_branch, граф не зовётся."""
+    svc = _make_mcp_service()
+    out = svc.related_symbols("a/b", "a.py#foo", branch="nope")
+    assert "REVIEW_BRANCHES" in out
+
+
+def test_callers_delegates_to_graph() -> None:
+    """callers зовёт graph.callers и форматирует множество."""
+    svc = _make_mcp_service()
+    svc.components.graph.callers.return_value = {"a.py#caller"}
+    out = svc.callers("a/b", "a.py#foo")
+    assert "a.py#caller" in out
+    svc.components.graph.callers.assert_called_once_with(
+        "a/b", ["a.py#foo"], branch=svc.settings.primary_branch())
+    svc.components.graph.callers.return_value = set()
+    assert svc.callers("a/b", "a.py#foo") == "(вызовов не найдено)"
+
+
+def test_definition_uses_graph_then_store() -> None:
+    """definition: find_symbol → fetch_nodes → отрендеренный исходник."""
+    svc = _make_mcp_service()
+    svc.components.graph.find_symbol.return_value = ["a.py#foo"]
+    node = SimpleNamespace(node_id="a.py#foo", path="a.py",
+                           start_line=10, end_line=12, text="def foo(): ...")
+    svc.components.store.fetch_nodes.return_value = [node]
+    out = svc.definition("a/b", "foo")
+    assert "a.py#foo" in out and "def foo()" in out and "a.py:10-12" in out
+    svc.components.graph.find_symbol.assert_called_once_with(
+        "a/b", "foo", branch=svc.settings.primary_branch())
+
+
+def test_definition_falls_back_to_search_base() -> None:
+    """Граф пуст → фолбэк на retriever.search_base."""
+    svc = _make_mcp_service()
+    svc.components.graph.find_symbol.return_value = []
+    svc.components.retriever.search_base.return_value.as_context.return_value = "semantic hit"
+    out = svc.definition("a/b", "foo")
+    assert "semantic hit" in out
+    svc.components.retriever.search_base.assert_called_once_with(
+        "a/b", "foo", top_k=3, branch=svc.settings.primary_branch())
+```
+
+Добавить импорт вверху файла теста (рядом с прочими import):
+
+```python
+from types import SimpleNamespace
+```
+
+- [ ] **Step 2: Прогнать — убедиться, что падают**
+
+Run: `.venv/bin/pytest tests/mcp/test_service.py -q -k "related_symbols or callers or definition"`
+Expected: FAIL (`AttributeError: 'MCPReviewService' object has no attribute 'related_symbols'`).
+
+- [ ] **Step 3: Реализовать методы**
+
+В `reviewer/mcp/service.py` добавить импорт в шапку (рядом с другими `from reviewer...`):
+
+```python
+from reviewer.index.refs import base_ref
+```
+
+После `search_codebase` добавить:
+
+```python
+    def related_symbols(self, repo: str, node_id: str,
+                        branch: str | None = None) -> str:
+        """Соседи символа по графу (calls/implements/tests) без PR-сессии."""
+        rb = self._resolve_repo_branch(repo, branch)
+        if isinstance(rb, str):
+            return rb
+        repo, resolved = rb
+        if self.components.graph is None:
+            return "(граф недоступен)"
+        try:
+            related = self.components.graph.expand(
+                repo, [node_id], hops=2, branch=resolved)
+        except Exception:
+            log.warning("related_symbols: сбой графа", exc_info=True)
+            return "(нет связей)"
+        return "\n".join(sorted(related)) or "(нет связей)"
+
+    def callers(self, repo: str, node_id: str,
+                branch: str | None = None) -> str:
+        """Кто вызывает символ node_id ('path#fqn') — входящие CALLS, без PR-сессии."""
+        rb = self._resolve_repo_branch(repo, branch)
+        if isinstance(rb, str):
+            return rb
+        repo, resolved = rb
+        if self.components.graph is None:
+            return "(граф недоступен)"
+        try:
+            found = self.components.graph.callers(
+                repo, [node_id], branch=resolved)
+        except Exception:
+            log.warning("callers: сбой графа", exc_info=True)
+            return "(вызовов не найдено)"
+        return "\n".join(sorted(found)) or "(вызовов не найдено)"
+
+    def definition(self, repo: str, symbol: str,
+                   branch: str | None = None) -> str:
+        """Где определён символ + исходник (граф → индекс → семантический фолбэк),
+        без PR-сессии."""
+        rb = self._resolve_repo_branch(repo, branch)
+        if isinstance(rb, str):
+            return rb
+        repo, resolved = rb
+        try:
+            ids: list[str] = []
+            if self.components.graph is not None:
+                ids = self.components.graph.find_symbol(
+                    repo, symbol, branch=resolved)
+            if ids:
+                nodes = self.components.store.fetch_nodes(
+                    repo, ids[:3], None, [], base_ref=base_ref(resolved))
+                if nodes:
+                    return "\n\n".join(
+                        f"// {n.node_id} ({n.path}:{n.start_line}-{n.end_line})\n{n.text}"
+                        for n in nodes)
+            pack = self.components.retriever.search_base(
+                repo, symbol, top_k=3, branch=resolved)
+            return pack.as_context() or "(определение не найдено)"
+        except Exception:
+            log.warning("definition: сбой", exc_info=True)
+            return "(определение не найдено)"
+```
+
+- [ ] **Step 4: Прогнать новые тесты — зелёные**
+
+Run: `.venv/bin/pytest tests/mcp/test_service.py -q -k "related_symbols or callers or definition"`
+Expected: PASS (все 7).
+
+- [ ] **Step 5: Прогнать весь файл (регрессия) + линт**
+
+Run: `.venv/bin/pytest tests/mcp/test_service.py -q && .venv/bin/ruff check reviewer/mcp/service.py`
+Expected: PASS, без ошибок линта.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add reviewer/mcp/service.py tests/mcp/test_service.py
+git commit -m "feat(mcp): session-less графовые методы related_symbols/callers/definition"
+```
+
+---
+
+### Task 3: MCP-тулы `related_symbols`/`callers`/`definition` в сервере
+
+**Files:**
+- Modify: `reviewer/entrypoints/mcp_server.py` (3 тула + докстринг счётчика)
+- Test: `tests/mcp/test_server_tools.py`
+
+**Interfaces:**
+- Consumes: `service.related_symbols/callers/definition` (Task 2).
+- Produces: MCP-тулы `related_symbols(repo, node_id, branch=None)`, `callers(repo, node_id, branch=None)`, `definition(repo, symbol, branch=None)`.
+
+- [ ] **Step 1: Написать падающие тесты регистрации и проброса**
+
+В `tests/mcp/test_server_tools.py` добавить:
+
+```python
+def test_graph_base_tools_registered():
+    import asyncio
+
+    svc = _service()
+    svc.related_symbols.return_value = "x"
+    svc.callers.return_value = "x"
+    svc.definition.return_value = "x"
+    server = create_server(svc)
+    names = {t.name for t in asyncio.run(server.list_tools())}
+    assert {"related_symbols", "callers", "definition"} <= names
+
+
+def test_related_symbols_tool_forwards():
+    import asyncio
+
+    svc = _service()
+    svc.related_symbols.return_value = "neighbors"
+    server = create_server(svc)
+    asyncio.run(server.call_tool(
+        "related_symbols", {"repo": "owner/name", "node_id": "a.py#foo"}))
+    svc.related_symbols.assert_called_once_with("owner/name", "a.py#foo", None)
+
+
+def test_callers_tool_forwards():
+    import asyncio
+
+    svc = _service()
+    svc.callers.return_value = "callers"
+    server = create_server(svc)
+    asyncio.run(server.call_tool(
+        "callers", {"repo": "owner/name", "node_id": "a.py#foo", "branch": "main"}))
+    svc.callers.assert_called_once_with("owner/name", "a.py#foo", "main")
+
+
+def test_definition_tool_forwards():
+    import asyncio
+
+    svc = _service()
+    svc.definition.return_value = "def"
+    server = create_server(svc)
+    asyncio.run(server.call_tool(
+        "definition", {"repo": "owner/name", "symbol": "foo"}))
+    svc.definition.assert_called_once_with("owner/name", "foo", None)
+```
+
+- [ ] **Step 2: Прогнать — убедиться, что падают**
+
+Run: `.venv/bin/pytest tests/mcp/test_server_tools.py -q -k "graph_base or related_symbols or callers or definition"`
+Expected: FAIL (тулы ещё не зарегистрированы → `Unknown tool` / отсутствуют в `names`).
+
+- [ ] **Step 3: Зарегистрировать тулы**
+
+В `reviewer/entrypoints/mcp_server.py` после тула `search_codebase` (строка ~116) добавить:
+
+```python
+    @mcp.tool()
+    def related_symbols(repo: str, node_id: str, branch: str | None = None) -> str:
+        """Code-graph neighbors (calls/implementations/tests) of a symbol node_id
+        'path#fqn' over the base index (no PR session).
+        branch defaults to the primary tracked branch."""
+        return service.related_symbols(repo, node_id, branch)
+
+    @mcp.tool()
+    def callers(repo: str, node_id: str, branch: str | None = None) -> str:
+        """Direct callers of a symbol node_id 'path#fqn' over the base index
+        (no PR session). branch defaults to the primary tracked branch."""
+        return service.callers(repo, node_id, branch)
+
+    @mcp.tool()
+    def definition(repo: str, symbol: str, branch: str | None = None) -> str:
+        """Find a symbol definition over the base index (graph -> index -> semantic
+        fallback), no PR session. branch defaults to the primary tracked branch."""
+        return service.definition(repo, symbol, branch)
+```
+
+- [ ] **Step 4: Обновить докстринг счётчика тулов**
+
+В `reviewer/entrypoints/mcp_server.py` в докстринге `create_server` заменить:
+
+```
+    """Создать и вернуть сконфигурированный FastMCP-сервер с 15 тулами.
+```
+
+на:
+
+```
+    """Создать и вернуть сконфигурированный FastMCP-сервер с 18 тулами.
+```
+
+- [ ] **Step 5: Прогнать тесты сервера — зелёные**
+
+Run: `.venv/bin/pytest tests/mcp/test_server_tools.py -q`
+Expected: PASS (новые + существующие).
+
+- [ ] **Step 6: Линт**
+
+Run: `.venv/bin/ruff check reviewer/entrypoints/mcp_server.py`
+Expected: без ошибок.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add reviewer/entrypoints/mcp_server.py tests/mcp/test_server_tools.py
+git commit -m "feat(mcp): зарегистрировать session-less графовые тулы в MCP-сервере"
+```
+
+---
+
+### Task 4: Скил `plugin/skills/ask/SKILL.md`
+
+**Files:**
+- Create: `plugin/skills/ask/SKILL.md`
+
+**Interfaces:**
+- Consumes: MCP-тулы `search_codebase`/`related_symbols`/`callers`/`definition` (Task 3) + harness `Read`/`Grep`/`Glob`.
+- Produces: скил `reviewer_ask` (авто-дискавери из `plugin/skills/`).
+
+- [ ] **Step 1: Создать файл скила**
+
+Создать `plugin/skills/ask/SKILL.md` со следующим содержимым (тело — английское; правило «отвечать по-русски» внутри):
+
+````markdown
+---
+name: reviewer_ask
+description: Answer grounded questions about the codebase (onboarding / Q&A) using the reviewer RAG + code graph. Use when the user asks how the code works, where something lives, or to explain a subsystem ("where is auth", "how does X work", "explain the indexing flow", "как устроено…", "где у нас…", "объясни код"). Requires a built base index + graph (reviewer MCP server). Not for reviewing PRs.
+---
+
+# Ask (codebase Q&A)
+
+Answer a free-text question about the codebase with a **grounded** response: every claim is
+backed by a real `path:line` citation, never an invented path. Built on the reviewer MCP server
+(hybrid RAG + code graph). This skill reads and explains; it does NOT modify code or review PRs.
+
+**Always answer the user in Russian** (the project language), regardless of this file's language.
+Tool calls, code identifiers, and `path:line` citations stay verbatim.
+
+## Inputs
+
+`$ARGUMENTS` — a free-text question about the code (e.g. "where is authentication",
+"how does index freshness work", "explain the retrieval pipeline").
+
+## Tools
+
+Session-less reviewer MCP tools (no PR / `prepare_review` needed):
+- `search_codebase(repo, query, top_k?, branch?)` — hybrid semantic+lexical search; already
+  includes 1-hop graph expansion + rerank. Returns chunks headed by `path#fqn (path:start-end)`.
+- `related_symbols(repo, node_id, branch?)` — graph neighbors (calls/implements/tests) of a
+  `node_id` ('path#fqn').
+- `callers(repo, node_id, branch?)` — direct callers of a `node_id` (impact).
+- `definition(repo, symbol, branch?)` — where a symbol is defined + its source.
+
+Plus the harness file tools (`Read`, `Grep`, `Glob`) to read source from the local clone on disk.
+
+## Pipeline
+
+1. **Resolve repo/branch.**
+   - `repo`: `git remote get-url origin` → strip a trailing `.git`, take the last two path
+     segments (`owner/name`). Pass `""` to let the server use `DEFAULT_REPO` if origin is missing.
+   - `branch`: `git branch --show-current`. Pass it only if it is in `REVIEW_BRANCHES`; if the
+     user named a branch, use that; otherwise omit it (the server uses the primary branch).
+
+2. **Search.** Call `search_codebase(repo, "<question>", branch=…)`. Parse the
+   `path#fqn (path:start-end)` headers to get candidate symbols (`node_id`) and line ranges.
+   If the result is `(ничего не найдено)`, go to Fallback.
+
+3. **Expand (only as needed).** For the symbols most relevant to the question, call
+   `related_symbols` / `callers` / `definition` to follow the graph. Do NOT expand everything —
+   only what the answer requires. Stop once you can answer.
+
+4. **Confirm source.** Before citing any `path:line`, open it with `Read` (from disk) and verify
+   the cited code actually exists and says what you claim. Drop any citation you cannot confirm.
+
+5. **Answer (adaptive), in Russian.**
+   - Default (focused question): a direct answer in 2–4 sentences, then an **Evidence** list —
+     each item `path:line` + a one-line "why this is relevant".
+   - Broad question ("explain subsystem X"): expand into sections — Краткий ответ / Ключевые
+     символы / Поток / Связанные места — each claim still carrying a confirmed `path:line`.
+
+## Grounding contract (hard rule)
+
+Cite ONLY paths that were returned by a tool AND confirmed by `Read`. Never invent or guess a
+path or line number. If you cannot ground a statement, say so explicitly instead of fabricating a
+citation. This is the skill's acceptance criterion.
+
+## Fallback (fail-open)
+
+If the reviewer MCP server is unreachable or returns `(ничего не найдено)` / `(граф недоступен)`
+(Postgres/Neo4j/index down), degrade gracefully:
+- Use the harness `Grep`/`Glob`/`Read` over the local clone to locate and confirm code.
+- Tell the user (in Russian) that semantic/graph search was unavailable and the answer comes from
+  a lexical search, so it may be less complete.
+Never abort — always return the best grounded answer you can.
+
+## Notes
+
+- Precondition: the base index + graph must be built (`reviewer index`). Graph precision depends on
+  the backend: SCIP → `IMPLEMENTS` + accurate `CALLS`; tree-sitter → `CALLS` by name only.
+- Read-only: this skill never edits code and never posts to GitHub. Posting a human-facing review
+  guide to a PR is a separate skill (PRI-119).
+````
+
+- [ ] **Step 2: Проверить структуру и frontmatter**
+
+Run: `head -4 plugin/skills/ask/SKILL.md`
+Expected: корректный YAML-frontmatter с `name: reviewer_ask` и однострочным `description`.
+
+- [ ] **Step 3: Sanity — скил в той же форме, что соседи**
+
+Run: `ls plugin/skills/ask/ && grep -c "name: reviewer_" plugin/skills/ask/SKILL.md`
+Expected: файл `SKILL.md` на месте; `grep` → `1`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add plugin/skills/ask/SKILL.md
+git commit -m "feat(skill): ask — grounded Q&A по кодовой базе (PRI-118)"
+```
+
+---
+
+### Task 5: Документация — упомянуть session-less графовые тулы
+
+**Files:**
+- Modify: `CLAUDE.md` (таблица модулей, строка `reviewer/tools/`)
+- Modify: `README.md` (рядом с упоминанием `search_codebase`)
+
+**Interfaces:** нет (только доки).
+
+- [ ] **Step 1: Обновить таблицу модулей в `CLAUDE.md`**
+
+Найти строку:
+
+```
+| `reviewer/tools/` | инструменты MCP-агента (`search_code`, `get_related_symbols`, `read_file`, `get_definition`, `find_callers`, `get_changed_file_diff`) |
+```
+
+Заменить на:
+
+```
+| `reviewer/tools/` | инструменты MCP-агента PR-сессии (`search_code`, `get_related_symbols`, `read_file`, `get_definition`, `find_callers`, `get_changed_file_diff`); session-less варианты для Q&A — `search_codebase`/`related_symbols`/`callers`/`definition` в `mcp/service.py` |
+```
+
+- [ ] **Step 2: Упомянуть тулы в `README.md`**
+
+Run: `grep -n "search_codebase" README.md`
+Если есть упоминание `search_codebase` — добавить рядом (в том же абзаце/списке) фразу:
+
+```
+Рядом с `search_codebase` доступны session-less графовые тулы `related_symbols`/`callers`/`definition` (обход графа без PR-сессии) — их использует скил `/rag-reviewer:reviewer_ask` для grounded-вопросов по кодовой базе.
+```
+
+Если упоминания `search_codebase` в README нет — добавить короткий пункт о скиле `reviewer_ask` в раздел про скилы/CLI (там, где перечислены `solve-task`/`review-pr`).
+
+- [ ] **Step 3: Проверка**
+
+Run: `grep -n "related_symbols\|reviewer_ask\|session-less" CLAUDE.md README.md`
+Expected: новые упоминания присутствуют.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add CLAUDE.md README.md
+git commit -m "docs: упомянуть session-less графовые тулы и скил ask (PRI-118)"
+```
+
+---
+
+### Task 6: Ручная верификация критерия приёмки (integration)
+
+Требует поднятых Postgres/Neo4j + построенного base-индекса (`reviewer index`). Не unit-тест — ручной прогон.
+
+**Files:** нет (проверка).
+
+- [ ] **Step 1: Поднять инфраструктуру (если не поднята)**
+
+Run: `docker compose up -d && .venv/bin/reviewer check`
+Expected: ParadeDB (5433), Neo4j (7687) доступны; `reviewer check` зелёный.
+
+- [ ] **Step 2: Убедиться, что индекс построен**
+
+Run: `.venv/bin/reviewer search "authentication" 2>&1 | head -20`
+Expected: непустой результат (если пусто — сначала `.venv/bin/reviewer index . --ref main`).
+
+- [ ] **Step 3: Прогнать скил `reviewer_ask` на критерии приёмки**
+
+В Claude Code (репозиторий открыт как проект) вызвать `/rag-reviewer:reviewer_ask где аутентификация` (или иной осмысленный для этого репо вопрос, например `где гибридный поиск` / `как устроена свежесть индекса`).
+
+Expected: ответ по-русски, содержит конкретные файлы/символы с `path:line`, каждый подтверждён `Read`; **нет выдуманных путей**. Это и есть критерий приёмки PRI-118.
+
+- [ ] **Step 4: Прогнать полный unit-набор (финальная регрессия)**
+
+Run: `.venv/bin/pytest -q && .venv/bin/ruff check reviewer/`
+Expected: PASS; без новых ошибок линта в изменённых файлах.
+
+---
+
+## Self-Review (выполнено автором плана)
+
+**1. Spec coverage:**
+- Секция 1 спеки (3 session-less тула + рефактор `_resolve_repo_branch`) → Tasks 1–3. ✅
+- Секция 2 (скил `reviewer_ask`, pipeline, grounding, fail-open, англ. тело/рус. ответы) → Task 4. ✅
+- Секция 3 (доки: счётчик тулов, CLAUDE.md, README.md) → Task 3 Step 4 + Task 5. ✅
+- Критерий приёмки → Task 6. ✅
+- `read_file` session-less и «карта подсистемы» — намеренно вне объёма (follow-up), в задачах отсутствуют. ✅
+
+**2. Placeholder scan:** Код и тесты приведены целиком; команды с ожидаемым выводом. README-шаг условный, но с конкретным текстом и точной командой поиска — не плейсхолдер. ✅
+
+**3. Type consistency:** Имена/сигнатуры (`related_symbols`/`callers`/`definition`, `_resolve_repo_branch -> tuple[str,str] | str`, `base_ref(resolved)`, `fetch_nodes(repo, ids[:3], None, [], base_ref=…)`, `search_base(..., top_k=3, branch=…)`) совпадают между Tasks 2/3 и проверены против текущего кода. Узлы `fetch_nodes` имеют `.node_id/.path/.start_line/.end_line/.text` (как в `code_tools.get_definition`). ✅

--- a/docs/superpowers/specs/2026-06-19-ask-skill-design.md
+++ b/docs/superpowers/specs/2026-06-19-ask-skill-design.md
@@ -1,0 +1,143 @@
+# Дизайн: скил `ask` (grounded Q&A по кодовой базе) + session-less граф
+
+- **Задача:** PRI-118 / ID-118 «4. Q&A / онбординг по кодовой базе» (колонка «Плагин/агент (скилы)», оценка M).
+- **Дата:** 2026-06-19.
+- **Статус:** одобрен (brainstorming), готов к writing-plans.
+
+## Цель
+
+Дать новый Claude Code-скил `plugin/skills/ask/` для **grounded-вопросов по кодовой базе** (онбординг/Q&A),
+а не ревью PR. Поток: вопрос → семантико-лексический поиск → точечное раскрытие по графу → подтверждение
+исходника → ответ с цитатами `path:line`, **без выдуманных путей**.
+
+**Критерий приёмки (из задачи):** вопрос «где аутентификация» возвращает конкретные файлы/символы с
+обоснованием; ответы grounded (со ссылками), без галлюцинированных путей.
+
+## Контекст и развилка (зачем Path B)
+
+Существующие примитивы:
+- `search_codebase(repo, query, top_k, branch)` — **session-less** MCP-тул (`mcp_server.py:109`). Под капотом
+  `Retriever.search_base` (`retriever.py:60-98`) уже делает гибрид (RRF) + graph-expansion 1 hop + Voyage rerank.
+  Возвращает чанки с заголовками `path#fqn (path:start-end)`.
+- Графовые тулы `get_related_symbols` / `find_callers` / `get_definition` и `read_file` **привязаны к PR-сессии**
+  (`repo, pr` → `service._session(repo, pr)`, требует `prepare_review`). Для Q&A без PR через MCP недоступны.
+
+Почему не «просто grep» (нативный поиск Claude Code):
+- **Семантика** бьёт через разрыв словаря: «где аутентификация» найдёт `verify_token`/`check_credentials` даже
+  без слова «auth». Grep требует заранее знать нейминг — это и есть онбординг-выигрыш.
+- **Граф** даёт точность за счёт типов: точные callers/implements против ложных срабатываний/пропусков grep
+  (`self.method()`, алиасы импорта, одноимённые методы).
+- **Экономия токенов** на расплывчатых вопросах: reranked top-k чанков с кодом внутри → меньше последующих
+  чтений и тупиков. Для точной строки grep дешевле → скил **дополняет** grep, а не заменяет (fail-open на grep).
+
+**Решение: Path B** — добавить session-less варианты графовых тулов. Цена умеренная: графовые операции
+(`components.graph.expand/callers/find_symbol`) PR-overlay не требуют и **не тратят Voyage-токены** (чистый Neo4j);
+session-less вариант зеркаля́ет уже существующий паттерн `search_codebase` (который зовёт
+`components.retriever.search_base` напрямую, `service.py:326-351`). Переиспользуется будущими скилами PRI-119
+(PR walkthrough) и PRI-126 (радиус поражения) — строим один раз на три скила.
+
+**Вне объёма (follow-up):** режим «карта подсистемы» (N-hop обход от точки входа) — выносится в отдельную
+итерацию, логично слить с PRI-119/PRI-126, которым нужен тот же session-less обход. Session-less `read_file`
+**не добавляем** — harness `Read` читает исходник с диска (репо открыто как проект).
+
+## Секция 1 — Сервер: 3 session-less графовых MCP-тула
+
+### Сервисный слой (`reviewer/mcp/service.py`)
+
+Все методы session-less, fail-soft (`try/except` + `log.warning` + текстовая заглушка), с общим резолвом
+repo/branch.
+
+- **Рефактор:** вынести из `search_codebase` приватный хелпер
+  `_resolve_repo_branch(repo, branch) -> tuple[str, str] | str`:
+  - repo: `repo or default_repo`; `normalize_repo`; пустой/некорректный → строка-ошибка;
+  - branch: если задан и не в `REVIEW_BRANCHES` → строка-ошибка; иначе `branch or primary_branch()`;
+  - возвращает `(repo, resolved_branch)` либо текст ошибки (как сейчас отдаёт `search_codebase`).
+  - `search_codebase` переписать поверх хелпера (поведение не меняется — покрыто существующими тестами).
+- `related_symbols(repo, node_id, branch=None) -> str`
+  → `components.graph.expand(repo, [node_id], hops=2, branch=resolved)` → отсортированные id или `(нет связей)`.
+- `callers(repo, node_id, branch=None) -> str`
+  → `components.graph.callers(repo, [node_id], branch=resolved)` → или `(вызовов не найдено)`.
+- `definition(repo, symbol, branch=None) -> str`
+  → `graph.find_symbol(repo, symbol, branch=resolved)` → `store.fetch_nodes(repo, ids[:3], overlay_ref=None,
+  changed_paths=[], base_ref=base_ref(resolved))` → фолбэк `retriever.search_base(repo, symbol, top_k=3,
+  branch=resolved)`. Зеркало `code_tools.get_definition`, но без overlay.
+
+### MCP-слой (`reviewer/entrypoints/mcp_server.py`)
+
+Тонкие обёртки `@mcp.tool()` над сервисными методами. **Имена не должны совпадать** с session-bound тулами
+(`get_related_symbols`/`find_callers`/`get_definition` заняты — FastMCP требует уникальности). Имена:
+
+| Тул | Сигнатура | Назначение |
+|---|---|---|
+| `related_symbols` | `(repo, node_id, branch=None)` | соседи по графу (calls/implements/tests) |
+| `callers` | `(repo, node_id, branch=None)` | прямые вызывающие (impact) |
+| `definition` | `(repo, symbol, branch=None)` | определение символа (graph → index → semantic) |
+
+Докстринги по-английски, как у соседних тулов.
+
+### Тесты
+
+`tests/mcp/` (или существующий файл сервиса) — unit на 3 метода с фейковыми `graph`/`store`/`retriever`
+(по образцу `tests/tools/test_code_tools.py`):
+- happy-path делегирование в `components.graph.*` с правильными `(repo, branch)`;
+- резолв branch: валидная из `REVIEW_BRANCHES` / невалидная (ошибка-строка) / дефолт (primary);
+- fail-soft: исключение в графе → заглушка, не пробрасывается;
+- `definition` фолбэк на `retriever.search_base`, когда граф пуст.
+
+## Секция 2 — Скил `plugin/skills/ask/SKILL.md`
+
+**Язык:** тело SKILL.md — **английский** (экономия токенов при загрузке, как `solve-task`/`sync-codebase`),
+но скил **явно инструктирует агента отвечать пользователю по-русски**.
+
+**Frontmatter:**
+- `name: reviewer_ask`
+- `description` с триггерами EN+RU: «ask about the codebase», «explain how X works», «where is X»,
+  «как устроено…», «где у нас…», «объясни код». Требует построенный base-индекс + граф.
+
+**Inputs:** `$ARGUMENTS` — свободный вопрос по коду.
+
+**Pipeline:**
+1. **Resolve repo/branch** — как `solve-task`: `git remote get-url origin` → `owner/name`; текущая ветка
+   (`git branch --show-current`), если она в `REVIEW_BRANCHES`, иначе omit → первичная.
+2. **Search** — `search_codebase(repo, question, branch)` (уже 1-hop граф + rerank). Из заголовков чанков
+   `path#fqn (path:start-end)` извлечь node_id и строки.
+3. **Expand (по необходимости)** — для ключевых символов точечно `related_symbols` / `callers` / `definition`.
+   Не обходить всё подряд — только то, что нужно для ответа.
+4. **Confirm source** — harness `Read` по `path:line` с диска для проверки и точных цитат.
+5. **Answer (adaptive):**
+   - по умолчанию: прямой ответ 2-4 предложения + список «доказательств» `path:line` с однострочным «почему»;
+   - широкий вопрос («объясни подсистему X»): развернуть в разделы (Краткий ответ / Ключевые символы /
+     Поток / Связанные места).
+
+**Grounding-контракт (жёсткий, = критерий приёмки):** цитировать **только** пути, реально вернувшиеся из
+тулов и подтверждённые `Read`. Непроверенный путь в ответ не попадает; ничего не выдумывать.
+
+**Fail-open:** Postgres/Neo4j/индекс недоступны → деградация на harness `Grep`/`Glob`/`Read` по диску + явное
+предупреждение «семантика/граф недоступны, лексический поиск». Никогда не падать.
+
+**Notes:**
+- Предусловие — `reviewer index` построен. Точность графа зависит от бэкенда: SCIP → `IMPLEMENTS` + точные
+  `CALLS`; tree-sitter → `CALLS` по имени.
+- Граница с PRI-119: `ask` отвечает в терминал на вопрос по базе; walkthrough постит гид по PR. Раздельно.
+- «Карта подсистемы» (N-hop) — follow-up.
+
+## Секция 3 — Документация
+
+- `mcp_server.py` докстринг `create_server`: «15 тулов» → «18 тулов».
+- `CLAUDE.md` (таблица модулей, строка `reviewer/tools/`) и `README.md`: упомянуть 3 session-less графовых тула
+  рядом с `search_codebase`.
+- `plugin.json` не трогаем — скилы авто-дискаверятся из `plugin/skills/`.
+
+## Порядок реализации (для writing-plans)
+
+1. Рефактор `_resolve_repo_branch` + переписать `search_codebase` поверх него (зелёные существующие тесты).
+2. 3 сервисных метода + unit-тесты.
+3. 3 MCP-тула в `mcp_server.py` + обновить докстринг счётчика тулов.
+4. `plugin/skills/ask/SKILL.md`.
+5. Доки (`CLAUDE.md`, `README.md`).
+6. Ручная проверка критерия приёмки: «где аутентификация» → grounded-ответ с `path:line` (нужны поднятые
+   Postgres/Neo4j + построенный индекс).
+
+## Открытые вопросы
+
+Нет (имена тулов `related_symbols`/`callers`/`definition` подтверждены; объём B зафиксирован).

--- a/plugin/skills/ask/SKILL.md
+++ b/plugin/skills/ask/SKILL.md
@@ -1,0 +1,77 @@
+---
+name: reviewer_ask
+description: Answer grounded questions about the codebase (onboarding / Q&A) using the reviewer RAG + code graph. Use when the user asks how the code works, where something lives, or to explain a subsystem ("where is auth", "how does X work", "explain the indexing flow", "как устроено…", "где у нас…", "объясни код"). Requires a built base index + graph (reviewer MCP server). Not for reviewing PRs.
+---
+
+# Ask (codebase Q&A)
+
+Answer a free-text question about the codebase with a **grounded** response: every claim is
+backed by a real `path:line` citation, never an invented path. Built on the reviewer MCP server
+(hybrid RAG + code graph). This skill reads and explains; it does NOT modify code or review PRs.
+
+**Always answer the user in Russian** (the project language), regardless of this file's language.
+Tool calls, code identifiers, and `path:line` citations stay verbatim.
+
+## Inputs
+
+`$ARGUMENTS` — a free-text question about the code (e.g. "where is authentication",
+"how does index freshness work", "explain the retrieval pipeline").
+
+## Tools
+
+Session-less reviewer MCP tools (no PR / `prepare_review` needed):
+- `search_codebase(repo, query, top_k?, branch?)` — hybrid semantic+lexical search; already
+  includes 1-hop graph expansion + rerank. Returns chunks headed by `path#fqn (path:start-end)`.
+- `related_symbols(repo, node_id, branch?)` — graph neighbors (calls/implements/tests) of a
+  `node_id` ('path#fqn').
+- `callers(repo, node_id, branch?)` — direct callers of a `node_id` (impact).
+- `definition(repo, symbol, branch?)` — where a symbol is defined + its source.
+
+Plus the harness file tools (`Read`, `Grep`, `Glob`) to read source from the local clone on disk.
+
+## Pipeline
+
+1. **Resolve repo/branch.**
+   - `repo`: `git remote get-url origin` → strip a trailing `.git`, take the last two path
+     segments (`owner/name`). Pass `""` to let the server use `DEFAULT_REPO` if origin is missing.
+   - `branch`: `git branch --show-current`. Pass it only if it is in `REVIEW_BRANCHES`; if the
+     user named a branch, use that; otherwise omit it (the server uses the primary branch).
+
+2. **Search.** Call `search_codebase(repo, "<question>", branch=…)`. Parse the
+   `path#fqn (path:start-end)` headers to get candidate symbols (`node_id`) and line ranges.
+   If the result is `(ничего не найдено)`, go to Fallback.
+
+3. **Expand (only as needed).** For the symbols most relevant to the question, call
+   `related_symbols` / `callers` / `definition` to follow the graph. Do NOT expand everything —
+   only what the answer requires. Stop once you can answer.
+
+4. **Confirm source.** Before citing any `path:line`, open it with `Read` (from disk) and verify
+   the cited code actually exists and says what you claim. Drop any citation you cannot confirm.
+
+5. **Answer (adaptive), in Russian.**
+   - Default (focused question): a direct answer in 2–4 sentences, then an **Evidence** list —
+     each item `path:line` + a one-line "why this is relevant".
+   - Broad question ("explain subsystem X"): expand into sections — Краткий ответ / Ключевые
+     символы / Поток / Связанные места — each claim still carrying a confirmed `path:line`.
+
+## Grounding contract (hard rule)
+
+Cite ONLY paths that were returned by a tool AND confirmed by `Read`. Never invent or guess a
+path or line number. If you cannot ground a statement, say so explicitly instead of fabricating a
+citation. This is the skill's acceptance criterion.
+
+## Fallback (fail-open)
+
+If the reviewer MCP server is unreachable or returns `(ничего не найдено)` / `(граф недоступен)`
+(Postgres/Neo4j/index down), degrade gracefully:
+- Use the harness `Grep`/`Glob`/`Read` over the local clone to locate and confirm code.
+- Tell the user (in Russian) that semantic/graph search was unavailable and the answer comes from
+  a lexical search, so it may be less complete.
+Never abort — always return the best grounded answer you can.
+
+## Notes
+
+- Precondition: the base index + graph must be built (`reviewer index`). Graph precision depends on
+  the backend: SCIP → `IMPLEMENTS` + accurate `CALLS`; tree-sitter → `CALLS` by name only.
+- Read-only: this skill never edits code and never posts to GitHub. Posting a human-facing review
+  guide to a PR is a separate skill (PRI-119).

--- a/plugin/skills/solve-task/SKILL.md
+++ b/plugin/skills/solve-task/SKILL.md
@@ -39,6 +39,14 @@ brief to `superpowers:brainstorming` (which leads to writing-plans → subagent-
      is connected, you may read the most relevant similar tasks from the board for fuller detail.
    - `search_codebase("<task description>")` → relevant existing code (files/symbols to touch or
      mimic).
+   - **Deepen via the code graph (optional — when `search_codebase` surfaced concrete symbols).**
+     `search_codebase` chunks are headed by `path#fqn (path:start-end)`; feed those `node_id`s to the
+     session-less graph tools to sharpen the brief:
+     - `callers(repo, node_id, branch?)` → who depends on the code you would change (blast radius — what not to break);
+     - `related_symbols(repo, node_id, branch?)` → neighbors (calls / implementations / tests) to touch or mimic;
+     - `definition(repo, symbol, branch?)` → exact source of a symbol to follow as a pattern.
+     Expand only the few symbols central to the task. Pass the same `branch` you pass to `search_codebase`.
+     Fail-open: a `(граф недоступен)` / `(нет связей)` / `(вызовов не найдено)` note is non-fatal — continue.
 
    **Branch selection for `search_codebase`.** Before calling `search_codebase`, determine the
    current git branch of the project: `git branch --show-current`. If it is in `REVIEW_BRANCHES`
@@ -46,13 +54,14 @@ brief to `superpowers:brainstorming` (which leads to writing-plans → subagent-
    branch's index. If the user explicitly stated which branch to work from, use that branch instead.
    Otherwise, omit `branch` entirely and the server will use the primary branch (the first entry in
    `REVIEW_BRANCHES`).
+   The same branch applies to `callers` / `related_symbols` / `definition` — pass it (or omit it) identically.
 
 4. **Distill the solution brief.** Write a structured markdown brief. Apply a strict relevance
    filter: include an item ONLY if it directly informs the implementation; drop the rest and note how
    many were dropped. Sections:
    - **Task** — key/title/requirements/criteria (or the user's formulation in board-less mode).
    - **Related work** — only the relevant linked/similar tasks and their PRs (what to reuse / follow).
-   - **Relevant code** — files/symbols to touch or mimic, each with a one-line "why".
+   - **Relevant code** — files/symbols to touch or mimic, each with a one-line "why"; where the graph surfaced them, note key callers / impacted symbols (blast radius).
    - **Constraints / open questions** — limits, unknowns, and context gaps (e.g. "board unavailable",
      "task corpus empty").
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "rag-reviewer"
-version = "0.2.0"
+version = "0.2.1"
 requires-python = ">=3.11,<3.14"
 dependencies = [
     "pydantic-settings>=2.3",

--- a/reviewer/entrypoints/mcp_server.py
+++ b/reviewer/entrypoints/mcp_server.py
@@ -15,7 +15,7 @@ log = logging.getLogger(__name__)
 
 
 def create_server(service: MCPReviewService) -> FastMCP:
-    """Создать и вернуть сконфигурированный FastMCP-сервер с 15 тулами.
+    """Создать и вернуть сконфигурированный FastMCP-сервер с 18 тулами.
 
     Все тулы — обычные def (sync), а не async: сервис не потокобезопасен
     и рассчитан на последовательное исполнение sync-тулов FastMCP в event loop.
@@ -114,6 +114,25 @@ def create_server(service: MCPReviewService) -> FastMCP:
         (REVIEW_BRANCHES); defaults to the primary branch. Use it (e.g. from /solve-task)
         to find relevant existing code by a free-text formulation."""
         return service.search_codebase(repo, query, top_k, branch)
+
+    @mcp.tool()
+    def related_symbols(repo: str, node_id: str, branch: str | None = None) -> str:
+        """Code-graph neighbors (calls/implementations/tests) of a symbol node_id
+        'path#fqn' over the base index (no PR session).
+        branch defaults to the primary tracked branch."""
+        return service.related_symbols(repo, node_id, branch)
+
+    @mcp.tool()
+    def callers(repo: str, node_id: str, branch: str | None = None) -> str:
+        """Direct callers of a symbol node_id 'path#fqn' over the base index
+        (no PR session). branch defaults to the primary tracked branch."""
+        return service.callers(repo, node_id, branch)
+
+    @mcp.tool()
+    def definition(repo: str, symbol: str, branch: str | None = None) -> str:
+        """Find a symbol definition over the base index (graph -> index -> semantic
+        fallback), no PR session. branch defaults to the primary tracked branch."""
+        return service.definition(repo, symbol, branch)
 
     @mcp.tool()
     def publish_review(

--- a/reviewer/mcp/service.py
+++ b/reviewer/mcp/service.py
@@ -12,6 +12,7 @@ from reviewer.agent.assemble import AssembledReview, assemble_review, ground_lin
 from reviewer.agent.dedup import dedup_findings
 from reviewer.app import Components
 from reviewer.config.settings import Settings
+from reviewer.index.refs import base_ref
 from reviewer.mcp.session_serde import from_payload, to_payload
 from reviewer.mcp.session_store import SessionStore
 from reviewer.services.review_service import (
@@ -361,6 +362,67 @@ class MCPReviewService:
             log.warning("search_codebase: сбой поиска", exc_info=True)
             return "(ничего не найдено)"
         return pack.as_context() or "(ничего не найдено)"
+
+    def related_symbols(self, repo: str, node_id: str,
+                        branch: str | None = None) -> str:
+        """Соседи символа по графу (calls/implements/tests) без PR-сессии."""
+        rb = self._resolve_repo_branch(repo, branch)
+        if isinstance(rb, str):
+            return rb
+        repo, resolved = rb
+        if self.components.graph is None:
+            return "(граф недоступен)"
+        try:
+            related = self.components.graph.expand(
+                repo, [node_id], hops=2, branch=resolved)
+        except Exception:
+            log.warning("related_symbols: сбой графа", exc_info=True)
+            return "(нет связей)"
+        return "\n".join(sorted(related)) or "(нет связей)"
+
+    def callers(self, repo: str, node_id: str,
+                branch: str | None = None) -> str:
+        """Кто вызывает символ node_id ('path#fqn') — входящие CALLS, без PR-сессии."""
+        rb = self._resolve_repo_branch(repo, branch)
+        if isinstance(rb, str):
+            return rb
+        repo, resolved = rb
+        if self.components.graph is None:
+            return "(граф недоступен)"
+        try:
+            found = self.components.graph.callers(
+                repo, [node_id], branch=resolved)
+        except Exception:
+            log.warning("callers: сбой графа", exc_info=True)
+            return "(вызовов не найдено)"
+        return "\n".join(sorted(found)) or "(вызовов не найдено)"
+
+    def definition(self, repo: str, symbol: str,
+                   branch: str | None = None) -> str:
+        """Где определён символ + исходник (граф → индекс → семантический фолбэк),
+        без PR-сессии."""
+        rb = self._resolve_repo_branch(repo, branch)
+        if isinstance(rb, str):
+            return rb
+        repo, resolved = rb
+        try:
+            ids: list[str] = []
+            if self.components.graph is not None:
+                ids = self.components.graph.find_symbol(
+                    repo, symbol, branch=resolved)
+            if ids:
+                nodes = self.components.store.fetch_nodes(
+                    repo, ids[:3], None, [], base_ref=base_ref(resolved))
+                if nodes:
+                    return "\n\n".join(
+                        f"// {n.node_id} ({n.path}:{n.start_line}-{n.end_line})\n{n.text}"
+                        for n in nodes)
+            pack = self.components.retriever.search_base(
+                repo, symbol, top_k=3, branch=resolved)
+            return pack.as_context() or "(определение не найдено)"
+        except Exception:
+            log.warning("definition: сбой", exc_info=True)
+            return "(определение не найдено)"
 
     def publish_review(
         self,

--- a/reviewer/mcp/service.py
+++ b/reviewer/mcp/service.py
@@ -342,7 +342,7 @@ class MCPReviewService:
         if branch and branch not in self.settings.review_branches_list():
             return (f"(ветка {branch!r} не в REVIEW_BRANCHES "
                     f"({self.settings.review_branches_list()}))")
-        return repo, branch or self.settings.primary_branch()
+        return (repo, branch or self.settings.primary_branch())
 
     def search_codebase(self, repo: str, query: str, top_k: int = 10,
                         branch: str | None = None) -> str:

--- a/reviewer/mcp/service.py
+++ b/reviewer/mcp/service.py
@@ -323,12 +323,12 @@ class MCPReviewService:
             active_keys, keep_with_prs=keep_with_prs
         )
 
-    def search_codebase(self, repo: str, query: str, top_k: int = 10,
-                        branch: str | None = None) -> str:
-        """Гибрид-поиск по base-индексу репозитория (без PR-сессии) — для /solve-task.
+    def _resolve_repo_branch(self, repo: str, branch: str | None) -> tuple[str, str] | str:
+        """Резолв (repo, ветка) для session-less тулов.
 
-        branch — отслеживаемая ветка (allowlist REVIEW_BRANCHES); по умолчанию
-        первичная. Поиск идёт по индексу указанной ветки (base:<branch>).
+        Возвращает (normalized_repo, resolved_branch) при успехе либо строку-заметку
+        об ошибке (её тул отдаёт пользователю как есть). Ветка валидируется по
+        REVIEW_BRANCHES; пустая ветка → первичная.
         """
         from reviewer.services.repo_id import normalize_repo
         raw = repo or self.settings.default_repo
@@ -341,7 +341,19 @@ class MCPReviewService:
         if branch and branch not in self.settings.review_branches_list():
             return (f"(ветка {branch!r} не в REVIEW_BRANCHES "
                     f"({self.settings.review_branches_list()}))")
-        resolved = branch or self.settings.primary_branch()
+        return repo, branch or self.settings.primary_branch()
+
+    def search_codebase(self, repo: str, query: str, top_k: int = 10,
+                        branch: str | None = None) -> str:
+        """Гибрид-поиск по base-индексу репозитория (без PR-сессии) — для /solve-task.
+
+        branch — отслеживаемая ветка (allowlist REVIEW_BRANCHES); по умолчанию
+        первичная. Поиск идёт по индексу указанной ветки (base:<branch>).
+        """
+        rb = self._resolve_repo_branch(repo, branch)
+        if isinstance(rb, str):
+            return rb
+        repo, resolved = rb
         try:
             pack = self.components.retriever.search_base(
                 repo, query, top_k=top_k, branch=resolved)

--- a/tests/mcp/test_server.py
+++ b/tests/mcp/test_server.py
@@ -88,7 +88,7 @@ def _make_mcp_service(number: int = 7) -> MCPReviewService:
 # ---------------------------------------------------------------------------
 
 def test_server_registers_all_tools() -> None:
-    """create_server регистрирует ровно 15 ожидаемых MCP-тулов."""
+    """create_server регистрирует ровно 18 ожидаемых MCP-тулов."""
     from reviewer.entrypoints.mcp_server import create_server
 
     server = create_server(_make_mcp_service())
@@ -110,6 +110,9 @@ def test_server_registers_all_tools() -> None:
         "get_board_config",
         "publish_review",
         "search_codebase",
+        "related_symbols",
+        "callers",
+        "definition",
     }
 
 

--- a/tests/mcp/test_server_tools.py
+++ b/tests/mcp/test_server_tools.py
@@ -105,3 +105,48 @@ def test_purge_orphaned_tasks_tool_forwards_to_service():
         {"active_keys": ["ID-1", "ID-2"], "keep_with_prs": True},
     ))
     svc.purge_orphaned_tasks.assert_called_once_with(["ID-1", "ID-2"], True)
+
+
+def test_graph_base_tools_registered():
+    import asyncio
+
+    svc = _service()
+    svc.related_symbols.return_value = "x"
+    svc.callers.return_value = "x"
+    svc.definition.return_value = "x"
+    server = create_server(svc)
+    names = {t.name for t in asyncio.run(server.list_tools())}
+    assert {"related_symbols", "callers", "definition"} <= names
+
+
+def test_related_symbols_tool_forwards():
+    import asyncio
+
+    svc = _service()
+    svc.related_symbols.return_value = "neighbors"
+    server = create_server(svc)
+    asyncio.run(server.call_tool(
+        "related_symbols", {"repo": "owner/name", "node_id": "a.py#foo"}))
+    svc.related_symbols.assert_called_once_with("owner/name", "a.py#foo", None)
+
+
+def test_callers_tool_forwards():
+    import asyncio
+
+    svc = _service()
+    svc.callers.return_value = "callers"
+    server = create_server(svc)
+    asyncio.run(server.call_tool(
+        "callers", {"repo": "owner/name", "node_id": "a.py#foo", "branch": "main"}))
+    svc.callers.assert_called_once_with("owner/name", "a.py#foo", "main")
+
+
+def test_definition_tool_forwards():
+    import asyncio
+
+    svc = _service()
+    svc.definition.return_value = "def"
+    server = create_server(svc)
+    asyncio.run(server.call_tool(
+        "definition", {"repo": "owner/name", "symbol": "foo"}))
+    svc.definition.assert_called_once_with("owner/name", "foo", None)

--- a/tests/mcp/test_service.py
+++ b/tests/mcp/test_service.py
@@ -5,6 +5,7 @@
 """
 from __future__ import annotations
 
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -513,3 +514,76 @@ def test_search_codebase_rejects_untracked_branch() -> None:
     out = svc.search_codebase("a/b", "x", branch="release/v9")
     assert "REVIEW_BRANCHES" in out
     svc.components.retriever.search_base.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Тесты Task 2: session-less методы related_symbols/callers/definition
+# ---------------------------------------------------------------------------
+
+def test_related_symbols_delegates_to_graph() -> None:
+    """related_symbols зовёт graph.expand(repo, [node_id], hops=2, branch=primary)."""
+    svc = _make_mcp_service()
+    svc.components.graph.expand.return_value = {"a.py#bar", "a.py#baz"}
+    out = svc.related_symbols("a/b", "a.py#foo")
+    assert "a.py#bar" in out and "a.py#baz" in out
+    svc.components.graph.expand.assert_called_once_with(
+        "a/b", ["a.py#foo"], hops=2, branch=svc.settings.primary_branch())
+
+
+def test_related_symbols_empty_and_failsoft() -> None:
+    """Пусто → '(нет связей)'; исключение графа → тоже заглушка, не падаем."""
+    svc = _make_mcp_service()
+    svc.components.graph.expand.return_value = set()
+    assert svc.related_symbols("a/b", "a.py#foo") == "(нет связей)"
+    svc.components.graph.expand.side_effect = RuntimeError("neo4j down")
+    assert svc.related_symbols("a/b", "a.py#foo") == "(нет связей)"
+
+
+def test_related_symbols_graph_none() -> None:
+    """graph=None (Neo4j выключен) → '(граф недоступен)'."""
+    svc = _make_mcp_service()
+    svc.components.graph = None
+    assert svc.related_symbols("a/b", "a.py#foo") == "(граф недоступен)"
+
+
+def test_related_symbols_invalid_branch() -> None:
+    """Невалидная ветка → заметка из _resolve_repo_branch, граф не зовётся."""
+    svc = _make_mcp_service()
+    out = svc.related_symbols("a/b", "a.py#foo", branch="nope")
+    assert "REVIEW_BRANCHES" in out
+
+
+def test_callers_delegates_to_graph() -> None:
+    """callers зовёт graph.callers и форматирует множество."""
+    svc = _make_mcp_service()
+    svc.components.graph.callers.return_value = {"a.py#caller"}
+    out = svc.callers("a/b", "a.py#foo")
+    assert "a.py#caller" in out
+    svc.components.graph.callers.assert_called_once_with(
+        "a/b", ["a.py#foo"], branch=svc.settings.primary_branch())
+    svc.components.graph.callers.return_value = set()
+    assert svc.callers("a/b", "a.py#foo") == "(вызовов не найдено)"
+
+
+def test_definition_uses_graph_then_store() -> None:
+    """definition: find_symbol → fetch_nodes → отрендеренный исходник."""
+    svc = _make_mcp_service()
+    svc.components.graph.find_symbol.return_value = ["a.py#foo"]
+    node = SimpleNamespace(node_id="a.py#foo", path="a.py",
+                           start_line=10, end_line=12, text="def foo(): ...")
+    svc.components.store.fetch_nodes.return_value = [node]
+    out = svc.definition("a/b", "foo")
+    assert "a.py#foo" in out and "def foo()" in out and "a.py:10-12" in out
+    svc.components.graph.find_symbol.assert_called_once_with(
+        "a/b", "foo", branch=svc.settings.primary_branch())
+
+
+def test_definition_falls_back_to_search_base() -> None:
+    """Граф пуст → фолбэк на retriever.search_base."""
+    svc = _make_mcp_service()
+    svc.components.graph.find_symbol.return_value = []
+    svc.components.retriever.search_base.return_value.as_context.return_value = "semantic hit"
+    out = svc.definition("a/b", "foo")
+    assert "semantic hit" in out
+    svc.components.retriever.search_base.assert_called_once_with(
+        "a/b", "foo", top_k=3, branch=svc.settings.primary_branch())

--- a/tests/mcp/test_service.py
+++ b/tests/mcp/test_service.py
@@ -505,3 +505,11 @@ def test_search_codebase_falls_back_to_default_repo() -> None:
     svc.search_codebase("", "find foo")
     call_args = svc.components.retriever.search_base.call_args
     assert call_args.args[0] == "d/efault"
+
+
+def test_search_codebase_rejects_untracked_branch() -> None:
+    """Ветка не из REVIEW_BRANCHES → понятная заметка, retriever не зовётся."""
+    svc = _make_mcp_service()
+    out = svc.search_codebase("a/b", "x", branch="release/v9")
+    assert "REVIEW_BRANCHES" in out
+    svc.components.retriever.search_base.assert_not_called()

--- a/tests/mcp/test_service.py
+++ b/tests/mcp/test_service.py
@@ -576,6 +576,8 @@ def test_definition_uses_graph_then_store() -> None:
     assert "a.py#foo" in out and "def foo()" in out and "a.py:10-12" in out
     svc.components.graph.find_symbol.assert_called_once_with(
         "a/b", "foo", branch=svc.settings.primary_branch())
+    svc.components.store.fetch_nodes.assert_called_once_with(
+        "a/b", ["a.py#foo"], None, [], base_ref="base:main")
 
 
 def test_definition_falls_back_to_search_base() -> None:


### PR DESCRIPTION
## PRI-118 — Q&A / онбординг по кодовой базе

Новый скил `reviewer_ask` для **grounded-вопросов по коду** (онбординг/Q&A) + три session-less графовых MCP-тула, на которых он стоит. По запросу — заодно обогащён `solve-task` теми же тулами.

### Что сделано
- **Сервер (session-less граф).** `MCPReviewService.related_symbols` / `callers` / `definition` (`reviewer/mcp/service.py`) — обход графа **без PR-сессии** (зеркалят `search_codebase`, читают base-индекс/граф: `overlay_ref=None`, `base_ref=base_ref(branch)`), fail-soft, guard на `graph is None`. Вынесен общий хелпер `_resolve_repo_branch`. Зарегистрированы как MCP-тулы `related_symbols`/`callers`/`definition` (`mcp_server.py`, имена не конфликтуют с session-bound `get_related_symbols`/`find_callers`/`get_definition`; всего тулов 15→18).
- **Скил `reviewer_ask`** (`plugin/skills/ask/SKILL.md`): вопрос → `search_codebase` → точечный граф → harness `Read` → адаптивный ответ. Жёсткий контракт grounding (только подтверждённые `path:line`, без выдуманных путей — критерий приёмки), fail-open на лексический поиск. Тело скила английское (токены), ответы пользователю — по-русски.
- **`solve-task`** (`plugin/skills/solve-task/SKILL.md`): сбор контекста дополнен графовыми тулами (радиус поражения / образцы кода).
- **Документация:** `CLAUDE.md`, `README.md`.
- **Дизайн/план:** `docs/superpowers/specs|plans/2026-06-19-ask-skill*`.

### Тестирование
- Ядро: **420 passed** (`pytest -q --ignore=tests/web`); добавлены 11 unit-тестов (7 сервисных + 4 серверных) + ассерт call-args `fetch_nodes` (фиксирует обход overlay). ruff чист на изменённых файлах.
- Тулы проверены **вживую** против реального Neo4j/индекса (`reviewer check` зелёный, scip-python → точный граф): `related_symbols`/`callers` возвращают реальные узлы, branch-guard срабатывает.
- ⚠️ 2 предсуществующих падения (`task_board` из `.env` reviewer-mcp) — вне диффа этой ветки; `tests/web` требует extra `[web]` (нет `fastapi`).

### Заметки
- Предусловие скила: построенный base-индекс + граф (`reviewer index`). Точность графа: SCIP → `IMPLEMENTS`+точные `CALLS`; tree-sitter → `CALLS` по имени.
- Вне объёма (follow-up): режим «карта подсистемы» (N-hop), session-less `read_file` — сольются с PRI-119/PRI-126.
