### PR TITLE
docs(readme): полное обновление README (EN/RU) и плагина

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,25 @@ An agent that automatically reviews pull/merge requests using **RAG + a code gra
 
 ---
 
+## Table of contents
+
+- [What it is](#what-it-is)
+- [How it works / Architecture](#how-it-works--architecture)
+- [One-click install prompt](#one-click-install-prompt)
+- [Installation](#installation)
+- [Configuration reference](#configuration-reference)
+- [CLI reference](#cli-reference)
+- [Skills reference](#skills-reference)
+- [MCP tools reference](#mcp-tools-reference)
+- [Plugin usage](#plugin-usage)
+- [Per-repo policy & task board](#per-repo-policy--task-board)
+- [Observability web admin](#observability-web-admin)
+- [Known limitations & caveats](#known-limitations--caveats)
+- [Tests](#tests)
+- [Project layout](#project-layout)
+
+---
+
 ## What it is
 
 Plain linters catch syntax and style but miss **meaning and relationships**: a broken
@@ -24,7 +43,9 @@ A single PR review runs as three stages:
    policy and per-file review units are assembled.
 2. **analyze** — the Claude Code skill fans out one subagent per file. Each reasons over the diff
    in a tool loop, pulling in whatever code it needs: `search_code`, `get_related_symbols`,
-   `read_file`, `get_definition`, `find_callers`, `get_changed_file_diff`.
+   `read_file`, `get_definition`, `find_callers`, `get_changed_file_diff`. In parallel,
+   dimension subagents run a **performance** and **maintainability** pass, plus a **requirements**
+   pass when a task board is wired up, and a final **verify** pass strips hallucinations.
 3. **publish** — a deterministic tail: policy gate (category/severity/confidence/paths) → line
    grounding by exact code quote (anti-hallucination) → dedup → assemble (inline vs summary,
    suggestion invariants, fingerprint idempotency, comment cap) → post to GitHub → history record
@@ -97,7 +118,7 @@ the index keeps a persistent base and layers PR changes on top:
                 │        └─────────────────── publish_review (gate/grounding/dedup/assemble) ◀─────┘
                 └─────────────────────────────────────────────────────────────────────────────────┘
 
-  Stores (Docker):  Postgres/ParadeDB (:5433)  ·  Neo4j (:7687)
+  Stores (Docker):  Postgres/ParadeDB (:5433)  ·  Neo4j (:7687)  ·  web admin (:8000)
   External API:     Voyage (embeddings voyage-code-3 + reranker rerank-2.5)
 ```
 
@@ -138,7 +159,8 @@ The MCP server is published on PyPI as [`rag-reviewer`](https://pypi.org/project
 and runs via `uvx` — **no clone of this repo required**.
 
 Requirements: Docker, [`uv`](https://docs.astral.sh/uv/getting-started/installation/) (includes `uvx`),
-a Voyage API key, a GitHub token.
+a Voyage API key, a GitHub token. Python 3.11–3.13 (only needed for a `pip`/editable install; `uvx`
+manages its own).
 
 ### Quick setup (recommended, all platforms)
 
@@ -160,7 +182,7 @@ reviewer init
 
 # 3) Register the MCP server (and skills) in your editor/CLI
 reviewer install --all        # auto-detect installed clients + install skills
-#    or a specific one: reviewer install cursor|vscode|claude-code|windsurf|gemini|antigravity|mimo|opencode|kimi|trae|codex
+#    or a specific one: reviewer install cursor|vscode|claude-code|claude-desktop|windsurf|gemini|antigravity|mimo|opencode|kimi|trae|codex
 #    skills go to clients that support them (Gemini/Mimo/Kimi); add --no-skills to skip
 
 # 4) Verify
@@ -197,13 +219,8 @@ uv tool upgrade rag-reviewer
 - **GitHub** (`GITHUB_TOKEN`): a PAT with *Pull requests: Read and write* + *Contents: Read*
   (fine-grained) or the `repo` scope (classic). Quick option: `gh auth token`.
 
-All other settings have defaults (documented in `.env.example`). `DEFAULT_REPO` (optional) sets
-the default `owner/name` for single-repo deployments. `REVIEW_BRANCHES` (optional, CSV, default
-`main`) lists the branches to track — each gets its own isolated base index; PRs targeting a
-branch outside this list are silently skipped by `prepare_review`. `TASK_BOARD_TYPE` /
-`TASK_BOARD_MCP` / `TASK_BOARD_KEY_PATTERN` / `TASK_BOARD_URL_TEMPLATE` (optional) configure the task
-board **once for the whole deployment**, so it need not be repeated in every repo's `.review.yml`
-(see *Per-repo policy* below).
+All other settings have defaults (documented in `.env.example` and in
+[Configuration reference](#configuration-reference) below).
 
 ### Manual setup (alternative)
 
@@ -293,7 +310,7 @@ args = ["-lc", "uvx --from rag-reviewer@latest reviewer-mcp"]
 
 After adding, restart the tool — `reviewer` will appear alongside other MCP servers.
 
-#### Claude Code
+### Claude Code (plugin marketplace)
 
 Two commands, from any project:
 
@@ -304,20 +321,18 @@ Two commands, from any project:
 
 You get:
 
-- **Skills:** `/rag-reviewer:reviewer_review-pr`, `/rag-reviewer:reviewer_solve-task`, `/rag-reviewer:reviewer_sync-codebase`, `/rag-reviewer:reviewer_sync-tasks`
-  (plus `/rag-reviewer:reviewer_maintainability-review`, `/rag-reviewer:reviewer_performance-review`, and `/rag-reviewer:reviewer_ask`).
-- **MCP server** `reviewer` exposing: `prepare_review`, `publish_review`, `search_code`,
-  `get_related_symbols`, `read_file`, `get_definition`, `find_callers`, `get_changed_file_diff`,
-  `index_task`, `search_tasks`, `get_task_context`, `search_codebase`.
-  Alongside `search_codebase`, session-less graph tools `related_symbols`/`callers`/`definition` (graph traversal without a PR session) are available — used by the `/rag-reviewer:reviewer_ask` skill for grounded codebase Q&A.
+- **Skills:** `/rag-reviewer:reviewer_review-pr`, `/rag-reviewer:reviewer_solve-task`,
+  `/rag-reviewer:reviewer_sync-codebase`, `/rag-reviewer:reviewer_sync-tasks`,
+  `/rag-reviewer:reviewer_performance-review`, `/rag-reviewer:reviewer_maintainability-review`,
+  `/rag-reviewer:reviewer_ask` (see [Skills reference](#skills-reference)).
+- **MCP server** `reviewer` exposing the 20 tools in [MCP tools reference](#mcp-tools-reference).
 
 > Run `/plugin` to confirm `rag-reviewer` is installed and enabled.
 
-### 3. Install skills globally (optional)
+### Install skills globally (optional)
 
-Skills (`reviewer_review-pr`, `reviewer_solve-task`, `reviewer_sync-codebase`, `reviewer_sync-tasks`, `reviewer_performance-review`, `reviewer_maintainability-review`, `reviewer_ask`)
-let you invoke the full review workflow with a single command. Without them you can still call MCP
-tools directly, but the skills wrap them into a guided flow.
+The 7 skills wrap the MCP tools into guided flows. Without them you can still call MCP tools
+directly, but the skills are the intended entry point.
 
 **`reviewer install` already installs them** for clients that support file-based skills (Gemini,
 Mimo, Kimi). To (re)install just the skills — or pick a specific client — use:
@@ -347,81 +362,311 @@ rm /tmp/rag-reviewer.tgz
 | Claude Code | bundled in the plugin (step above) |
 | Cursor | project-level via `.cursor-plugin/plugin.json` |
 
+That's it. Build the base index (recommended — see [CLI reference](#cli-reference)) and review a PR
+(see [Plugin usage](#plugin-usage)).
+
 ---
 
-That's it. Build the base index (recommended — see [CLI](#cli)) and review a PR (see
-[Plugin usage](#plugin-usage)).
+## Configuration reference
 
-## CLI
+Everything is configured through environment variables (`.env`, see `.env.example` with comments).
+The **only required external key is `VOYAGE_API_KEY`**; `GITHUB_TOKEN` is required for PR review.
+All other settings have working defaults that match the bundled `docker-compose.yml`. The `.env`
+is resolved from `$REVIEWER_ENV_FILE` → `~/.config/rag-reviewer/.env` → `./.env` (real env vars
+always win).
 
-All CLI commands are available via `uvx --from rag-reviewer <command>`, or after
-`pip install rag-reviewer` / `pip install -e ".[dev]"` (for contributors) simply as `reviewer`.
+### Voyage — embeddings + reranker (required)
+
+| Variable | Default | Purpose |
+|---|---|---|
+| `VOYAGE_API_KEY` | `""` | **Required.** Voyage key for embeddings + reranking. |
+| `EMBEDDING_MODEL` | `voyage-code-3` | Embedding model. |
+| `EMBEDDING_DIM` | `1024` | Embedding dimension; **must match** the `vector(N)` column in Postgres — changing it requires a reindex. |
+| `EMBEDDING_BATCH_SIZE` | `256` | Texts per embedding request (≤1000 and ≤120K tokens). |
+| `RERANK_MODEL` | `rerank-2.5` | Voyage reranker model. |
+
+### GitHub (required for PR review)
+
+| Variable | Default | Purpose |
+|---|---|---|
+| `GITHUB_TOKEN` | `""` | PAT — *Pull requests: Read and write* + *Contents: Read*. |
+| `GITHUB_RETRY_ATTEMPTS` | `3` | Retries on GitHub API network errors. |
+| `GITHUB_RETRY_BACKOFF_BASE` | `1.0` | Exponential backoff base (seconds). |
+
+### Stores (Postgres/ParadeDB + Neo4j)
+
+| Variable | Default | Purpose |
+|---|---|---|
+| `PG_DSN` | `postgresql://reviewer:reviewer@localhost:5433/reviewer` | ParadeDB (pgvector + pg_search) on host port **5433**. |
+| `PG_POOL_MIN_SIZE` | `1` | Min Postgres pool connections. |
+| `PG_POOL_MAX_SIZE` | `4` | Max Postgres pool connections. |
+| `NEO4J_URI` | `neo4j://localhost:7687` | Neo4j bolt URI. |
+| `NEO4J_USER` | `neo4j` | Neo4j user. |
+| `NEO4J_PASSWORD` | `reviewerpass` | Neo4j password (one-off dev default). |
+| `GRAPH_BACKEND` | `auto` | Code-graph engine: `auto` (SCIP if `scip-python` in PATH, else tree-sitter), `scip`, `treesitter`. |
+
+### Multi-repo / multi-branch (optional)
+
+| Variable | Default | Purpose |
+|---|---|---|
+| `DEFAULT_REPO` | `""` | Default `owner/name` for session-less tools and `reviewer index` without `--repo`; empty = multi-repo (repo must be passed explicitly). |
+| `REVIEW_BRANCHES` | `main` | CSV of tracked branches; the first is **primary** (default for `reviewer index --ref` and CLI search). PRs targeting a branch outside the list are skipped. |
+
+### Review policy (env defaults; per-repo `.review.yml` overrides)
+
+| Variable | Default | Purpose |
+|---|---|---|
+| `REVIEW_SEVERITY_THRESHOLD` | `medium` | Minimum severity to keep: `low`/`medium`/`high`/`critical`. |
+| `REVIEW_MIN_CONFIDENCE` | `0.5` | Drop findings with confidence below this (0..1). |
+| `REVIEW_MAX_COMMENTS` | `25` | Cap on inline comments per review. |
+| `REVIEW_MAX_FILES` | `50` | Cap on `.py` files reviewed; the rest go to the summary as skipped. |
+| `REVIEW_CATEGORIES` | `""` | CSV whitelist of categories (`correctness`, `security`, `performance`, `style`, `requirements`); empty = all. |
+| `REVIEW_SUGGESTIONS` | `apply` | `apply` = applyable GitHub `suggestion` blocks; `text` = text-only advice. |
+| `REVIEW_OUTPUT_LANGUAGE` | `ru` | Language of the published findings' text. |
+| `REVIEW_SKIP_DRAFTS` | `true` | Don't review draft PRs. |
+| `MAX_TOOL_RESULT_CHARS` | `8000` | Max length of a tool result fed into the prompt. |
+
+### Observability & sessions (optional)
+
+| Variable | Default | Purpose |
+|---|---|---|
+| `REVIEW_HISTORY` | `true` | Record run history in Postgres (`review_runs`/`review_findings`), fail-soft. |
+| `REVIEW_SESSION_PERSIST` | `true` | Persist the PR session in Postgres for crash recovery. |
+| `REVIEW_SESSION_TTL_HOURS` | `24` | TTL (hours) of a persisted session. |
+| `WEB_ADMIN_USER` | `""` | Basic-auth user for `reviewer serve` / the `web` service; empty = no auth. |
+| `WEB_ADMIN_PASSWORD` | `""` | Basic-auth password; empty = no auth. |
+
+### Task board (optional) — deploy-wide default
+
+A board connection is the same for every repo of one team, so it is configured **once** in the
+reviewer-mcp env rather than duplicated in each repo's `.review.yml`. See
+[Per-repo policy & task board](#per-repo-policy--task-board).
+
+| Variable | Default | Purpose |
+|---|---|---|
+| `TASK_BOARD_TYPE` | `""` | Board type: `yougile`, `jira`, … (selects the skill playbook). |
+| `TASK_BOARD_MCP` | `""` | Name of the connected board MCP server (LLM-side tools `mcp__<mcp>__*`). |
+| `TASK_BOARD_KEY_PATTERN` | `""` | Task-key regex, e.g. `[A-Z]+-\d+`. |
+| `TASK_BOARD_URL_TEMPLATE` | `""` | Task-link template, e.g. `https://ru.yougile.com/team/<id>/#{code}`. |
+| `TASK_BOARD_API_KEY` | `""` | **REST API key** for server-side bulk sync (`sync_board`). Server-internal — never returned to clients. |
+| `TASK_BOARD_API_BASE` | `""` | REST API base URL; empty → default per type (`yougile`: `https://yougile.com/api-v2`). |
+
+> **Getting `TASK_BOARD_API_KEY` (Yougile).** UI: press `Ctrl + ~` (or ⚙ next to the company name →
+> "Настроить") → **API** → create/copy the key. REST: get `companyId` (`Ctrl + Alt + Q`, or
+> `POST /api-v2/auth/companies {login,password}`), then `POST /api-v2/auth/keys {login,password,companyId}`.
+> The key belongs **only** in the reviewer-mcp env (`~/.config/rag-reviewer/.env`), not in a chat or a client config.
+
+---
+
+## CLI reference
+
+All commands run via `uvx --from rag-reviewer <command>`, or after `uv tool install rag-reviewer` /
+`pip install -e ".[dev]"` simply as `reviewer`. Two entry points are installed:
+`reviewer` (the CLI below) and `reviewer-mcp` (the MCP server, started by your editor/plugin).
+
+| Command | Arguments | Options | What it does |
+|---|---|---|---|
+| `check` | — | — | Verify environment readiness (keys, Postgres, Neo4j, GitHub). Prints ✓/✗ per item; exits 1 on any problem. Spends no Voyage quota. |
+| `init` | — | `--path FILE` (default `~/.config/rag-reviewer/.env`), `--yes` (accept defaults, CI mode) | Interactive wizard that writes the `.env` (Voyage/GitHub + optional groups). |
+| `install` | `[client]` | `--all`, `--list`, `--path FILE`, `--pin VERSION`, `--no-latest`, `--no-skills`, `--dry-run` | Register the MCP server (and skills) in AI clients (cross-platform). |
+| `install-skills` | `[client]` | `--all`, `--list`, `--path FILE` | Install only the skills into a client's global skills directory. |
+| `update` | — | — | Check PyPI for a newer `rag-reviewer` and report how to upgrade. |
+| `index` | `<repo>` (path to local clone) | `--ref BRANCH` (git ref to read; default = primary branch), `--branch NAME` (storage key; default = `--ref`), `--repo OWNER/NAME` (default from git `origin`) | Build/update the base index of a branch (vectors + graph). Done once, then incremental. |
+| `search` | `<query>` | `--repo OWNER/NAME` (default `DEFAULT_REPO`), `--branch NAME` (default primary) | Diagnostic hybrid search over a branch's base index. |
+| `status` | `[path]` (default `.`) | `--repo OWNER/NAME` (default from git `origin`), `--branch NAME` (default: all `REVIEW_BRANCHES`) | Index health / freshness vs the clone's HEAD. Spends no Voyage quota. |
+| `migrate-branches` | — | — | One-time: rename legacy `ref="base"` → `base:<primary>` after upgrading to multi-branch. |
+| `serve` | — | `--host HOST` (default `127.0.0.1`), `--port PORT` (default `8000`) | Run the observability web admin on the host. |
+| `reviewer-mcp` | — | — | MCP server (stdio transport). Started automatically by the plugin / editor. |
+
+Examples:
 
 ```bash
-# Create ~/.config/rag-reviewer/.env from template (fill in VOYAGE_API_KEY + GITHUB_TOKEN).
-# Flags: --path FILE (custom location), --force (overwrite existing).
+# First-time setup
 uvx --from rag-reviewer reviewer init
-
-# Register the MCP server (and skills) in installed AI clients automatically (cross-platform).
-# --all auto-detects installed clients; or name one: cursor, claude-desktop, claude-code,
-# vscode, windsurf, gemini, antigravity, mimo, opencode, kimi, trae, codex.
-# Skills are installed for clients that support them (Gemini/Mimo/Kimi); --no-skills to skip.
-# Flags: --list, --dry-run, --path FILE, --pin VERSION, --no-latest, --no-skills.
 uvx --from rag-reviewer reviewer install --all
-uvx --from rag-reviewer reviewer install cursor
-
-# Install only the skills into a client's global skills directory (Gemini/Mimo/Kimi).
-# --all auto-detects; --list shows targets + directories; --path overrides the directory.
-uvx --from rag-reviewer reviewer install-skills --all
-
-# Check environment readiness: keys, Postgres, Neo4j, GitHub. Prints ✓/✗ per item;
-# exits 1 on any problem. Spends no Voyage quota.
 uvx --from rag-reviewer reviewer check
 
-# Update rag-reviewer to the latest version from PyPI.
-uvx --from rag-reviewer reviewer update
-
-# Build/update the base index of the target branch from a local clone (vectors + graph).
-# Done once, then updated incrementally; gives RAG and the graph whole-repo context.
-# --repo may be omitted if the local clone's origin remote is GitHub (owner/name derived automatically)
-# or DEFAULT_REPO is set in .env.
+# Build the base index (whole-repo context for RAG + graph)
 uvx --from rag-reviewer reviewer index /path/to/repo --ref main --repo owner/name
+uvx --from rag-reviewer reviewer index /path/to/repo --ref master --repo owner/name   # second tracked branch
 
-# Build the index for a second tracked branch (isolated index, same deployment).
-uvx --from rag-reviewer reviewer index /path/to/repo --ref master --repo owner/name
-
-# Diagnostic hybrid search over the base index (verify the index works).
-# --branch selects which tracked branch's index to search (default: primary branch).
-uvx --from rag-reviewer reviewer search "token verification"
+# Diagnostics (no Voyage spend except `search`)
 uvx --from rag-reviewer reviewer search "token verification" --branch master
-
-# Index health / freshness (does not spend Voyage quota).
-uvx --from rag-reviewer reviewer status
 uvx --from rag-reviewer reviewer status /path/to/repo --branch dev
 
-# One-time migration: rename legacy ref="base" → "base:<primary>" after upgrading to multi-branch.
-uvx --from rag-reviewer reviewer migrate-branches
-
-# Observability web admin (run history, findings) on the host.
-uvx --from rag-reviewer reviewer serve   # http://127.0.0.1:8000  (options: --host / --port)
-
-# MCP server (stdio transport) — started automatically by the plugin.
-uvx --from rag-reviewer@latest reviewer-mcp
+# Web admin
+uvx --from rag-reviewer reviewer serve --host 127.0.0.1 --port 8000
 ```
 
 Reviewing works even without a prior `index` — context is then limited to the diff and the overlay
 (RAG/graph are "thin"). For full whole-repo impact analysis, run `index` against the target branch.
 
+---
+
+## Skills reference
+
+Skills are the guided entry points for the workflow. With the plugin installed they are invoked as
+`/rag-reviewer:<name>` in Claude Code (the leading `/rag-reviewer:` is the plugin namespace; on
+other clients the skill name is the same). Arguments are passed as free text after the skill name
+(`$ARGUMENTS`).
+
+### `reviewer_review-pr` — full PR review
+
+Orchestrates the three-stage pipeline (`prepare_review` → subagents → `publish_review`).
+
+- **Arguments:** the PR as `owner/repo#N`, `owner/repo N`, or a GitHub PR URL. Add `--dry-run` to
+  assemble and return the full report **without** posting to GitHub.
+- **MCP tools used:** `prepare_review`, `search_code`, `get_related_symbols`, `read_file`,
+  `get_definition`, `find_callers`, `get_changed_file_diff`, `publish_review`; plus
+  `index_task` / `get_task_context` / `search_tasks` when a task board is wired up.
+- **Flow:** prepare (PR + policy + units + board config) → fan out one analysis subagent per file →
+  parallel **performance** / **maintainability** dimensions (+ **requirements** if a `TaskBrief`
+  exists) → **verify** pass (drops `is_real=false` findings) → publish (gate/grounding/dedup/assemble).
+  If `prepare_review` returns `status:"skipped"` (target branch not tracked) it stops; draft PRs are
+  skipped unless `REVIEW_SKIP_DRAFTS=false`.
+
+### `reviewer_solve-task` — gather context for a task, then hand off to dev
+
+Reads a task (if a key + board), pulls related/similar tasks and relevant code, distills a brief,
+and enters brainstorming. It disciplines context-gathering — it does **not** write the code.
+
+- **Arguments:** a task key (e.g. `PRI-4`, must match `key_pattern`) **or** a free-text description
+  (e.g. "add a logout endpoint"). Board-less mode falls back to description + code search.
+- **MCP tools used:** `get_board_config`, `index_task`, `get_task_context`, `search_tasks`,
+  `search_codebase`, `related_symbols`, `callers`, `definition`, `get_pr_diff`; plus the connected
+  board MCP (`mcp__<board>__*`) to read the task.
+- **Flow:** resolve board config → identify task (key vs free text) → best-effort, fail-open context
+  gathering (task graph, similar tasks, relevant code, lazy PR diffs of similar tasks) → distill a
+  structured brief (Task / Related work / Relevant code / Constraints) → hand off to
+  `superpowers:brainstorming` with the brief as seed.
+
+### `reviewer_sync-codebase` — build/update the base index
+
+Thin wrapper over `reviewer index` (vector store + code graph) from a local clone.
+
+- **Arguments (all optional):** `--path <path>` (default: CWD), `--ref <branch>` (default: `main`),
+  `--repo <owner/name>` (default: derived from `git remote get-url origin`),
+  `--backend <auto|scip|treesitter>` (default: `auto`, sets `GRAPH_BACKEND`).
+- **MCP tools used:** none directly — it shells out to `uvx --from rag-reviewer reviewer index`.
+- **Flow:** resolve inputs → check prerequisites (`uvx`, git repo, `reviewer check`, Docker up) →
+  run indexing → optional `reviewer search` to verify → report chunks/nodes/edges and which graph
+  backend was used.
+
+### `reviewer_sync-tasks` — warm the task graph & vector store
+
+A thin trigger over the server-side ETL tool `sync_board` — the reviewer enumerates the board over
+REST itself, so the LLM passes no task text (O(1) tokens regardless of board size).
+
+- **Arguments (all optional):** `--board <name>` (limit to one board/project), `--limit <N>` (smoke
+  run; **disables purge and watermark advance**), `--purge-orphaned` (remove tasks no longer on the
+  board; off by default), `--no-keep-with-prs` (with purge, also remove tasks that have PR history —
+  protected by default).
+- **MCP tools used:** `sync_board` (single call).
+- **Flow:** map args → one `sync_board(...)` call → print a counts summary (enumerated/changed/
+  embedded/unchanged/failed, purge, warnings). On `{"status":"error",...}` the board is not
+  configured server-side — set `TASK_BOARD_*` in `~/.config/rag-reviewer/.env` and reconnect.
+
+### `reviewer_performance-review` — performance-only review
+
+Reviews a diff only for performance/efficiency risks (N+1 queries, repeated work, bad asymptotics,
+missing batching/caching, blocking I/O, memory growth).
+
+- **Arguments (standalone):** scope — `staged`, `unstaged`, uncommitted, branch-vs-base, a commit,
+  a branch comparison, a file list, or a PR-like scope. If unclear, it asks. Inside
+  `reviewer_review-pr` it runs as a dimension over the provided unit diffs.
+- **MCP tools used (when run in the PR pipeline):** `search_code`, `read_file`, `find_callers`,
+  `get_related_symbols`, `get_definition`, `get_changed_file_diff`.
+- **Output:** JSON `{"findings":[{category:"performance", severity, file, line, side, code_quote,
+  message, suggestion, fix, confidence}]}`.
+
+### `reviewer_maintainability-review` — maintainability-only review
+
+Reviews a diff only for maintainability risks (unnecessary complexity, poor readability,
+duplication, weak separation of concerns, convention drift).
+
+- **Arguments (standalone):** same scope options as the performance review. Inside
+  `reviewer_review-pr` it runs as a dimension over the provided unit diffs.
+- **MCP tools used (when run in the PR pipeline):** `search_code`, `get_related_symbols`,
+  `read_file`, `get_definition`, `find_callers`, `get_changed_file_diff`.
+- **Output:** JSON `{"findings":[{category:"maintainability", severity, file, line, side, code_quote,
+  message, suggestion, fix, confidence}]}`.
+
+### `reviewer_ask` — grounded codebase Q&A
+
+Answers a free-text question about the codebase with citations (`path:line`), using RAG + the code
+graph. For onboarding / explaining a subsystem — **not** for reviewing PRs. Requires a built base
+index.
+
+- **Arguments:** a free-text question (e.g. "where is authentication", "how does index freshness
+  work", "explain the retrieval pipeline", "как устроено…").
+- **MCP tools used:** `search_codebase`, `related_symbols`, `callers`, `definition`; plus harness
+  `Read`/`Grep`/`Glob`.
+- **Flow:** resolve repo/branch → `search_codebase` → optionally expand via the graph → answer with
+  an Evidence list of `path:line` citations.
+
+---
+
+## MCP tools reference
+
+The `reviewer-mcp` server exposes 20 tools. PR-session tools require an active `prepare_review` for
+that `(repo, pr)` in the same running server; the rest are session-less.
+
+### Review lifecycle
+
+| Tool | Signature | Returns / does |
+|---|---|---|
+| `prepare_review` | `(repo: str, pr: int)` | Open a PR session: sync base index, build the PR overlay, load policy, assemble per-file units. Returns PR meta + policy + units (or `{"status":"skipped"}` for an untracked target branch). |
+| `publish_review` | `(repo, pr, summary, findings: list[dict], dry_run=False, task_key=None)` | Deterministic tail: gate → grounding → dedup → inline/summary split → post to GitHub → history → overlay cleanup. `dry_run=true` returns the report without posting; `task_key` links the PR to a task on real publish. |
+
+Each finding: `{category, severity(low|medium|high|critical), file, line, side(RIGHT|LEFT),
+code_quote, message, suggestion, fix:{start_line,end_line,replacement}|null, confidence:0..1}`.
+
+### PR-session analysis tools (require `prepare_review`)
+
+| Tool | Signature | Returns / does |
+|---|---|---|
+| `search_code` | `(repo, pr, query: str)` | Hybrid semantic+lexical search over `base ∪ overlay`. |
+| `get_related_symbols` | `(repo, pr, node_id: str)` | Graph neighbors (calls/implementations) of `node_id` = `path#fqn`. |
+| `read_file` | `(repo, pr, path, start=1, end=400)` | Source of a file at the PR HEAD (1-based, inclusive). |
+| `get_definition` | `(repo, pr, symbol: str)` | Definition of a symbol (graph → index → semantic fallback). |
+| `find_callers` | `(repo, pr, node_id: str)` | Direct callers of `node_id` `path#fqn` (impact analysis). |
+| `get_changed_file_diff` | `(repo, pr, path: str)` | Unified diff of another changed file in the same PR. |
+
+### Session-less tools (Q&A, `solve-task`)
+
+| Tool | Signature | Returns / does |
+|---|---|---|
+| `search_codebase` | `(repo, query, top_k=10, branch=None, include_tests=False)` | Hybrid search over a repo's base index; line-numbered, deduped, tests excluded by default. |
+| `related_symbols` | `(repo, node_id, branch=None)` | Graph neighbors (calls/implements/tests) of a symbol. |
+| `callers` | `(repo, node_id, branch=None)` | Incoming `CALLS` of `node_id` `path#fqn`. |
+| `definition` | `(repo, symbol, branch=None)` | Symbol definition (graph → index → semantic fallback). |
+| `get_pr_diff` | `(repo, number: int)` | Unified diff of any (historical) PR; capped, fail-soft. |
+
+### Tasks / boards
+
+| Tool | Signature | Returns / does |
+|---|---|---|
+| `sync_board` | `(board=None, limit=None, purge_orphaned=False, keep_with_prs=True)` | Server-side ETL: enumerate the board over REST, normalize to `TaskBrief`, index. Incremental via a per-board watermark; O(1) tokens. |
+| `index_task` | `(task: dict)` | Index one normalized `TaskBrief` into the task graph + vector store (idempotent). |
+| `index_tasks_batch` | `(tasks: list[dict])` | Same for a list, in one Voyage call. |
+| `search_tasks` | `(query, top_k=5)` | Semantically similar tasks from the indexed corpus. |
+| `get_task_context` | `(key: str)` | Graph context: the task, its PRs, linked tasks and their PRs, and the touched code. |
+| `purge_orphaned_tasks` | `(active_keys: list[str], keep_with_prs=True)` | Remove tasks no longer on the board (PR-linked tasks protected by default). |
+| `get_board_config` | `()` | Deploy-wide board config (`TASK_BOARD_*`); fallback for `sync-tasks`/`solve-task`. Credentials are **not** returned. |
+
+---
+
 ## Plugin usage
 
-With the plugin installed (see [Installation](#installation)) and Claude Code open at the repo root,
-call a skill:
+With the plugin installed and Claude Code open at the repo root, call a skill:
 
 ```text
-/rag-reviewer:reviewer_review-pr owner/repo#42     # review a PR (prepare_review → subagents → publish_review)
-/rag-reviewer:reviewer_sync-codebase               # build/update vector store + code graph from local clone
-/rag-reviewer:reviewer_sync-tasks                  # warm the task graph & vector store (server-side ETL via sync_board)
-/rag-reviewer:reviewer_solve-task <key | free text>  # gather disciplined context for a task, then hand off to dev
+/rag-reviewer:reviewer_review-pr owner/repo#42        # review a PR (prepare → subagents → publish)
+/rag-reviewer:reviewer_review-pr owner/repo#42 --dry-run   # assemble the report without posting
+/rag-reviewer:reviewer_sync-codebase --ref main      # build/update vector store + code graph
+/rag-reviewer:reviewer_sync-tasks                    # warm the task graph (server-side ETL)
+/rag-reviewer:reviewer_solve-task PRI-4              # gather task context, then hand off to dev
+/rag-reviewer:reviewer_ask how does index freshness work   # grounded codebase Q&A
 ```
 
 A typical end-to-end run:
@@ -433,10 +678,9 @@ reviewer index /tmp/REPO --ref master     # optionally index a second branch (RE
 # in Claude Code (from the repo root):  /rag-reviewer:reviewer_review-pr ORG/REPO#42
 ```
 
-For a dry run, pass `--dry-run` to the review skill — `publish_review` assembles the full report
-without posting to GitHub.
+---
 
-### Per-repo policy
+## Per-repo policy & task board
 
 A `.review.yml` file in the **target (base) branch** overrides the env defaults (a PR cannot weaken
 its own review — see *Caveats*):
@@ -475,7 +719,34 @@ costs O(1) tokens regardless of board size. It is incremental via a per-board ti
 the watermark advance. The board REST credentials live only in the reviewer-mcp environment
 (`TASK_BOARD_API_KEY` / `TASK_BOARD_API_BASE`). This inverts the "reviewer Python never touches the
 board" rule **for bulk sync only** — single-task reads in `solve-task` / `review-pr` still go through
-the board-MCP on the LLM side.
+the board-MCP on the LLM side. The task graph (`:Task`) is global, so one task can span PRs across
+several microservice repos.
+
+---
+
+## Observability web admin
+
+Every `publish_review` records the run in Postgres (`review_runs` / `review_findings`): repo/PR,
+model, timings, status, findings with verdicts and whether they were posted. The write is
+**fail-soft** (a logging failure never breaks the review) and gated by `REVIEW_HISTORY` (default
+`true`). The web admin (FastAPI + React/Vite SPA) shows run history, aggregates (gate filter rate,
+trends over time, findings by category/severity) and per-run details with finding drill-down.
+
+```bash
+# Via Docker (no manual steps) — the `web` service builds the frontend and serves FastAPI:
+docker compose up -d           # Postgres + Neo4j + web admin → http://127.0.0.1:8000
+
+# On the host (for frontend dev):
+pip install -e ".[web]"
+(cd web/frontend && npm install && npm run build)
+reviewer serve                 # http://127.0.0.1:8000 (options: --host / --port)
+```
+
+API: `GET /api/runs` (filterable list), `GET /api/runs/{id}` (run + findings),
+`GET /api/runs/{id}/trace` (step trace, forward-only — empty for pre-feature runs),
+`GET /api/stats?days=N` (aggregates).
+
+---
 
 ## Known limitations & caveats
 
@@ -510,11 +781,13 @@ A factual list of what this does and does not do today.
   diff, no overlap with other fixes); otherwise the advice is plain text.
 - **MCP session is in-process.** State between `prepare_review` and `publish_review` lives in the
   running `reviewer-mcp` process (`_Session` in `MCPReviewService`). Both calls for one PR must hit
-  the **same** running server — a restart in between loses the session.
+  the **same** running server — a restart in between loses the session (mitigated by
+  `REVIEW_SESSION_PERSIST`).
 - **Voyage free tier** = 3 RPM / 10K TPM; TPM is the main blocker — a full `reviewer index` of a
   large repo throttles (there is retry/backoff with jitter). A single PR review (overlay + query
   embeddings) fits within the limit.
-- **LLM cost.** A review fans out Claude subagents per file — that is real token cost, not free.
+- **LLM cost.** A review fans out Claude subagents per file plus dimension passes — that is real
+  token cost, not free.
 - **Observability web admin auth is optional.** Basic auth is enabled only if `WEB_ADMIN_USER` /
   `WEB_ADMIN_PASSWORD` are set; by default it is not hardened for public exposure (it binds to
   loopback in `docker-compose.yml`).
@@ -528,6 +801,7 @@ A factual list of what this does and does not do today.
 ```bash
 .venv/bin/pytest -q                 # unit: fast, on fakes; never hit external APIs
 .venv/bin/pytest -m integration     # integration: needs running Postgres/Neo4j + a Voyage key
+.venv/bin/ruff check .              # lint (line-length 100, target py311)
 ```
 
 `pytest` excludes integration tests by default (`addopts = -m 'not integration'`). External services
@@ -538,19 +812,22 @@ happen only in integration/E2E.
 
 ```
 reviewer/
-  config/      Settings (pydantic-settings): env → review thresholds, stores
+  config/      Settings (pydantic-settings): env → review thresholds, stores, branches, board
   vcs/         VCSProvider + github.py (httpx) · diff.py (lines available for inline)
   index/       chunker(tree-sitter) · embeddings(Voyage) · reranker · store(pgvector+pg_search/RRF) · freshness
   graph/       builder(tree-sitter call-graph) · scip(SCIP parser) · backend(backend orchestrator) · store(Neo4j)
   retrieval/   Retriever: hybrid + graph expansion + rerank → ContextPack
+  llm/         _retry.py (retry/backoff for Voyage)
   tools/       agent tools (search_code, get_related_symbols, read_file, get_definition, …)
+  tasks/       TaskBrief normalization · boards/ (TaskBoardProvider REST: yougile) · TaskService.index_batch
   agent/       state (ReviewUnit) · assemble · dedup
   mcp/         MCPReviewService: prepare / tool calls / publish; session management
   services/    ReviewService.prepare: ingest PR, overlay, units
   policy/      ReviewPolicy: env defaults + .review.yml + gating
-  entrypoints/ cli.py (index / search / check / serve) · mcp_server.py (FastMCP)
+  entrypoints/ cli.py (Click) · mcp_server.py (FastMCP, 20 tools)
+  install.py   reviewer init / install / install-skills (cross-platform client wiring)
   web/         FastAPI + React/Vite SPA — observability web admin
   app.py       dependency assembly from Settings
-plugin/        Claude Code plugin (skills /rag-reviewer:reviewer_review-pr, reviewer_solve-task, reviewer_sync-codebase, reviewer_sync-tasks)
+plugin/        Claude Code plugin (7 skills /rag-reviewer:reviewer_*)
 docker-compose.yml   ParadeDB (pgvector+pg_search) + Neo4j + web admin
 ```

--- a/README.ru.md
+++ b/README.ru.md
@@ -15,11 +15,16 @@
 - [Архитектура: как связаны части](#архитектура-как-связаны-части)
 - [Как работает ревью (поток данных)](#как-работает-ревью-поток-данных)
 - [Свежесть индекса на «живом» репозитории](#свежесть-индекса-на-живом-репозитории)
+- [Промт для быстрой установки](#промт-для-быстрой-установки)
 - [Быстрый старт](#быстрый-старт)
-- [Использование (CLI)](#использование-cli)
-- [Эксплуатация](#эксплуатация)
+- [Конфигурация (справочник env)](#конфигурация-справочник-env)
+- [CLI (справочник команд)](#cli-справочник-команд)
+- [Скиллы (справочник с параметрами)](#скиллы-справочник-с-параметрами)
+- [MCP-тулы (справочник)](#mcp-тулы-справочник)
+- [Использование плагина](#использование-плагина)
+- [Политика per-repo и доска задач](#политика-per-repo-и-доска-задач)
+- [Эксплуатация и веб-админка](#эксплуатация-и-веб-админка)
 - [Пример ревью «от диффа до комментария»](#пример-ревью-от-диффа-до-комментария)
-- [Конфигурация](#конфигурация)
 - [Структура проекта](#структура-проекта)
 - [Тесты](#тесты)
 - [Ограничения и заметки](#ограничения-и-заметки)
@@ -34,6 +39,8 @@
 - **Граф кода** — структурно подтянуть вызывающих/вызываемых/реализации/тесты изменённого символа;
 - **LLM с инструментами** — рассуждать над диффом, дотягивая нужный код тулзами, и выносить замечания;
 - **Verify-проход** — отсеять галлюцинации, не теряя реальных багов.
+
+Один прогон ревью идёт тремя стадиями: **`prepare_review` (MCP)** → **анализ (Claude subagents)** → **`publish_review` (MCP)**.
 
 ## Архитектура: как связаны части
 
@@ -65,7 +72,7 @@
                 │        └──────────────────── publish_review (gate/grounding/dedup/assemble) ◀─────────┘│
                 └────────────────────────────────────────────────────────────────────────────────────────┘
 
-  Хранилища поднимаются в Docker:  Postgres/ParadeDB (:5433)  ·  Neo4j (:7687)
+  Хранилища поднимаются в Docker:  Postgres/ParadeDB (:5433)  ·  Neo4j (:7687)  ·  веб-админка (:8000)
   Внешние API:  Voyage (эмбеддинги voyage-code-3 + reranker rerank-2.5)
 ```
 
@@ -77,7 +84,8 @@
 | Индекс (RAG) | `reviewer/index/` | чанкинг (tree-sitter), эмбеддинги (Voyage), хранилище (pgvector+BM25), свежесть |
 | Граф кода | `reviewer/graph/` | построение рёбер `CALLS` + `IMPLEMENTS` (SCIP-бэкенд) или только `CALLS` (tree-sitter); оркестрация в `backend.py`; хранение и обход в Neo4j |
 | Ретрив | `reviewer/retrieval/` | гибрид (RRF) + graph-expansion + Voyage rerank → контекст |
-| Инструменты | `reviewer/tools/` | `search_code`, `get_related_symbols`, `read_file`, `get_definition`, `find_callers`, `get_changed_file_diff`; `index_task` — индексирует задачу в граф и вектор; `search_tasks` — семантический поиск по задачам; `get_task_context` — граф/история задачи и связанных PR; `search_codebase` — session-less гибрид-поиск по base-индексу (для /solve-task) |
+| Инструменты | `reviewer/tools/` | `search_code`, `get_related_symbols`, `read_file`, `get_definition`, `find_callers`, `get_changed_file_diff`; session-less `search_codebase`/`related_symbols`/`callers`/`definition` для Q&A |
+| Задачи/доски | `reviewer/tasks/` | нормализация в `TaskBrief`, REST-провайдеры досок (`TaskBoardProvider`, yougile — референс), `TaskService.index_batch` |
 | MCP-сервис | `reviewer/mcp/` | `MCPReviewService`: prepare/tool-вызовы/publish; управление сессиями PR |
 | Сервис | `reviewer/services/` | `ReviewService.prepare`: ingest PR, overlay, units |
 | Агент | `reviewer/agent/` | state (ReviewUnit) · assemble · dedup |
@@ -98,7 +106,7 @@
                upsert в Postgres под ref="pr:N"  (content-hash дедуп)
                   │
 3. plan        дифф → review-units (по файлу): {path, node_ids изменённых символов, patch}
-               → payload скиллу: юниты/политика/патчи
+               → payload скиллу: юниты/политика/патчи/конфиг доски
                   │
 ────────── analyze: Claude subagents (скилл /rag-reviewer:reviewer_review-pr) ──────────
 4. analyze     Subagents в tool-loop по каждому файлу:
@@ -109,6 +117,8 @@
                         + Voyage rerank → top-N  → ContextPack (код с цитатами path:line)
                  • get_related_symbols(node) → связанные символы из графа
                  • read_file, get_definition, find_callers, get_changed_file_diff
+               параллельно: dimension-проходы performance / maintainability
+               (+ requirements, если подключена доска) и финальный verify (отсев галлюцинаций)
                → findings (JSON): category, severity, line, message, suggestion, confidence
                   │  (findings аккумулируются со всех файлов)
                   │
@@ -124,7 +134,8 @@
                  • иначе → пункт в сводку (с ссылкой file:line)
                + кап max_comments + идемпотентность по фингерпринту (не дублировать на повторном push)
                   │
-8. publish     GitHubProvider: один review = сводка + массив inline-комментариев
+8. publish     GitHubProvider: один review = сводка + массив inline-комментариев;
+               при task_key — линковка PR к задаче в графе
 ```
 
 Ключевые свойства:
@@ -137,9 +148,10 @@
 
 Код меняется с каждым push'ем, а полный реиндекс большого репо дорог. Решение — **стабильная база + content-hash дедуп + overlay на PR**:
 
-- **`ref="base"`** — персистентный индекс целевой ветки. Обновляется инкрементально (`reviewer index`): чанкуются только изменённые файлы, эмбеддятся только чанки с новым `content_hash`.
+- **`ref="base:<branch>"`** — персистентный индекс отслеживаемой ветки (напр. `base:main`, `base:master`). Каждая ветка из `REVIEW_BRANCHES` имеет **изолированный** индекс. Обновляется инкрементально (`reviewer index --ref <branch>`): чанкуются только изменённые файлы, эмбеддятся только чанки с новым `content_hash` (эмбеддинги переиспользуются между ветками по хешу — экономия Voyage).
 - **`ref="pr:N"`** — эфемерный overlay: только изменённые файлы PR на его HEAD.
-- **На запросе**: `retrieval = (base, где path ∉ изменённых) ∪ overlay`. То есть для изменённых файлов агент видит **новую** версию, для остального — стабильную базу. Это и есть условие «находить произвольный релевантный код по всему репо, но по актуальной версии».
+- **На запросе**: `retrieval = (base:<branch>, где path ∉ изменённых) ∪ overlay`. Для изменённых файлов агент видит **новую** версию, для остального — стабильную базу. Это и есть условие «находить произвольный релевантный код по всему репо, но по актуальной версии».
+- **Мульти-бранч**: PR ревьюится против индекса своей целевой ветки (`base_ref` из PR). PR в ветку вне `REVIEW_BRANCHES` пропускается (`prepare_review` → `{"status":"skipped",...}`). Граф кода (`:Symbol` в Neo4j) тоже разрезан по ветке через свойство `branch` (составная уникальность `(repo, branch, id)`).
 
 ## Промт для быстрой установки
 
@@ -175,7 +187,7 @@ MCP-сервер опубликован на PyPI как [`rag-reviewer`](https:
 и запускается через `uvx` — **клонировать этот репозиторий не нужно**.
 
 Нужны: Docker, [`uv`](https://docs.astral.sh/uv/getting-started/installation/) (включает `uvx`),
-ключ Voyage, GitHub-токен.
+ключ Voyage, GitHub-токен. Python 3.11–3.13 — только для `pip`/editable-установки (у `uvx` свой).
 
 ### Быстрая установка (рекомендуется, все платформы)
 
@@ -197,7 +209,7 @@ reviewer init
 
 # 3) Прописать MCP-сервер (и скиллы) в ваш редактор/CLI
 reviewer install --all        # автодетект клиентов + установка скиллов
-#    или конкретный: reviewer install cursor|vscode|claude-code|windsurf|gemini|antigravity|mimo|opencode|kimi|trae|codex
+#    или конкретный: reviewer install cursor|vscode|claude-code|claude-desktop|windsurf|gemini|antigravity|mimo|opencode|kimi|trae|codex
 #    скиллы ставятся в клиенты, которые их поддерживают (Gemini/Mimo/Kimi); --no-skills чтобы пропустить
 
 # 4) Проверить
@@ -219,17 +231,22 @@ uv tool upgrade rag-reviewer
 > покрывает и установку плагином (marketplace): там сервер доступен везде, но плагин не раздаёт
 > разрешений.
 
+> **Откуда читаются ключи.** `.env` резолвится из фиксированного места, **не** из текущего каталога —
+> MCP-клиенты запускают сервер с произвольным CWD, поэтому проектный `./.env` ненадёжен. Порядок
+> поиска: `$REVIEWER_ENV_FILE` → `$XDG_CONFIG_HOME/rag-reviewer/.env` (по умолчанию
+> `~/.config/rag-reviewer/.env`) → `./.env` (удобно при запуске из клона репо). Реальные переменные
+> окружения всегда побеждают файл, поэтому ключи можно передать и блоком
+> `"env": { "VOYAGE_API_KEY": "…", "GITHUB_TOKEN": "…" }` в конфиге MCP-клиента — работает везде.
+
 Где взять ключи:
 - **Voyage** (`VOYAGE_API_KEY`): https://dashboard.voyageai.com/ — есть бесплатный пул; привяжите карту, чтобы снять лимит 3 RPM / 10K TPM.
 - **GitHub** (`GITHUB_TOKEN`): PAT с правами *Pull requests: Read and write* + *Contents: Read* (fine-grained) или scope `repo` (classic). Быстрый вариант: `gh auth token`.
 
-`DEFAULT_REPO` (опц.) задаёт дефолтный `owner/name` — тогда `--repo` у CLI и тулов можно не указывать.
+Остальные настройки имеют дефолты (см. `.env.example` и [справочник env](#конфигурация-справочник-env) ниже).
 
-### 2. Ручная установка плагина (альтернатива)
+### Ручная установка плагина (альтернатива)
 
 Если вы предпочитаете прописать конфиг вручную, а не через `reviewer install`:
-
-У каждого AI-инструмента свой конфиг-файл:
 
 | Инструмент | Глобальный конфиг | Проектный конфиг | Инструкция |
 |---|---|---|---|
@@ -251,7 +268,7 @@ uv tool upgrade rag-reviewer
 в соответствующем инструменте, MCP-сервер подключится автоматически. Для **глобальной установки**
 (работает из любого проекта) добавьте запись в глобальный конфиг-файл.
 
-Формат записи по типу инструмента (macOS/Linux — на Windows используйте `reviewer install`):
+Формат записи (macOS/Linux — на Windows используйте `reviewer install`):
 
 **Mimo Code** (`mimocode.json`):
 ```json
@@ -313,7 +330,7 @@ args = ["-lc", "uvx --from rag-reviewer@latest reviewer-mcp"]
 
 После добавления перезапустите инструмент — `reviewer` появится рядом с другими MCP-серверами.
 
-#### Claude Code
+#### Claude Code (marketplace)
 
 Из любого проекта двумя командами:
 
@@ -324,19 +341,18 @@ args = ["-lc", "uvx --from rag-reviewer@latest reviewer-mcp"]
 
 Вы получаете:
 
-- **Скиллы:** `/rag-reviewer:reviewer_review-pr`, `/rag-reviewer:reviewer_solve-task`, `/rag-reviewer:reviewer_sync-codebase`, `/rag-reviewer:reviewer_sync-tasks`
-  (а также `/rag-reviewer:reviewer_maintainability-review` и `/rag-reviewer:reviewer_performance-review`).
-- **MCP-сервер** `reviewer` с тулами: `prepare_review`, `publish_review`, `search_code`,
-  `get_related_symbols`, `read_file`, `get_definition`, `find_callers`, `get_changed_file_diff`,
-  `index_task`, `search_tasks`, `get_task_context`, `search_codebase`.
+- **Скиллы:** `/rag-reviewer:reviewer_review-pr`, `/rag-reviewer:reviewer_solve-task`,
+  `/rag-reviewer:reviewer_sync-codebase`, `/rag-reviewer:reviewer_sync-tasks`,
+  `/rag-reviewer:reviewer_performance-review`, `/rag-reviewer:reviewer_maintainability-review`,
+  `/rag-reviewer:reviewer_ask` (см. [справочник скиллов](#скиллы-справочник-с-параметрами)).
+- **MCP-сервер** `reviewer` с 20 тулами (см. [справочник MCP-тулов](#mcp-тулы-справочник)).
 
 > Команда `/plugin` покажет, что `rag-reviewer` установлен и включён.
 
-### 3. Глобальная установка скиллов (опционально)
+#### Глобальная установка скиллов (опционально)
 
-Скиллы (`reviewer_review-pr`, `reviewer_solve-task`, `reviewer_sync-codebase`, `reviewer_sync-tasks`, `reviewer_performance-review`, `reviewer_maintainability-review`)
-дают полный рабочий процесс ревью одной командой. Без них можно вызывать MCP-тулы напрямую,
-но скиллы оборачивают их в управляемый сценарий.
+7 скиллов оборачивают MCP-тулы в управляемый сценарий. Без них можно вызывать тулы напрямую,
+но скиллы — основная точка входа.
 
 **`reviewer install` уже ставит их** для клиентов с файловыми скиллами (Gemini, Mimo, Kimi).
 Чтобы (пере)установить только скиллы или выбрать конкретного клиента:
@@ -366,118 +382,412 @@ rm /tmp/rag-reviewer.tgz
 | Claude Code | поставляется в плагине (шаг выше) |
 | Cursor | на уровне проекта через `.cursor-plugin/plugin.json` |
 
-## Использование
+---
 
-После `pip install -e .` доступны команды `reviewer` (CLI) и `reviewer-mcp` (MCP-сервер для плагина).
+## Конфигурация (справочник env)
 
-### CLI
+Всё ключевое — через `.env` (см. `.env.example` с комментариями). **Единственный обязательный
+внешний ключ — `VOYAGE_API_KEY`**; `GITHUB_TOKEN` обязателен для ревью PR. Остальное имеет дефолты,
+совпадающие с поставляемым `docker-compose.yml`. Порядок резолва `.env`: `$REVIEWER_ENV_FILE` →
+`~/.config/rag-reviewer/.env` → `./.env` (реальные переменные окружения всегда побеждают).
+
+### Voyage — эмбеддинги + реранкер (обязательно)
+
+| Переменная | Дефолт | Назначение |
+|---|---|---|
+| `VOYAGE_API_KEY` | `""` | **Обязателен.** Ключ Voyage для эмбеддингов и реранкинга. |
+| `EMBEDDING_MODEL` | `voyage-code-3` | Модель эмбеддингов. |
+| `EMBEDDING_DIM` | `1024` | Размерность; **должна совпадать** с колонкой `vector(N)` в Postgres — смена требует реиндекса. |
+| `EMBEDDING_BATCH_SIZE` | `256` | Текстов в одном запросе эмбеддинга (≤1000 и ≤120K токенов). |
+| `RERANK_MODEL` | `rerank-2.5` | Модель реранкера Voyage. |
+
+### GitHub (обязательно для ревью PR)
+
+| Переменная | Дефолт | Назначение |
+|---|---|---|
+| `GITHUB_TOKEN` | `""` | PAT — *Pull requests: Read and write* + *Contents: Read*. |
+| `GITHUB_RETRY_ATTEMPTS` | `3` | Ретраи на сетевые сбои GitHub API. |
+| `GITHUB_RETRY_BACKOFF_BASE` | `1.0` | База экспоненциального backoff (сек). |
+
+### Хранилища (Postgres/ParadeDB + Neo4j)
+
+| Переменная | Дефолт | Назначение |
+|---|---|---|
+| `PG_DSN` | `postgresql://reviewer:reviewer@localhost:5433/reviewer` | ParadeDB (pgvector + pg_search) на host-порту **5433**. |
+| `PG_POOL_MIN_SIZE` | `1` | Минимум соединений в пуле Postgres. |
+| `PG_POOL_MAX_SIZE` | `4` | Максимум соединений в пуле Postgres. |
+| `NEO4J_URI` | `neo4j://localhost:7687` | bolt-URI Neo4j. |
+| `NEO4J_USER` | `neo4j` | Пользователь Neo4j. |
+| `NEO4J_PASSWORD` | `reviewerpass` | Пароль Neo4j (одноразовый dev-дефолт). |
+| `GRAPH_BACKEND` | `auto` | Движок графа: `auto` (SCIP если `scip-python` в PATH, иначе tree-sitter), `scip`, `treesitter`. |
+
+### Мульти-репо / мульти-ветки (опционально)
+
+| Переменная | Дефолт | Назначение |
+|---|---|---|
+| `DEFAULT_REPO` | `""` | Дефолтный `owner/name` для session-less тулов и `reviewer index` без `--repo`; пусто = мульти-репо (репо передаётся явно). |
+| `REVIEW_BRANCHES` | `main` | CSV отслеживаемых веток; первая — **первичная** (дефолт для `reviewer index --ref` и CLI search). PR в ветку вне списка пропускается. |
+
+### Политика ревью (env-дефолты; per-repo `.review.yml` переопределяет)
+
+| Переменная | Дефолт | Назначение |
+|---|---|---|
+| `REVIEW_SEVERITY_THRESHOLD` | `medium` | Мин. важность находки: `low`/`medium`/`high`/`critical`. |
+| `REVIEW_MIN_CONFIDENCE` | `0.5` | Отбрасывать находки ниже уверенности (0..1). |
+| `REVIEW_MAX_COMMENTS` | `25` | Кап inline-комментариев на ревью. |
+| `REVIEW_MAX_FILES` | `50` | Кап файлов `.py` на ревью; лишние — в сводку как пропущенные. |
+| `REVIEW_CATEGORIES` | `""` | CSV вайтлист категорий (`correctness`, `security`, `performance`, `style`, `requirements`); пусто = все. |
+| `REVIEW_SUGGESTIONS` | `apply` | `apply` = applyable GitHub `suggestion`-блоки; `text` = только текстовые советы. |
+| `REVIEW_OUTPUT_LANGUAGE` | `ru` | Язык текста публикуемых находок. |
+| `REVIEW_SKIP_DRAFTS` | `true` | Не ревьюить draft-PR. |
+| `MAX_TOOL_RESULT_CHARS` | `8000` | Макс. длина результата tool-вызова в промпте. |
+
+### Наблюдаемость и сессии (опционально)
+
+| Переменная | Дефолт | Назначение |
+|---|---|---|
+| `REVIEW_HISTORY` | `true` | Писать историю прогонов в Postgres (`review_runs`/`review_findings`), fail-soft. |
+| `REVIEW_SESSION_PERSIST` | `true` | Персистить сессию PR в Postgres (crash-recovery). |
+| `REVIEW_SESSION_TTL_HOURS` | `24` | TTL персистнутой сессии (часы). |
+| `WEB_ADMIN_USER` | `""` | Basic-auth логин для `reviewer serve` / сервиса `web`; пусто = без auth. |
+| `WEB_ADMIN_PASSWORD` | `""` | Basic-auth пароль; пусто = без auth. |
+
+### Доска задач (опционально) — глобальный дефолт деплоя
+
+Подключение к доске одинаково для всех репозиториев команды, поэтому задаётся **один раз** в env
+reviewer-mcp, а не дублируется в `.review.yml` каждого репо. См.
+[Политику per-repo и доску задач](#политика-per-repo-и-доска-задач).
+
+| Переменная | Дефолт | Назначение |
+|---|---|---|
+| `TASK_BOARD_TYPE` | `""` | Тип доски: `yougile`, `jira`, … (выбирает плейбук скилла). |
+| `TASK_BOARD_MCP` | `""` | Имя подключённого MCP-сервера доски (тулы LLM-стороны `mcp__<mcp>__*`). |
+| `TASK_BOARD_KEY_PATTERN` | `""` | Регэксп ключа задачи, напр. `[A-Z]+-\d+`. |
+| `TASK_BOARD_URL_TEMPLATE` | `""` | Шаблон ссылки на задачу, напр. `https://ru.yougile.com/team/<id>/#{code}`. |
+| `TASK_BOARD_API_KEY` | `""` | **REST API-ключ** для server-side болк-синка (`sync_board`). Server-internal — клиентам не отдаётся. |
+| `TASK_BOARD_API_BASE` | `""` | Base URL REST API; пусто → дефолт по типу (`yougile`: `https://yougile.com/api-v2`). |
+
+> **Как получить `TASK_BOARD_API_KEY` (Yougile).** UI: `Ctrl + ~` (или ⚙ рядом с названием компании →
+> «Настроить») → **API** → создать/скопировать ключ. REST: узнать `companyId` (`Ctrl + Alt + Q`, либо
+> `POST /api-v2/auth/companies {login,password}`), затем `POST /api-v2/auth/keys {login,password,companyId}`.
+> Ключ кладётся **только** в env reviewer-mcp (`~/.config/rag-reviewer/.env`), не в чат и не в конфиг клиента.
+
+---
+
+## CLI (справочник команд)
+
+Команды запускаются как `uvx --from rag-reviewer <command>`, либо после `uv tool install rag-reviewer` /
+`pip install -e ".[dev]"` — просто `reviewer`. Ставятся две точки входа: `reviewer` (CLI ниже) и
+`reviewer-mcp` (MCP-сервер, запускается редактором/плагином).
+
+| Команда | Аргументы | Опции | Что делает |
+|---|---|---|---|
+| `check` | — | — | Проверка готовности окружения (ключи, Postgres, Neo4j, GitHub). ✓/✗ по пунктам; exit 1 при проблеме. Квоту Voyage не тратит. |
+| `init` | — | `--path FILE` (по умолчанию `~/.config/rag-reviewer/.env`), `--yes` (принять дефолты, CI-режим) | Интерактивный wizard записи `.env` (Voyage/GitHub + опциональные группы). |
+| `install` | `[client]` | `--all`, `--list`, `--path FILE`, `--pin VERSION`, `--no-latest`, `--no-skills`, `--dry-run` | Прописать MCP-сервер (и скиллы) в AI-клиенты (кроссплатформенно). |
+| `install-skills` | `[client]` | `--all`, `--list`, `--path FILE` | Установить только скиллы в глобальную папку клиента. |
+| `update` | — | — | Проверить PyPI на новую версию `rag-reviewer`. |
+| `index` | `<repo>` (путь к клону) | `--ref BRANCH` (git-ref для чтения; дефолт — первичная ветка), `--branch NAME` (ключ хранения; дефолт = `--ref`), `--repo OWNER/NAME` (дефолт из git `origin`) | Построить/обновить base-индекс ветки (вектора + граф). Раз, далее инкрементально. |
+| `search` | `<query>` | `--repo OWNER/NAME` (дефолт `DEFAULT_REPO`), `--branch NAME` (дефолт — первичная) | Диагностический гибрид-поиск по base-индексу ветки. |
+| `status` | `[path]` (дефолт `.`) | `--repo OWNER/NAME` (дефолт из git `origin`), `--branch NAME` (дефолт — все `REVIEW_BRANCHES`) | Здоровье/свежесть индекса vs HEAD клона. Квоту Voyage не тратит. |
+| `migrate-branches` | — | — | Разово: переименовать legacy `ref="base"` → `base:<primary>` после апгрейда на мульти-бранч. |
+| `serve` | — | `--host HOST` (дефолт `127.0.0.1`), `--port PORT` (дефолт `8000`) | Веб-админка наблюдаемости на хосте. |
+| `reviewer-mcp` | — | — | MCP-сервер (stdio). Запускается плагином/редактором автоматически. |
+
+Примеры:
 
 ```bash
-# Создать ~/.config/rag-reviewer/.env из шаблона (заполнить VOYAGE_API_KEY + GITHUB_TOKEN).
-# Флаги: --path FILE (другое расположение), --force (перезаписать существующий).
-reviewer init
+# Первичная настройка
+uvx --from rag-reviewer reviewer init
+uvx --from rag-reviewer reviewer install --all
+uvx --from rag-reviewer reviewer check
 
-# Прописать MCP-сервер (и скиллы) в установленные AI-клиенты (кроссплатформенно).
-# --all автодетектирует установленных клиентов; или укажи конкретный:
-# cursor, claude-desktop, claude-code, vscode, windsurf, gemini, antigravity,
-# mimo, opencode, kimi, trae, codex.
-# Скиллы ставятся в клиенты, которые их поддерживают (Gemini/Mimo/Kimi); --no-skills чтобы пропустить.
-# Флаги: --list, --dry-run, --path FILE, --pin VERSION, --no-latest, --no-skills.
-reviewer install --all
-reviewer install cursor
+# Построить base-индекс (контекст всего репо для RAG + графа)
+uvx --from rag-reviewer reviewer index /path/to/repo --ref main --repo owner/name
+uvx --from rag-reviewer reviewer index /path/to/repo --ref master --repo owner/name   # вторая ветка
 
-# Установить только скиллы в глобальную папку клиента (Gemini/Mimo/Kimi).
-# --all автодетект; --list показать цели и каталоги; --path переопределить каталог.
-reviewer install-skills --all
+# Диагностика
+uvx --from rag-reviewer reviewer search "token verification" --branch master
+uvx --from rag-reviewer reviewer status /path/to/repo --branch dev
 
-# Проверить готовность окружения: ключи, Postgres, Neo4j, GitHub.
-# Выводит ✓/✗ по каждому пункту; exit 1 при любой проблеме. Квоту Voyage не тратит.
-reviewer check
-
-# Обновить rag-reviewer до последней версии с PyPI.
-reviewer update
-
-# Проиндексировать базу целевой ветки локального клона (вектора + граф).
-# Делается один раз и обновляется инкрементально; даёт RAG/графу контекст всего репо.
-# --repo можно опустить, если origin-remote является GitHub (owner/name дерайвится автоматически)
-# или задан DEFAULT_REPO в .env.
-reviewer index /path/to/repo --ref main --repo owner/name
-
-# Диагностический гибрид-поиск по базе (проверить, что индекс работает).
-reviewer search "token verification"
+# Веб-админка
+uvx --from rag-reviewer reviewer serve --host 127.0.0.1 --port 8000
 ```
 
-### Ревью через Claude Code-плагин
+Ревью работает и без предварительного `index` — тогда контекст ограничен диффом и overlay
+(RAG/граф «тонкие»). Для полноценного анализа влияния на весь репозиторий запустите `index` по
+целевой ветке.
 
-С установленным плагином (см. [Быстрый старт](#быстрый-старт)) и Claude Code, открытым в корне репо, вызовите скилл:
+---
+
+## Скиллы (справочник с параметрами)
+
+Скиллы — управляемые точки входа. С установленным плагином зовутся как `/rag-reviewer:<name>` в
+Claude Code (`/rag-reviewer:` — namespace плагина; в других клиентах имя скилла такое же). Аргументы
+передаются свободным текстом после имени (`$ARGUMENTS`).
+
+### `reviewer_review-pr` — полное ревью PR
+
+Оркестрирует три стадии (`prepare_review` → subagents → `publish_review`).
+
+- **Аргументы:** PR как `owner/repo#N`, `owner/repo N` или GitHub PR URL. Флаг `--dry-run` — собрать
+  и вернуть полный отчёт **без** постинга в GitHub.
+- **MCP-тулы:** `prepare_review`, `search_code`, `get_related_symbols`, `read_file`,
+  `get_definition`, `find_callers`, `get_changed_file_diff`, `publish_review`; плюс
+  `index_task` / `get_task_context` / `search_tasks`, если подключена доска.
+- **Поток:** prepare (PR + политика + units + конфиг доски) → fan-out одного субагента на файл →
+  параллельно dimension-проходы **performance** / **maintainability** (+ **requirements**, если есть
+  `TaskBrief`) → **verify** (отсев находок с `is_real=false`) → publish (gate/grounding/dedup/assemble).
+  Если `prepare_review` вернул `status:"skipped"` (ветка вне `REVIEW_BRANCHES`) — стоп; draft-PR
+  пропускаются, если не `REVIEW_SKIP_DRAFTS=false`.
+
+### `reviewer_solve-task` — собрать контекст задачи и передать в разработку
+
+Читает задачу (если есть ключ и доска), тянет связанные/похожие задачи и релевантный код, сводит
+бриф и входит в brainstorming. Дисциплинирует сбор контекста — **код не пишет**.
+
+- **Аргументы:** ключ задачи (напр. `PRI-4`, по `key_pattern`) **или** свободное описание (напр.
+  «add a logout endpoint»). Board-less режим: описание + поиск по коду.
+- **MCP-тулы:** `get_board_config`, `index_task`, `get_task_context`, `search_tasks`,
+  `search_codebase`, `related_symbols`, `callers`, `definition`, `get_pr_diff`; плюс подключённая
+  доска (`mcp__<board>__*`) для чтения задачи.
+- **Поток:** резолв конфига доски → идентификация задачи (ключ vs текст) → best-effort fail-open сбор
+  контекста (граф задач, похожие задачи, релевантный код, ленивые диффы PR похожих задач) → бриф
+  (Task / Related work / Relevant code / Constraints) → передача в `superpowers:brainstorming`.
+
+### `reviewer_sync-codebase` — построить/обновить base-индекс
+
+Тонкая обёртка над `reviewer index` (вектор + граф) из локального клона.
+
+- **Аргументы (все опц.):** `--path <path>` (дефолт: CWD), `--ref <branch>` (дефолт: `main`),
+  `--repo <owner/name>` (дефолт: из `git remote get-url origin`),
+  `--backend <auto|scip|treesitter>` (дефолт: `auto`, задаёт `GRAPH_BACKEND`).
+- **MCP-тулы:** нет — вызывает `uvx --from rag-reviewer reviewer index`.
+- **Поток:** резолв входов → проверка пререквизитов (`uvx`, git-репо, `reviewer check`, Docker up) →
+  индексация → опц. `reviewer search` для проверки → отчёт по чанкам/узлам/рёбрам и бэкенду графа.
+
+### `reviewer_sync-tasks` — прогреть граф и вектор задач
+
+Тонкий триггер server-side ETL-тула `sync_board` — reviewer сам перечисляет доску по REST, LLM не
+передаёт текст задач (O(1) токенов независимо от размера доски).
+
+- **Аргументы (все опц.):** `--board <name>` (одна доска/проект), `--limit <N>` (smoke-прогон;
+  **отключает purge и продвижение курсора**), `--purge-orphaned` (удалить задачи, которых больше нет
+  на доске; по умолчанию off), `--no-keep-with-prs` (с purge — удалять и задачи с PR-историей,
+  по умолчанию защищены).
+- **MCP-тулы:** `sync_board` (один вызов).
+- **Поток:** маппинг аргументов → один `sync_board(...)` → печать counts-сводки (перечислено/изменено/
+  заэмбеждено/без изменений/ошибок, purge, warnings). При `{"status":"error",...}` доска не настроена
+  на сервере — задать `TASK_BOARD_*` в `~/.config/rag-reviewer/.env` и переподключить MCP.
+
+### `reviewer_performance-review` — ревью только производительности
+
+Смотрит дифф только на риски производительности (N+1, повторная работа, плохая асимптотика, нет
+батчинга/кэша, блокирующий I/O, рост памяти).
+
+- **Аргументы (standalone):** scope — `staged`, `unstaged`, незакоммиченное, branch-vs-base, коммит,
+  сравнение веток, список файлов, PR-подобный объём. Если неясно — спрашивает. Внутри
+  `reviewer_review-pr` запускается как dimension по диффам units.
+- **MCP-тулы (в PR-конвейере):** `search_code`, `read_file`, `find_callers`, `get_related_symbols`,
+  `get_definition`, `get_changed_file_diff`.
+- **Вывод:** JSON `{"findings":[{category:"performance", severity, file, line, side, code_quote,
+  message, suggestion, fix, confidence}]}`.
+
+### `reviewer_maintainability-review` — ревью только сопровождаемости
+
+Смотрит дифф только на риски сопровождаемости (лишняя сложность, плохая читаемость, дублирование,
+слабое разделение ответственности, дрейф от конвенций репо).
+
+- **Аргументы (standalone):** те же опции scope, что у performance-ревью. Внутри
+  `reviewer_review-pr` — как dimension по диффам units.
+- **MCP-тулы (в PR-конвейере):** `search_code`, `get_related_symbols`, `read_file`,
+  `get_definition`, `find_callers`, `get_changed_file_diff`.
+- **Вывод:** JSON `{"findings":[{category:"maintainability", severity, file, line, side, code_quote,
+  message, suggestion, fix, confidence}]}`.
+
+### `reviewer_ask` — обоснованный Q&A по коду
+
+Отвечает на свободный вопрос о коде с цитатами (`path:line`), используя RAG + граф. Для онбординга /
+объяснения подсистемы — **не** для ревью PR. Нужен построенный base-индекс.
+
+- **Аргументы:** свободный вопрос (напр. «где аутентификация», «как работает свежесть индекса»,
+  «объясни ретрив», «как устроено…»).
+- **MCP-тулы:** `search_codebase`, `related_symbols`, `callers`, `definition`; плюс harness
+  `Read`/`Grep`/`Glob`.
+- **Поток:** резолв repo/branch → `search_codebase` → опц. расширение графом → ответ с Evidence-списком
+  цитат `path:line`.
+
+---
+
+## MCP-тулы (справочник)
+
+Сервер `reviewer-mcp` отдаёт 20 тулов. Тулы PR-сессии требуют активного `prepare_review` для того же
+`(repo, pr)` в том же запущенном сервере; остальные — session-less.
+
+### Жизненный цикл ревью
+
+| Тул | Сигнатура | Что делает / возвращает |
+|---|---|---|
+| `prepare_review` | `(repo: str, pr: int)` | Открыть сессию PR: досинк base-индекса, overlay PR, политика, per-file units. Возвращает мету PR + политику + units (или `{"status":"skipped"}` для нетрекаемой целевой ветки). |
+| `publish_review` | `(repo, pr, summary, findings: list[dict], dry_run=False, task_key=None)` | Детерминированный хвост: gate → grounding → dedup → inline/summary → пост в GitHub → история → очистка overlay. `dry_run=true` возвращает отчёт без постинга; `task_key` линкует PR к задаче при реальной публикации. |
+
+Поле находки: `{category, severity(low|medium|high|critical), file, line, side(RIGHT|LEFT),
+code_quote, message, suggestion, fix:{start_line,end_line,replacement}|null, confidence:0..1}`.
+
+### Тулы PR-сессии (требуют `prepare_review`)
+
+| Тул | Сигнатура | Что делает |
+|---|---|---|
+| `search_code` | `(repo, pr, query: str)` | Гибрид-поиск по `base ∪ overlay`. |
+| `get_related_symbols` | `(repo, pr, node_id: str)` | Соседи графа (calls/implementations) узла `path#fqn`. |
+| `read_file` | `(repo, pr, path, start=1, end=400)` | Исходник файла на HEAD PR (1-based, inclusive). |
+| `get_definition` | `(repo, pr, symbol: str)` | Определение символа (граф → индекс → семантический фолбэк). |
+| `find_callers` | `(repo, pr, node_id: str)` | Прямые вызывающие узла `path#fqn` (impact-анализ). |
+| `get_changed_file_diff` | `(repo, pr, path: str)` | Unified diff другого изменённого файла этого PR. |
+
+### Session-less тулы (Q&A, `solve-task`)
+
+| Тул | Сигнатура | Что делает |
+|---|---|---|
+| `search_codebase` | `(repo, query, top_k=10, branch=None, include_tests=False)` | Гибрид-поиск по base-индексу репо; с номерами строк, дедуп, тесты исключены по умолчанию. |
+| `related_symbols` | `(repo, node_id, branch=None)` | Соседи графа (calls/implements/tests) символа. |
+| `callers` | `(repo, node_id, branch=None)` | Входящие `CALLS` узла `path#fqn`. |
+| `definition` | `(repo, symbol, branch=None)` | Определение символа (граф → индекс → семантический фолбэк). |
+| `get_pr_diff` | `(repo, number: int)` | Unified diff любого (исторического) PR; кап, fail-soft. |
+
+### Задачи / доски
+
+| Тул | Сигнатура | Что делает |
+|---|---|---|
+| `sync_board` | `(board=None, limit=None, purge_orphaned=False, keep_with_prs=True)` | Server-side ETL: перечислить доску по REST, нормализовать в `TaskBrief`, проиндексировать. Инкрементально по watermark; O(1) токенов. |
+| `index_task` | `(task: dict)` | Индексировать один `TaskBrief` в граф + вектор (идемпотентно). |
+| `index_tasks_batch` | `(tasks: list[dict])` | То же для списка, одним вызовом Voyage. |
+| `search_tasks` | `(query, top_k=5)` | Семантически похожие задачи из индекса. |
+| `get_task_context` | `(key: str)` | Граф-контекст: задача, её PR, связанные задачи и их PR, затронутый код. |
+| `purge_orphaned_tasks` | `(active_keys: list[str], keep_with_prs=True)` | Удалить задачи, которых больше нет на доске (с PR-историей защищены по умолчанию). |
+| `get_board_config` | `()` | Deploy-wide конфиг доски (`TASK_BOARD_*`); фолбэк для `sync-tasks`/`solve-task`. Креды **не** отдаёт. |
+
+---
+
+## Использование плагина
+
+С установленным плагином и Claude Code, открытым в корне репо, вызовите скилл:
 
 ```text
-/rag-reviewer:reviewer_review-pr owner/repo#42
+/rag-reviewer:reviewer_review-pr owner/repo#42        # ревью PR (prepare → subagents → publish)
+/rag-reviewer:reviewer_review-pr owner/repo#42 --dry-run   # собрать отчёт без постинга
+/rag-reviewer:reviewer_sync-codebase --ref main      # построить/обновить вектор + граф
+/rag-reviewer:reviewer_sync-tasks                    # прогреть граф задач (server-side ETL)
+/rag-reviewer:reviewer_solve-task PRI-4             # собрать контекст задачи и передать в разработку
+/rag-reviewer:reviewer_ask как работает свежесть индекса   # обоснованный Q&A по коду
 ```
-
-Плагин вызывает `prepare_review` (через MCP), затем запускает subagents с инструментами поиска `search_code`, `get_related_symbols`, `read_file` и т.д., наконец `publish_review` (через MCP) постит результат в GitHub.
 
 Типичный сценарий:
 
 ```bash
 git clone https://github.com/ORG/REPO /tmp/REPO
 reviewer index /tmp/REPO --ref main --repo ORG/REPO   # построить базу+граф
+reviewer index /tmp/REPO --ref master --repo ORG/REPO # опц. вторая ветка (REVIEW_BRANCHES=main,master)
 # в Claude Code: /rag-reviewer:reviewer_review-pr ORG/REPO#42   # ревью PR #42
 ```
 
-> Ревью работает и без предварительного `index` — тогда контекст ограничен диффом и overlay (RAG/граф «тонкие»). Для полноценного анализа влияния на весь репозиторий запустите `index` по целевой ветке.
+---
 
-## Эксплуатация
+## Политика per-repo и доска задач
 
-### Диагностика и первый запуск
+Файл `.review.yml` в **целевой (base) ветке** репозитория переопределяет env-дефолты (PR не может
+ослабить собственное ревью):
 
-```bash
-# Проверить готовность окружения: ключи, Postgres, Neo4j, GitHub.
-# Выводит ✓/✗ по каждому пункту; exit 1 при любой проблеме.
-reviewer check
+```yaml
+categories: { correctness: true, security: true, performance: true, style: false, requirements: true }
+severity_threshold: medium
+min_confidence: 0.5
+paths: { ignore: ["**/migrations/**", "vendor/**"] }
+max_comments: 25
+
+# Контекст задачи (опц.): читать задачу с доски и проверять соответствие требованиям.
+# Доску (MCP) подключает пользователь на стороне сессии Claude Code; плагин её не бандлит.
+task_board:
+  type: yougile          # yougile | jira — выбирает плейбук скилла
+  mcp: yougile           # имя подключённого MCP-сервера доски (тулы зовутся mcp__<mcp>__*)
+  key_pattern: "[A-Z]+-\\d+"   # опц.; подходит Yougile PRI-34/ID-34 и Jira PROJ-123
+  # url_template: "https://ru.yougile.com/team/<teamId>/#{code}"  # опц.; ссылка на задачу в сводке
 ```
 
-Прогон без публикации: в скилле передайте `--dry-run` — `publish_review` соберёт отчёт, не постя в GitHub.
+**Блок `task_board` — глобальный дефолт деплоя, а не per-repo требование.** Подключение к доске
+одинаково для всех репозиториев команды, поэтому настраивается **один раз** в `.env` reviewer-mcp
+(`TASK_BOARD_TYPE` / `TASK_BOARD_MCP` / `TASK_BOARD_KEY_PATTERN` / `TASK_BOARD_URL_TEMPLATE`), и
+каждый репо его наследует — `.review.yml` ради доски не нужен. Блок `task_board` в `.review.yml` репо
+**переопределяет** дефолт для этого репо; пустой `task_board:` **выключает** доску для него.
+`review-pr` читает это через политику; `solve-task` — через тул `get_board_config` (и board-MCP на
+стороне LLM) как фолбэк, когда в локальном `.review.yml` блока нет.
+
+**Болк-синк задач — server-side, не LLM (`sync_board`).** Скилл `sync-tasks` — тонкий триггер: один
+вызов `sync_board(board, limit, purge_orphaned, keep_with_prs)`, и сервер сам ходит на доску по
+**REST** (`reviewer/tasks/boards/`, за интерфейсом `TaskBoardProvider`; yougile — референс),
+нормализует каждую задачу в `TaskBrief` в Python и индексирует через батч-индексатор. LLM не передаёт
+текст задач → синк стоит O(1) токенов независимо от размера доски. Инкрементальность — timestamp-
+watermark на доску в `index_meta` (`ref="tasks:<board>"`): повторный синк трогает ~0 задач; `--limit`
+отключает purge и продвижение курсора. Креды REST-доски живут только в env reviewer-mcp
+(`TASK_BOARD_API_KEY` / `TASK_BOARD_API_BASE`). Это разворачивает инвариант «reviewer Python никогда
+не трогает доску» **только для болк-синка** — одиночное чтение задачи в `solve-task` / `review-pr`
+по-прежнему идёт через board-MCP на стороне LLM. Граф задач (`:Task`) глобален — одна задача может
+охватывать PR из нескольких микросервисных репозиториев.
+
+**Граф и RAG по задачам.** Прочитанная задача индексируется в граф (Neo4j: узлы `:Task`/`:PR`, рёбра
+`TASK_LINK`/`IMPLEMENTED_BY`/`TOUCHES`) и в вектор (Postgres, таблица `tasks`) тулом `index_task`. При
+ревью агент видит связанные задачи и их PR/код через `get_task_context`, а похожие по смыслу — через
+`search_tasks`; при публикации PR автоматически линкуется к задаче (`task_key` в `publish_review`).
+Канонический ключ узла — сквозной код доски (Yougile `ID-N` / Jira key), прочие коды (Yougile `PRI-N`)
+хранятся как `aliases`, поэтому PR по любому коду резолвится в один узел.
+
+---
+
+## Эксплуатация и веб-админка
+
+### Диагностика и устойчивость
+
+```bash
+reviewer check          # ✓/✗ по ключам, Postgres, Neo4j, GitHub; exit 1 при проблеме
+```
+
+- Транзиентные ошибки Voyage/LLM (HTTP 429/5xx) ретраятся с экспоненциальным backoff и jitter.
+- Ошибка анализа одного файла не прерывает ревью — файл помечается как неудачный и попадает в сводку.
+- Эфемерный overlay `pr:N` удаляется из Postgres автоматически по окончании `publish_review` (и при
+  сбое prepare — fail-soft).
+
+### Свежесть base-индекса
+
+`reviewer index` фиксирует SHA проиндексированного ref в `index_meta`. При каждом `prepare_review`
+сверяется этот SHA с `base_sha` PR: при расхождении автоматически досинхронизируются чанки изменившихся
+файлов через GitHub compare API (без пересборки всего индекса). Граф (Neo4j) **также** инкрементально
+досинхронизируется в этом шаге (tree-sitter, repo-scoped, входящие `CALLS`-рёбра из неизменённых
+вызывающих сохраняются, fail-soft). Полная точность графа (рёбра `IMPLEMENTS`, все `CALLS`)
+восстанавливается ручным `reviewer index` с SCIP.
 
 ### Веб-админка наблюдаемости
 
-Каждый `publish_review` записывает прогон в Postgres (таблицы `review_runs` / `review_findings`):
-репозиторий/PR, модель, тайминги, статус, находки с вердиктами и фактом публикации. Запись
-**fail-soft** (сбой лога не ломает ревью) и гейтится `REVIEW_HISTORY` (дефолт `true`). Стоимости
-в записи нет — LLM-вызовы идут по подписке Claude Code.
-
-Веб-админка (FastAPI + React/Vite SPA) показывает историю прогонов, агрегаты (% отсева gate,
-графики во времени, находки по категориям/severity) и детали каждого прогона — с drill-down по
-находкам.
-
-**Через Docker (без ручных шагов).** Сервис `web` в `docker-compose.yml` сам собирает фронт
-(multi-stage: node → python) и поднимает FastAPI, читая ту же БД, что пишет `publish_review`:
+Каждый `publish_review` пишет прогон в Postgres (`review_runs` / `review_findings`): репо/PR, модель,
+тайминги, статус, находки с вердиктами и фактом публикации. Запись **fail-soft** и гейтится
+`REVIEW_HISTORY` (дефолт `true`). Стоимости в записи нет — LLM-вызовы идут по подписке Claude Code.
+Админка (FastAPI + React/Vite SPA) показывает историю прогонов, агрегаты (% отсева gate, графики во
+времени, находки по категориям/severity) и детали каждого прогона с drill-down.
 
 ```bash
-docker compose up -d                 # поднимает Postgres + Neo4j + web-админку
-# открыть http://127.0.0.1:8000
-```
+# Через Docker (без ручных шагов) — сервис web сам собирает фронт и поднимает FastAPI:
+docker compose up -d                 # Postgres + Neo4j + web-админка → http://127.0.0.1:8000
 
-**На хосте (для разработки фронта).** Альтернатива без Docker:
-
-```bash
+# На хосте (для разработки фронта):
 pip install -e ".[web]"
-cd web/frontend && npm install && npm run build && cd -
+(cd web/frontend && npm install && npm run build)
 reviewer serve                       # http://127.0.0.1:8000 (опции: --host/--port)
-
-# hot-reload фронта (в отдельном терминале, при запущенном reviewer serve):
+# hot-reload фронта (отдельный терминал при запущенном serve):
 cd web/frontend && npm run dev       # http://localhost:5173, /api проксируется на :8000
 ```
 
 API: `GET /api/runs` (список с фильтрами repo/status, пагинация), `GET /api/runs/{id}`
-(прогон + находки), `GET /api/runs/{id}/trace` (пошаговый трейс), `GET /api/stats?days=N` (агрегаты).
-
-> Трейс пишется только для **новых** прогонов (инструментация forward-only) — у прогонов,
-> сделанных до включения фичи, вкладка «Трейс» покажет пустое состояние.
-
-### Свежесть base-индекса
-
-`reviewer index` фиксирует SHA проиндексированного ref в таблице `index_meta`. При каждом `prepare_review` сверяется этот SHA с `base_sha` PR: если есть расхождение — автоматически досинхронизирует чанки изменившихся файлов через GitHub compare API (без пересборки всего индекса). Граф кода (Neo4j) **также** инкрементально досинхронизируется в этом же шаге (tree-sitter, repo-scoped, входящие `CALLS`-рёбра из неизменённых вызывающих сохраняются, fail-soft). Полная точность графа (рёбра `IMPLEMENTS`, все `CALLS`) восстанавливается ручным `reviewer index` с SCIP.
+(прогон + находки), `GET /api/runs/{id}/trace` (пошаговый трейс, forward-only — пусто для прогонов до
+включения фичи), `GET /api/stats?days=N` (агрегаты).
 
 ### Капы и флаги
 
@@ -487,20 +797,7 @@ API: `GET /api/runs` (список с фильтрами repo/status, пагин
 | `REVIEW_SKIP_DRAFTS` | `true` | не ревьюить draft-PR |
 | `REVIEW_MAX_COMMENTS` | 25 | кап inline-комментариев на ревью |
 
-### Устойчивость к ошибкам
-
-- Транзиентные ошибки LLM (HTTP 429/5xx) ретраятся с экспоненциальным backoff.
-- Ошибка анализа одного файла не прерывает ревью — файл помечается как неудачный и попадает в сводку.
-
-### Несколько репозиториев (мульти-репо)
-
-Один деплой (одна БД Postgres + Neo4j) обслуживает N репозиториев через `repo`-дискриминатор (`owner/name`): данные изолированы колонкой/свойством `repo` в Postgres (`chunks`, `index_meta`) и Neo4j (`:Symbol.repo`, составная уникальность `(repo, id)`). Каждое ревью выполняется в рамках своего репозитория — кросс-репо ретрив отсутствует.
-
-Для индексации: `reviewer index <path> --repo owner/name` (или `owner/name` дерайвится автоматически из git remote `origin`, если это GitHub; либо задаётся `DEFAULT_REPO` в `.env`).
-
-Граф задач (`:Task`) намеренно остаётся **глобальным** — одна задача может охватывать PR из нескольких микросервисных репозиториев.
-
-> **Миграция с single-repo.** Если у вас уже есть данные в индексе, выполните `reviewer index --repo owner/name` один раз (или задайте `DEFAULT_REPO`), чтобы проставить `repo`-дискриминатор.
+---
 
 ## Пример ревью «от диффа до комментария»
 
@@ -532,90 +829,27 @@ PR удаляет «лишнюю», на первый взгляд, провер
 
 > Агент **только комментирует** — он никогда не меняет и не откатывает код сам. Предложения могут приходить как **applyable** GitHub-блоки `suggestion` (кнопка «Apply»), но безопасно: блок ставится только когда модель даёт точную замену конкретного непрерывного диапазона строк диффа (диапазон целиком в RIGHT-части, без пересечений; иначе — текстовый совет). Поведение задаётся `REVIEW_SUGGESTIONS` (`apply`/`text`).
 
-## Конфигурация
-
-Всё ключевое — через `.env` (см. `.env.example` с комментариями). Главное:
-
-| Переменная | Назначение |
-|---|---|
-| `VOYAGE_API_KEY` | ключ Voyage (эмбеддинги + ранжирование) |
-| `GITHUB_TOKEN` | токен GitHub (PAT: *Pull requests: RW* + *Contents: R*) |
-| `EMBEDDING_MODEL` / `EMBEDDING_DIM` | модель Voyage и размерность (= колонке `vector(N)`; смена ⇒ реиндекс) |
-| `RERANK_MODEL` | модель реранкера Voyage |
-| `REVIEW_SEVERITY_THRESHOLD` | мин. важность: `low/medium/high/critical` |
-| `REVIEW_MIN_CONFIDENCE` | отбрасывать findings ниже уверенности (0..1) |
-| `REVIEW_MAX_COMMENTS` | кап inline-комментариев |
-| `REVIEW_CATEGORIES` | CSV вайтлист категорий (пусто = все) |
-| `REVIEW_SUGGESTIONS` | `apply` = applyable `suggestion`-блоки (кнопка «Apply»), `text` = только текстовые советы |
-| `REVIEW_MAX_FILES` | кап файлов PR; лишние — в сводку как пропущенные |
-| `REVIEW_OUTPUT_LANGUAGE` | язык текста находок в публикуемом ревью (дефолт `ru`) |
-| `REVIEW_SKIP_DRAFTS` | `true` = не ревьюить draft-PR |
-| `REVIEW_HISTORY` | `true` = сохранять историю прогонов в Postgres |
-| `PG_DSN`, `NEO4J_URI/USER/PASSWORD`, `GITHUB_TOKEN` | подключения и доступ |
-
-Эфемерный overlay `pr:N` удаляется из Postgres автоматически по окончании `publish_review`.
-
-**Политика per-repo.** Файл `.review.yml` в **целевой ветке** репозитория переопределяет env-дефолты (PR не может ослабить собственное ревью):
-
-```yaml
-categories: { correctness: true, security: true, performance: true, style: false, requirements: true }
-severity_threshold: medium
-min_confidence: 0.5
-paths: { ignore: ["**/migrations/**", "vendor/**"] }
-max_comments: 25
-
-# Контекст задачи (опц.): читать задачу с доски и проверять соответствие требованиям.
-# Доску (MCP) подключает пользователь на стороне сессии Claude Code; плагин её не бандлит.
-task_board:
-  type: yougile          # yougile | jira — выбирает плейбук скилла
-  mcp: yougile           # имя подключённого MCP-сервера доски (тулы зовутся mcp__<mcp>__*)
-  key_pattern: "[A-Z]+-\\d+"   # опц.; дефолт такой же (подходит Yougile PRI-34/ID-34 и Jira PROJ-123)
-  # url_template: "https://ru.yougile.com/team/<teamId>/#{code}"  # опц.; ссылка на задачу в сводке
-  #   Yougile: {code} → код проекта PRI-N (он в URL-фрагменте «#PRI-4»); {key} = канонический ID-N, в URL не идёт
-```
-
-**Контекст задачи (фаза 2).** Если задан `task_board` и в PR (title/body/ветка) найден ключ
-по `key_pattern`, скилл читает задачу с доски через её MCP и запускает проверку соответствия —
-новая категория находок `requirements` (включена по умолчанию). Находки без конкретной строки
-диффа уходят в сводку. Доска не настроена, ключ не найден или MCP недоступен → ревью работает
-как обычно, без деградации.
-
-**Граф и RAG по задачам (фаза 3).** Прочитанная задача индексируется в граф (Neo4j: узлы
-`:Task`/`:PR`, рёбра `TASK_LINK`/`IMPLEMENTED_BY`/`TOUCHES`) и в векторный индекс (Postgres,
-таблица `tasks`) тулом `index_task`. При ревью агент видит связанные задачи и их PR/код через
-`get_task_context`, а похожие по смыслу — через `search_tasks`; при публикации PR
-автоматически линкуется к задаче. Скилл `/reviewer_sync-tasks` прогревает корпус задач с доски (идемпотентно,
-с backoff под Voyage). Канонический ключ узла — сквозной код доски (Yougile `ID-N` / Jira key),
-прочие коды (Yougile `PRI-N`) хранятся как `aliases`, поэтому PR по любому коду резолвится в один
-узел. Neo4j/доска недоступны → контекст пуст с предупреждением, ревью продолжается.
-
-**Скилл `/reviewer_solve-task` (фаза 4).** `/reviewer_solve-task <ключ | свободный текст>` собирает контекст под
-задачу — читает задачу с доски (если есть ключ и подключена доска), тянет связанные и похожие
-задачи с их PR и кодом (`get_task_context`/`search_tasks`), ищет релевантный код по формулировке
-(`search_codebase` — session-less гибрид-поиск по base-индексу: BM25+ANN → graph-expansion →
-rerank), сводит **только релевантное** в структурированный бриф и передаёт его в штатный цикл
-разработки (`brainstorming` → план → реализация). Скилл дисциплинирует сбор контекста, не заменяя
-разработку; fail-open — без доски/графа работает по формулировке и коду.
-
 ## Структура проекта
 
 ```
 reviewer/
-  config/      Settings (pydantic-settings): env → пороги ревью, хранилища
+  config/      Settings (pydantic-settings): env → пороги ревью, хранилища, ветки, доска
   vcs/         VCSProvider + github.py (httpx) · diff.py (строки, доступные для inline)
   index/       chunker(tree-sitter) · embeddings(Voyage) · reranker · store(pgvector+pg_search/RRF) · freshness
   graph/       builder(tree-sitter call-graph) · scip(точный парсер SCIP) · backend(оркестратор бэкенда) · store(Neo4j)
   retrieval/   Retriever: гибрид + graph-expansion + rerank → ContextPack
   llm/         _retry.py (retry/backoff для Voyage)
   tools/       инструменты агента (search_code, get_related_symbols, read_file, get_definition, …)
+  tasks/       нормализация TaskBrief · boards/ (TaskBoardProvider REST: yougile) · TaskService.index_batch
   agent/       state (ReviewUnit) · assemble · dedup
-  mcp/         MCPReviewService: prepare/tool-вызовы/publish; MCP-сервер (server.py)
+  mcp/         MCPReviewService: prepare/tool-вызовы/publish; управление сессиями
   services/    ReviewService.prepare: ingest PR, overlay, units
   policy/      ReviewPolicy: env-дефолты + .review.yml + гейтинг
-  entrypoints/ cli.py (index / search / check / serve)
+  entrypoints/ cli.py (Click) · mcp_server.py (FastMCP, 20 тулов)
+  install.py   reviewer init / install / install-skills (кроссплатформенная привязка клиентов)
   web/         FastAPI + React/Vite SPA — веб-админка наблюдаемости
   app.py       сборка зависимостей из Settings
-plugin/        Claude Code-плагин (скиллы /rag-reviewer:reviewer_review-pr, reviewer_solve-task, reviewer_sync-codebase, reviewer_sync-tasks)
+plugin/        Claude Code-плагин (7 скиллов /rag-reviewer:reviewer_*)
 docker-compose.yml   ParadeDB (pgvector+pg_search) + Neo4j + web-админка
 ```
 
@@ -624,17 +858,28 @@ docker-compose.yml   ParadeDB (pgvector+pg_search) + Neo4j + web-админка
 ```bash
 .venv/bin/pytest -q                 # unit (быстрые, на фейках; внешние API не дёргают)
 .venv/bin/pytest -m integration     # integration: нужны поднятые Postgres/Neo4j + ключ Voyage
+.venv/bin/ruff check .              # линт (line-length 100, target py311)
 ```
 
-Внешние сервисы изолированы за интерфейсами и мокаются в unit-тестах; реальные вызовы — только в integration/E2E.
+`pytest` по умолчанию исключает integration-тесты (`addopts = -m 'not integration'`). Внешние сервисы
+изолированы за интерфейсами и мокаются в unit-тестах; реальные вызовы — только в integration/E2E.
 
 ## Ограничения и заметки
 
-- **v1 — только Python** (чанкер и граф). Другие языки — за тем же интерфейсом `GraphIndexer`/чанкера.
-- **Граф кода — два бэкенда** (настройка `GRAPH_BACKEND=auto|scip|treesitter`):
+- **Нет автотриггера.** Ревью не запускается на открытие/обновление PR — это ручной вызов скилла в Claude Code (нет GitHub App / webhook / CI из коробки).
+- **v1 — только Python** (чанкер и SCIP-бэкенд `scip-python`). Другие языки — за теми же интерфейсами чанкера/`GraphIndexer`.
+- **VCS — только GitHub**: `VCSProvider` реализован лишь для GitHub (абстракция под GitLab/Bitbucket есть, провайдеров нет).
+- **Граф кода — два бэкенда** (`GRAPH_BACKEND=auto|scip|treesitter`):
   - **SCIP** (`@sourcegraph/scip-python`, npm): точный type-aware граф с рёбрами `CALLS` + `IMPLEMENTS`; требует `scip-python` в PATH; индексирует через временный git worktree.
   - **tree-sitter** (fallback): быстрый, без внешних зависимостей, только `CALLS` по имени.
-  - Режим `auto` (по умолчанию): SCIP если найден, иначе tree-sitter; при ошибке SCIP — автооткат на tree-sitter с предупреждением.
-- **Voyage free tier** = 3 RPM / 10K TPM: полная индексация большого репо требует привязанной карты (бесплатные 200M токенов сохраняются) либо медленной инкрементальной индексации; в коде есть retry/backoff.
-- **VCS** — пока GitHub; GitLab/др. добавляются реализацией `VCSProvider`.
-- **Запуск** — пока CLI; webhook-сервис добавляется как точка входа (ядро уже библиотека).
+  - Режим `auto` (по умолчанию): SCIP если найден, иначе tree-sitter; при ошибке SCIP — автооткат на tree-sitter с предупреждением, при `scip` — ошибка пробрасывается.
+- **Авто-реиндекс графа инкрементальный, не полной точности.** На `prepare_review` при дрейфе SHA граф патчится по изменённым файлам (tree-sitter, repo-scoped); рёбра `IMPLEMENTS`, исходящие `CALLS` в неизменённые файлы и новые входящие `CALLS` восстанавливаются ручным `reviewer index` с SCIP.
+- **Мульти-репо через `repo`-дискриминатор**: один деплой обслуживает N репозиториев, изолированных колонкой/свойством `repo` (`owner/name`) в Postgres и Neo4j; кросс-репо ретрива нет. Граф задач `:Task` намеренно глобален. Внутри репо каждая ветка имеет изолированный индекс (`ref="base:<branch>"`; `branch` на узлах `:Symbol`, уникальность `(repo, branch, id)`).
+- **MCP-сессия в процессе.** Состояние между `prepare_review` и `publish_review` живёт в запущенном `reviewer-mcp` (`_Session` в `MCPReviewService`); оба вызова одного PR должны попасть в **тот же** сервер (смягчается `REVIEW_SESSION_PERSIST`).
+- **Voyage free tier** = 3 RPM / 10K TPM: полная индексация большого репо троттлится (есть retry/backoff с jitter); привязка карты снимает лимит. Ревью одного PR (overlay + query-эмбеддинги) в лимит укладывается.
+- **Стоимость LLM.** Ревью разворачивает Claude-субагентов на файл плюс dimension-проходы — это реальная стоимость токенов.
+- **Поверхность ревью.** Inline — только на строках диффа; остальное — в сводку. Applyable `suggestion` ставится только при безопасных инвариантах (`apply`, точная замена, диапазон целиком в RIGHT, без пересечений), иначе — текст.
+- **Капы GitHub API.** Список файлов PR пагинируется по 100; compare API для досинка базы отдаёт максимум 300 файлов — очень большие диффы усекаются.
+- **`.review.yml` берётся из base-ветки** (по дизайну — PR не может ослабить собственное ревью), не из head PR.
+- **Auth веб-админки опционален**: basic-auth включается только при `WEB_ADMIN_USER`/`WEB_ADMIN_PASSWORD`; по умолчанию слушает loopback в `docker-compose.yml`.
+```

--- a/plugin/README.md
+++ b/plugin/README.md
@@ -1,22 +1,40 @@
 # rag-reviewer — Claude Code plugin
 
-Плагин = этот репозиторий. Требования: выполненная установка
-`python -m venv .venv && .venv/bin/pip install -e ".[dev]"`, заполненный `.env`,
-поднятые ParadeDB/Neo4j (`docker compose up -d`), построенный base-индекс
-(`reviewer index /path/to/repo --ref main`).
+Корень Claude Code-плагина для скиллов `/rag-reviewer:reviewer_*`. Полная документация
+проекта — в корневых [README.md](../README.md) (англ.) и [README.ru.md](../README.ru.md) (рус.).
 
-MCP-сервер запускается из `.venv` репозитория с `cwd` в корне плагина —
-`./.env` подхватывается оттуда. Если сервер стартует из другого каталога,
+## Что внутри
+
+- **MCP-сервер** `reviewer` (`reviewer-mcp`, 20 тулов) — конфиг в `.mcp.json`.
+- **7 скиллов** (`plugin/skills/*/SKILL.md`):
+  `/rag-reviewer:reviewer_review-pr` · `/rag-reviewer:reviewer_solve-task` ·
+  `/rag-reviewer:reviewer_sync-codebase` · `/rag-reviewer:reviewer_sync-tasks` ·
+  `/rag-reviewer:reviewer_performance-review` · `/rag-reviewer:reviewer_maintainability-review` ·
+  `/rag-reviewer:reviewer_ask`.
+
+## Требования
+
+- Поднятые ParadeDB/Neo4j (`docker compose up -d`), заполненный `.env`
+  (`reviewer init`; обязателен `VOYAGE_API_KEY`, для ревью — `GITHUB_TOKEN`).
+- Построенный base-индекс (`reviewer index /path/to/repo --ref main`) — для полного
+  whole-repo контекста. Без него ревью работает «тонко» (только дифф + overlay).
+
 `.env` резолвится из фиксированного места: `$REVIEWER_ENV_FILE` →
-`~/.config/rag-reviewer/.env` → `./.env` (диагностика при сбое старта:
-`reviewer check`).
+`~/.config/rag-reviewer/.env` → `./.env`. Диагностика старта: `reviewer check`.
 
-Подключение: `claude --plugin-dir /path/to/rag_for_git` (или установка через
-локальный marketplace). Скиллы: `/rag-reviewer:review-pr`,
-`/rag-reviewer:performance-review`, `/rag-reviewer:maintainability-review`.
+## Установка плагина
 
-Headless:
+Через marketplace (из любого проекта):
+
+```text
+/plugin marketplace add mimfort/rag_for_git
+/plugin install rag-reviewer@rag-reviewer-marketplace
+```
+
+Или локально для разработки: `claude --plugin-dir /path/to/rag_for_git`.
+
+## Headless
 
 ```bash
-claude --plugin-dir . -p "/rag-reviewer:review-pr owner/repo#123 --dry-run" --permission-mode bypassPermissions
+claude --plugin-dir . -p "/rag-reviewer:reviewer_review-pr owner/repo#123 --dry-run" --permission-mode bypassPermissions
 ```


### PR DESCRIPTION
Полное обновление документации, сверено с кодом.

- **README.md / README.ru.md**: добавлены справочники CLI (10 команд + флаги), скиллов (7, с параметрами и используемыми MCP-тулами), MCP-тулов (20, дословные сигнатуры) и конфигурации (все env по группам с дефолтами).
- Добавлены скил `ask` и недостающие команды (`status`, `migrate-branches`); подсказка по получению ключа доски (`TASK_BOARD_API_KEY`, Yougile).
- Исправлено: `reviewer init` флаг `--yes` (был ошибочно `--force`); модель свежести обновлена на мульти-бранч (`base:<branch>`, уникальность `(repo, branch, id)`).
- **plugin/README.md**: имена скиллов `reviewer_*` и полный список из 7.

Только документация — изменений в коде нет.