### PR TITLE
feat(skills): проверка свежести base-индекса в solve-task/ask (PRI-141)

### DIFF
--- a/docs/superpowers/plans/2026-06-20-index-freshness-preflight.md
+++ b/docs/superpowers/plans/2026-06-20-index-freshness-preflight.md
@@ -1,0 +1,427 @@
+# Index Freshness Preflight Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Дать session-less скилам `solve-task` и `ask` способ обнаружить устаревший base-индекс (drift) и сообщить о нём пользователю, опираясь на новый машиночитаемый `reviewer status --json`.
+
+**Architecture:** Часть 1 — общая инфра: чистый рендер `render_status_json(report)` поверх уже существующего `RepoStatus` + флаг `--json` у CLI-команды `status`. Часть 2-3 — её потребители: `solve-task` получает блокирующий Step 0 Preflight (drift → подтверждение → reindex через `/reviewer_sync-codebase` + прогрев корпуса `sync_board`), `ask` — облегчённый warn-баннер раз за сессию. Проверка «бесплатна» по Voyage (читает `index_meta` + локальный git).
+
+**Tech Stack:** Python 3.11+, Click (CLI), pytest (unit на фейках), Markdown (SKILL.md скилы Claude Code).
+
+## Global Constraints
+
+- **Язык user-facing строк — русский** (сообщения о дрейфе, баннер, подсказки). Литералы в коде/SKILL.md, которые видит пользователь, — на русском.
+- **Прозу SKILL.md писать по-английски** — тела скилов в этом репо на английском (токен-эффективность); по-русски только литеральные user-facing строки внутри них (как в существующих `ask`/`solve-task`).
+- **Коммиты:** Conventional Commits на русском (`feat(...)`, `test(...)`, `docs(...)`), **без self-attribution** (никаких `Co-Authored-By`/упоминаний Claude).
+- **Ветка разработки — `dev`** (текущая; новые коммиты идут в неё).
+- **Финальные гейты:** `ruff check .` без **новых** замечаний (repo-wide clean не гарантирован — проверять изменённые пути); `pytest -q` зелёный (integration по умолчанию исключён).
+- **Не-цели:** не трогать ревью-скилы (`review-pr`/`maintainability`/`performance`); не добавлять авто-reindex без подтверждения; не вводить MCP-тул `index_status`.
+- Инструменты запускать из venv: `.venv/bin/pytest`, `.venv/bin/ruff`.
+
+---
+
+## File Structure
+
+| Файл | Ответственность | Действие |
+|---|---|---|
+| `reviewer/services/status.py` | сбор + рендер статуса base-индекса | + `render_status_json(report)` |
+| `reviewer/entrypoints/cli.py` | CLI-команды | + флаг `--json` у `status`, ветвление вывода |
+| `tests/services/test_status.py` | unit статуса (фейки) | + `test_render_status_json_shapes_payload`, `test_status_command_json` |
+| `plugin/skills/solve-task/SKILL.md` | скил подготовки контекста задачи | + Step 0 Preflight |
+| `plugin/skills/ask/SKILL.md` | скил Q&A по коду | + warn-only проверка свежести |
+| `tests/skills/test_preflight_guardrail.py` | guard-тесты контента скилов | новый файл |
+
+---
+
+## Task 1: `reviewer status --json` (рендер + флаг + unit-тесты)
+
+Общая инфраструктура. Рендер и флаг тесно связаны (флаг без рендера и рендер без флага бессмысленны) — одна задача.
+
+**Files:**
+- Modify: `reviewer/services/status.py` (добавить `import json` + функцию `render_status_json`)
+- Modify: `reviewer/entrypoints/cli.py:18` (импорт), `reviewer/entrypoints/cli.py:233-255` (команда `status`)
+- Test: `tests/services/test_status.py` (добавить 2 теста + `import json`)
+
+**Interfaces:**
+- Consumes: существующие `RepoStatus`, `BranchStatus`, `OverlayStatus`, `build_status_report` (`reviewer/services/status.py:15-71`); паттерн CLI-теста `FakeStore`/`FakeGraph`/`CliRunner` + `monkeypatch.setattr(cli_mod, "build_status_report", ...)` (`tests/services/test_status.py:83-93`).
+- Produces: `render_status_json(report: RepoStatus) -> str` — pretty-JSON (`{repo, branches:[{branch, ref, indexed_sha, updated_at, chunks, graph_nodes, drift}], overlays:[{ref, chunks}]}`); полный SHA, `updated_at` ISO-строка/`null`, `None`→`null`, `backend` не включается. CLI-флаг `--json`/`as_json: bool`.
+
+- [ ] **Step 1: Написать падающий unit-тест рендера**
+
+В `tests/services/test_status.py` добавить `import json` первой строкой и расширить импорт из `reviewer.services.status` именем `render_status_json`. Текущая строка 4:
+
+```python
+from reviewer.services.status import build_status_report, OverlayStatus, render_status, RepoStatus, BranchStatus
+```
+
+заменить на:
+
+```python
+from reviewer.services.status import build_status_report, OverlayStatus, render_status, render_status_json, RepoStatus, BranchStatus
+```
+
+И добавить тест в конец файла:
+
+```python
+def test_render_status_json_shapes_payload():
+    dt = datetime(2026, 6, 18, 14, 2)
+    rep = RepoStatus(
+        repo="a/x",
+        branches=[
+            BranchStatus("main", "base:main", "abc1234567def", dt, 1843, 1207, 0),
+            BranchStatus("dev", "base:dev", "def5678901abc", dt, 1850, None, 12),
+            BranchStatus("old", "base:old", None, None, 0, None, None),
+            BranchStatus("nogit", "base:nogit", "aaa1111222bbb", dt, 10, 5, None),
+        ],
+        overlays=[OverlayStatus("pr:24", 18)])
+    payload = json.loads(render_status_json(rep))
+    assert payload["repo"] == "a/x"
+    by = {b["branch"]: b for b in payload["branches"]}
+    assert by["main"]["drift"] == 0
+    assert by["main"]["indexed_sha"] == "abc1234567def"      # полный SHA, не усечён
+    assert by["main"]["updated_at"] == "2026-06-18T14:02:00"  # ISO 8601
+    assert by["dev"]["drift"] == 12
+    assert by["dev"]["graph_nodes"] is None                   # Neo4j недоступен → null
+    assert by["old"]["indexed_sha"] is None                   # не проиндексирована
+    assert by["old"]["updated_at"] is None
+    assert by["nogit"]["drift"] is None                       # дрейф неизвестен
+    assert payload["overlays"] == [{"ref": "pr:24", "chunks": 18}]
+```
+
+- [ ] **Step 2: Прогнать — убедиться, что падает**
+
+Run: `.venv/bin/pytest tests/services/test_status.py -q`
+Expected: FAIL — `ImportError: cannot import name 'render_status_json' from 'reviewer.services.status'` (ошибка сбора).
+
+- [ ] **Step 3: Реализовать `render_status_json`**
+
+В `reviewer/services/status.py` добавить `import json` в блок импортов (после `from datetime import datetime`):
+
+```python
+import json
+```
+
+И добавить функцию рядом с `render_status` (например, перед `render_status` или сразу после неё):
+
+```python
+def render_status_json(report: RepoStatus) -> str:
+    """Машиночитаемый JSON по RepoStatus (для скилов-потребителей).
+
+    Полный SHA (не усечён — потребитель машинный), datetime → ISO 8601,
+    None → null. `backend` в JSON не включается: это подсказка только для
+    текстового вывода, в список требуемых полей не входит.
+    """
+    payload = {
+        "repo": report.repo,
+        "branches": [
+            {
+                "branch": b.branch,
+                "ref": b.ref,
+                "indexed_sha": b.indexed_sha,
+                "updated_at": b.updated_at.isoformat() if b.updated_at else None,
+                "chunks": b.chunks,
+                "graph_nodes": b.graph_nodes,
+                "drift": b.drift,
+            }
+            for b in report.branches
+        ],
+        "overlays": [{"ref": o.ref, "chunks": o.chunks} for o in report.overlays],
+    }
+    return json.dumps(payload, ensure_ascii=False, indent=2)
+```
+
+- [ ] **Step 4: Прогнать — тест рендера зелёный**
+
+Run: `.venv/bin/pytest tests/services/test_status.py::test_render_status_json_shapes_payload -v`
+Expected: PASS.
+
+- [ ] **Step 5: Написать падающий CLI-тест флага `--json`**
+
+В `tests/services/test_status.py` добавить тест (рядом с `test_status_command_smoke`):
+
+```python
+def test_status_command_json(monkeypatch):
+    dt = datetime(2026, 6, 18, 14, 2)
+    rep = RepoStatus(
+        repo="a/x",
+        branches=[BranchStatus("main", "base:main", "abc1234567def", dt, 5, 3, 0)],
+        overlays=[])
+    monkeypatch.setattr(cli_mod, "build_status_report", lambda *a, **k: rep)
+    res = CliRunner().invoke(cli_mod.cli, ["status", ".", "--repo", "a/x", "--json"])
+    assert res.exit_code == 0, res.output
+    payload = json.loads(res.output)
+    assert payload["repo"] == "a/x"
+    assert payload["branches"][0]["drift"] == 0
+    assert payload["branches"][0]["indexed_sha"] == "abc1234567def"
+```
+
+- [ ] **Step 6: Прогнать — убедиться, что падает**
+
+Run: `.venv/bin/pytest tests/services/test_status.py::test_status_command_json -v`
+Expected: FAIL — `res.exit_code` == 2 (Click: `Error: No such option: --json`), ассерт `== 0` не проходит.
+
+- [ ] **Step 7: Добавить флаг `--json` в CLI**
+
+В `reviewer/entrypoints/cli.py` строку 18 импорта:
+
+```python
+from reviewer.services.status import build_status_report, render_status
+```
+
+заменить на:
+
+```python
+from reviewer.services.status import build_status_report, render_status, render_status_json
+```
+
+Добавить опцию и параметр сигнатуры. Текущие строки 237-239:
+
+```python
+@click.option("--branch", "branch_opt", default=None,
+              help="одна ветка; по умолчанию все из REVIEW_BRANCHES")
+def status(path: str, repo_tag: str | None, branch_opt: str | None) -> None:
+```
+
+заменить на:
+
+```python
+@click.option("--branch", "branch_opt", default=None,
+              help="одна ветка; по умолчанию все из REVIEW_BRANCHES")
+@click.option("--json", "as_json", is_flag=True, default=False,
+              help="машиночитаемый JSON вместо текста")
+def status(path: str, repo_tag: str | None, branch_opt: str | None,
+           as_json: bool) -> None:
+```
+
+Текущие строки 253-255 (вычисление `backend` + вывод):
+
+```python
+    backend = ("scip-python (точный)" if _shutil.which("scip-python")
+               else "tree-sitter (fallback, scip-python не найден)")
+    click.echo(render_status(report, backend))
+```
+
+заменить на (JSON-ветка раньше, `backend` считается только для текста):
+
+```python
+    if as_json:
+        click.echo(render_status_json(report))
+        return
+    backend = ("scip-python (точный)" if _shutil.which("scip-python")
+               else "tree-sitter (fallback, scip-python не найден)")
+    click.echo(render_status(report, backend))
+```
+
+- [ ] **Step 8: Прогнать — CLI-тест зелёный**
+
+Run: `.venv/bin/pytest tests/services/test_status.py -q`
+Expected: PASS (все тесты файла, включая старые `test_status_command_smoke`/`test_render_status_shapes_output`).
+
+- [ ] **Step 9: Линт изменённых файлов**
+
+Run: `.venv/bin/ruff check reviewer/services/status.py reviewer/entrypoints/cli.py tests/services/test_status.py`
+Expected: без замечаний.
+
+- [ ] **Step 10: Коммит**
+
+```bash
+git add reviewer/services/status.py reviewer/entrypoints/cli.py tests/services/test_status.py
+git commit -m "feat(status): машиночитаемый reviewer status --json (drift по веткам)"
+```
+
+---
+
+## Task 2: `solve-task` Step 0 Preflight
+
+Markdown-правка скила + guard-тест содержимого (TDD: red guard → правка → green).
+
+**Files:**
+- Create: `tests/skills/test_preflight_guardrail.py`
+- Modify: `plugin/skills/solve-task/SKILL.md` (вставить Step 0 перед пунктом «1. Config», после `## Pipeline`)
+
+**Interfaces:**
+- Consumes: `reviewer status --json` из Task 1; MCP-тул `sync_board(board, limit, purge_orphaned, keep_with_prs)` (сигнатура — `plugin/skills/sync-tasks/SKILL.md:33-54`); скил-делегат `/reviewer_sync-codebase`.
+- Produces: guard-функция `test_solve_task_has_preflight` в новом файле (Task 3 допишет в него `test_ask_has_warn_only_freshness`).
+
+- [ ] **Step 1: Написать падающий guard-тест для solve-task**
+
+Создать `tests/skills/test_preflight_guardrail.py`:
+
+```python
+"""Guardrail: скилы solve-task и ask проверяют свежесть base-индекса (PRI-141).
+
+solve-task — блокирующий Step 0 Preflight (drift → подтверждение → reindex,
++ sync_board прогрев корпуса задач). ask — облегчённый warn-only баннер,
+без sync_board/reindex/блокировки.
+"""
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+SOLVE = ROOT / "plugin" / "skills" / "solve-task" / "SKILL.md"
+ASK = ROOT / "plugin" / "skills" / "ask" / "SKILL.md"
+
+
+def test_solve_task_has_preflight():
+    text = SOLVE.read_text(encoding="utf-8")
+    assert "Preflight" in text                              # Step 0 добавлен
+    assert "reviewer status" in text and "--json" in text   # читает машиночитаемый статус
+    assert "drift" in text                                  # проверяет дрейф
+    assert "sync_board(" in text                            # прогрев корпуса задач
+    assert "reviewer_sync-codebase" in text                 # делегирование reindex
+```
+
+- [ ] **Step 2: Прогнать — убедиться, что падает**
+
+Run: `.venv/bin/pytest tests/skills/test_preflight_guardrail.py::test_solve_task_has_preflight -v`
+Expected: FAIL — `assert "Preflight" in text` (раздела ещё нет в SKILL.md).
+
+- [ ] **Step 3: Вставить Step 0 в `solve-task/SKILL.md`**
+
+В `plugin/skills/solve-task/SKILL.md` после строки `## Pipeline` (и пустой строки под ней), перед `1. **Config.**`, вставить новый пункт (проза — английская, user-facing строки — русские):
+
+```markdown
+0. **Preflight (index freshness + task-corpus warm-up).** Run this BEFORE anything else.
+   First resolve, once, the repo path (`git rev-parse --show-toplevel`) and the working branch
+   (`git branch --show-current`; if it is in `REVIEW_BRANCHES` use it, else the primary branch) —
+   step 3 reuses the same branch for `search_codebase`.
+
+   1. **Base-index freshness.** Run
+      `uvx --from rag-reviewer reviewer status <path> --branch <branch> --json` and read `drift`
+      for that branch:
+      - `drift == 0` → continue;
+      - `drift > 0` → tell the user (in Russian) «индекс отстаёт на N коммитов» and **ask for
+        confirmation**: reindex now? **Yes** → delegate to `/reviewer_sync-codebase`
+        (`--path <path> --ref <branch>`), which reindexes and reports problems, then continue;
+        **No** → continue on the stale index and record the gap under **Constraints / open
+        questions** in the brief;
+      - `drift == null` (no clone / no index record) → do not block; note it in the brief.
+   2. **Problem report — in the style of `sync-codebase`.** If `reviewer status` fails (Postgres /
+      reviewer MCP / Neo4j unreachable, no index, or `uvx` missing): tell the user (in Russian)
+      what is missing and the command to fix it. **Fail-open** — never abort; continue on the
+      stale/unknown index.
+   3. **Warm the task corpus.** Call `sync_board(board=null, limit=null, purge_orphaned=false)` —
+      incremental (timestamp watermark), cheap when the corpus is warm. Board not configured or
+      `status=error` → print the `TASK_BOARD_*` hint and continue board-less.
+
+   Decisions: stale → confirmation, never auto (Voyage free tier is 3 RPM / 10K TPM); failures →
+   reported like `sync-codebase`; `sync_board` runs incrementally at start.
+
+```
+
+(Существующие пункты 1-5 остаются как есть — нумерация 0..5 читается естественно, перенумеровывать не нужно.)
+
+- [ ] **Step 4: Прогнать — guard-тест зелёный**
+
+Run: `.venv/bin/pytest tests/skills/test_preflight_guardrail.py::test_solve_task_has_preflight -v`
+Expected: PASS.
+
+- [ ] **Step 5: Коммит**
+
+```bash
+git add plugin/skills/solve-task/SKILL.md tests/skills/test_preflight_guardrail.py
+git commit -m "feat(solve-task): Step 0 preflight — проверка свежести индекса + прогрев корпуса"
+```
+
+---
+
+## Task 3: `ask` warn-only проверка свежести
+
+**Files:**
+- Modify: `plugin/skills/ask/SKILL.md` (вставить freshness-check между шагом 1 «Resolve repo/branch» и шагом 2 «Search»)
+- Modify: `tests/skills/test_preflight_guardrail.py` (дописать `test_ask_has_warn_only_freshness`)
+
+**Interfaces:**
+- Consumes: `reviewer status --json` из Task 1; guard-файл из Task 2.
+- Produces: `test_ask_has_warn_only_freshness` — проверяет наличие warn-баннера и **отсутствие** вызова `sync_board(` (облегчённый режим).
+
+- [ ] **Step 1: Дописать падающий guard-тест для ask**
+
+В конец `tests/skills/test_preflight_guardrail.py` добавить:
+
+```python
+def test_ask_has_warn_only_freshness():
+    text = ASK.read_text(encoding="utf-8")
+    assert "--json" in text and "reviewer status" in text   # читает машиночитаемый статус
+    assert "отстаёт на" in text                             # warn-баннер про дрейф (рус.)
+    assert "reviewer_sync-codebase" in text                 # баннер указывает на reindex-скил
+    # облегчённый режим: НЕ зовёт sync_board и не реиндексирует
+    assert "sync_board(" not in text
+```
+
+- [ ] **Step 2: Прогнать — убедиться, что падает**
+
+Run: `.venv/bin/pytest tests/skills/test_preflight_guardrail.py::test_ask_has_warn_only_freshness -v`
+Expected: FAIL — `assert "отстаёт на" in text` (баннера ещё нет в `ask/SKILL.md`).
+
+- [ ] **Step 3: Вставить freshness-check в `ask/SKILL.md`**
+
+В `plugin/skills/ask/SKILL.md`, между концом пункта `1. **Resolve repo/branch.**` (после строки про `branch` и DEFAULT_REPO) и началом пункта `2. **Search.**`, вставить (проза — английская, баннер — русский):
+
+```markdown
+   **Freshness check (first code question of the session only).** After resolving repo/branch and
+   ONLY on the first code question in this conversation — rely on conversation memory: if you have
+   already checked index freshness earlier in this session, skip this — run
+   `uvx --from rag-reviewer reviewer status <path> --branch <branch> --json` and read `drift`. If
+   `drift > 0`, emit exactly **one banner line**, in Russian:
+   «⚠ индекс отстаёт на N коммитов, ответ может не учитывать свежие изменения → `/reviewer_sync-codebase`».
+   Do NOT block, reindex, ask for confirmation, or call `sync_board` — this is warn-only. Cost ≈ 0
+   Voyage (reads `index_meta` + local git). **Fail-open:** any error → skip the banner silently
+   (Q&A is latency-sensitive).
+
+```
+
+- [ ] **Step 4: Прогнать — оба guard-теста зелёные**
+
+Run: `.venv/bin/pytest tests/skills/test_preflight_guardrail.py -q`
+Expected: PASS (2 теста: solve-task + ask).
+
+- [ ] **Step 5: Коммит**
+
+```bash
+git add plugin/skills/ask/SKILL.md tests/skills/test_preflight_guardrail.py
+git commit -m "feat(ask): warn-only баннер устаревшего индекса (раз за сессию)"
+```
+
+---
+
+## Task 4: Финальный гейт (линт + полный прогон)
+
+Сводная проверка по всем изменениям. Коммит только если что-то пришлось чинить.
+
+**Files:** —
+
+- [ ] **Step 1: Линт изменённых путей**
+
+Run: `.venv/bin/ruff check reviewer/services/status.py reviewer/entrypoints/cli.py tests/services/test_status.py tests/skills/test_preflight_guardrail.py`
+Expected: без замечаний. (Repo-wide `ruff check .` может показывать предсуществующие замечания — критерий «без новых».)
+
+- [ ] **Step 2: Полный прогон unit-тестов**
+
+Run: `.venv/bin/pytest -q`
+Expected: PASS, без падений (integration по умолчанию исключён).
+
+- [ ] **Step 3: При необходимости — коммит правок**
+
+Если шаги 1-2 потребовали исправлений:
+
+```bash
+git add -A
+git commit -m "fix: устранить замечания линта/тестов preflight-свежести"
+```
+
+Если правок не было — задача завершена без дополнительного коммита.
+
+---
+
+## Self-Review
+
+**1. Spec coverage** (по разделам `2026-06-20-index-freshness-preflight-design.md`):
+- Часть 1 (`render_status_json` + `--json`) → Task 1 ✓
+- Часть 2 (solve-task Step 0: drift/подтверждение/делегирование/sync_board/fail-open) → Task 2 ✓
+- Часть 3 (ask warn-only, раз за сессию, без sync_board) → Task 3 ✓
+- Тесты (unit рендера + CLI-smoke + guard оба скила) → Task 1 (unit) + Task 2/3 (guard) ✓
+- Критерии приёмки (ruff/pytest) → Task 4 ✓
+
+**2. Placeholder scan:** код показан полностью в каждом шаге; «N коммитов» — литерал баннера (рантайм-подстановка скилом), не плейсхолдер плана.
+
+**3. Type consistency:** `render_status_json(report: RepoStatus) -> str` — одно имя во всех задачах; флаг `--json`→`as_json: bool`; guard-токены (`"Preflight"`, `"sync_board("`, `"отстаёт на"`, `"reviewer_sync-codebase"`, `"--json"`) совпадают с литералами, вставляемыми в SKILL.md (различение `sync_board(` с скобкой: присутствует в solve-task, отсутствует в ask, где употреблён только bare `sync_board`).

--- a/docs/superpowers/specs/2026-06-20-index-freshness-preflight-design.md
+++ b/docs/superpowers/specs/2026-06-20-index-freshness-preflight-design.md
@@ -1,0 +1,220 @@
+# Проверка свежести base-индекса в session-less скилах (PRI-141 / ID-141)
+
+**Дата:** 2026-06-20
+**Задача:** [PRI-141](https://ru.yougile.com/team/686c049c8af8/#PRI-141) — «solve-task (preflight) + ask (warn-only): проверка свежести индекса»
+**Статус:** дизайн утверждён, готов к плану реализации
+
+## Проблема
+
+Session-less скилы собирают контекст на **base-индексе**, но не проверяют его свежесть → молча
+работают по устаревшему коду. Затронуты ровно два скила:
+
+- `solve-task` — `search_codebase` на base, без проверки;
+- `ask` — `search_codebase` на base, без проверки.
+
+Ревью-скилы (`review-pr`, `maintainability-review`, `performance-review`) **уже прикрыты**: идут
+через `prepare_review`, где встроен досинк (сверка `indexed_sha` vs `base_sha` + досинк изменённых
+файлов и графа через GitHub compare API). Их **не трогаем**.
+
+## Цель
+
+Дать обоим скилам способ узнать дрейф base-индекса относительно git HEAD и сообщить о нём
+пользователю — с разной строгостью под разный профиль скила:
+
+- `solve-task` (подготовка к разработке, латентность терпима) — **блокирующий preflight с
+  подтверждением** и опциональной переиндексацией;
+- `ask` (Q&A, латентно-чувствителен) — **необязательный warn-баннер**, раз за сессию.
+
+## Не-цели
+
+- Авто-переиндексация без подтверждения (в `solve-task`); любой reindex/блокировка в `ask`.
+- Трогать ревью-скилы (`review-pr`/`maintainability`/`performance`) — у них досинк уже встроен в
+  `prepare_review`.
+- Отдельный MCP-тул `index_status` — переиспользуем CLI, т.к. reindex всё равно идёт через
+  `uvx … reviewer index`.
+
+## Архитектура
+
+Три части. Часть 1 — общая инфраструктура (машиночитаемый статус), части 2-3 — её потребители
+(правки двух SKILL.md).
+
+```
+reviewer status --json  ──┬──▶  solve-task Step 0 (drift → подтверждение → reindex)
+   (общая инфра)          └──▶  ask Step 0      (drift → warn-баннер, раз за сессию)
+```
+
+Данные о свежести **уже** полностью собраны в `reviewer/services/status.py`
+(`build_status_report` → `RepoStatus`): `drift`, `chunks`, `graph_nodes`, `indexed_sha`,
+`updated_at`, `ref` по веткам + overlays. Нужен только машиночитаемый рендер — поэтому
+session-less проверка остаётся «бесплатной» по Voyage (читает `index_meta` + локальный git).
+
+## Часть 1 — `reviewer status --json` (общая инфра)
+
+### `reviewer/services/status.py`
+
+Добавить чистую функцию-рендер рядом с `render_status`:
+
+```python
+def render_status_json(report: RepoStatus) -> str:
+    """Машиночитаемый JSON по RepoStatus (для скилов-потребителей)."""
+```
+
+Форма вывода:
+
+```json
+{
+  "repo": "owner/name",
+  "branches": [
+    {
+      "branch": "dev",
+      "ref": "base:dev",
+      "indexed_sha": "def5678901abc...",
+      "updated_at": "2026-06-18T14:02:00",
+      "chunks": 1850,
+      "graph_nodes": 1190,
+      "drift": 12
+    }
+  ],
+  "overlays": [
+    {"ref": "pr:24", "chunks": 18}
+  ]
+}
+```
+
+Правила сериализации:
+
+- `indexed_sha` — **полный** SHA (не усечён до 7 символов — потребитель машинный), `null` если
+  ветка не проиндексирована.
+- `updated_at` — ISO 8601 (`datetime.isoformat()`) либо `null`.
+- `graph_nodes` — `null` при недоступном Neo4j.
+- `drift` — `null` при неизвестном дрейфе (нет клона / нет записи индекса), целое ≥ 0 иначе.
+- `backend` (человеко-метка «scip/tree-sitter») в JSON **не включается** — это не данные, а
+  подсказка для текстового вывода; список требуемых полей задачи его не содержит.
+- `json.dumps(payload, ensure_ascii=False, indent=2)`.
+
+Решение: выделенная функция (а не `dataclasses.asdict` + `default=str`) — явный контроль формы,
+детерминированная сериализация `datetime`, развязка JSON-контракта с именами/порядком полей
+датакласса.
+
+### `reviewer/entrypoints/cli.py` (команда `status`, ~233-255)
+
+- Добавить флаг: `@click.option("--json", "as_json", is_flag=True, default=False, help="машиночитаемый JSON вместо текста")`.
+- В конце команды — ветвление вывода:
+
+  ```python
+  if as_json:
+      click.echo(render_status_json(report))
+  else:
+      click.echo(render_status(report, backend))
+  ```
+
+- `build_status_report`, резолв repo/branches и обработка `psycopg.OperationalError` не меняются.
+  `backend` вычисляется как сейчас (вызов `_shutil.which`) и используется только в текстовой ветке;
+  JSON-ветка его игнорирует.
+
+## Часть 2 — `solve-task` Step 0 Preflight
+
+Файл: `plugin/skills/solve-task/SKILL.md`. Новый **Step 0 — Preflight**, перед текущим шагом 1
+(Config). Step 0 определяет путь репо (`git rev-parse --show-toplevel`) и ветку
+(`git branch --show-current`, сверка с `REVIEW_BRANCHES`; если ветка вне списка — первичная)
+**один раз**; шаг 3 (Gather context) переиспользует ту же ветку для `search_codebase`.
+
+1. **Свежесть base-индекса.**
+   `uvx --from rag-reviewer reviewer status <path> --branch <b> --json` → распарсить `drift` по
+   целевой ветке:
+   - `drift == 0` → идём дальше;
+   - `drift > 0` → показать «индекс отстаёт на N коммитов» и **спросить подтверждение**:
+     переиндексировать сейчас?
+     - **Да** → делегировать в `/reviewer_sync-codebase` (`--path <path> --ref <branch>`); он
+       переиндексирует и отрепортит проблемы; затем продолжить;
+     - **Нет** → продолжить на устаревшем индексе, отметив gap в разделе «Constraints / open
+       questions» итогового brief'а;
+   - `drift` неизвестен (`null` — нет клона/записи) → не блокируем, помечаем.
+
+2. **Отчёт о проблемах — в стиле `sync-codebase`.** Если `reviewer status` падает (Postgres / MCP /
+   Neo4j недоступны, нет индекса, `uvx` отсутствует): сообщить чего не хватает + команду починки.
+   **Fail-open** — скил не падает, продолжает (на устаревшем/неизвестном индексе, board-less при
+   необходимости).
+
+3. **Прогрев корпуса задач.** `sync_board(board=null, limit=null, purge_orphaned=false)` —
+   инкрементальный (timestamp-watermark), дёшев при заполненном корпусе. Доска не сконфигурирована
+   или `status=error` → подсказка по `TASK_BOARD_*`, но продолжаем board-less.
+
+Решения: stale → подтверждение (не авто — бережём Voyage 3 RPM / 10K TPM); проблемы → как в
+`sync-codebase`; `sync_board` инкрементально на старте.
+
+После Step 0 существующий пайплайн (Config → Identify → Gather → Distill → Handoff) идёт без
+изменений.
+
+## Часть 3 — `ask` warn-only
+
+Файл: `plugin/skills/ask/SKILL.md`. Лёгкая проверка свежести между шагами 1 (Resolve repo/branch) и
+2 (Search). Поведение **облегчённое** (не как в `solve-task`):
+
+- Проверка **только на первом** code-вопросе в сессии. Опора на **память разговора**: если в этом
+  разговоре свежесть уже проверялась — пропустить (скилы не хранят состояние между вызовами; цена
+  «один спавн на сессию» обеспечивается инструкцией скила, а не персистентным маркером).
+- Иначе: `uvx --from rag-reviewer reviewer status <path> --branch <b> --json`, прочитать `drift`.
+  При `drift > 0` — **одна строка-баннер**:
+  «⚠ индекс отстаёт на N коммитов, ответ может не учитывать свежие изменения →
+  `/reviewer_sync-codebase`».
+- **Без** блокировки, авто-reindex, подтверждения и `sync_board` (задачи к `ask` не относятся).
+- Стоимость ≈ 0 по Voyage (читает `index_meta` + локальный git); единственная цена — один спавн
+  `reviewer status` на сессию.
+- **Fail-open:** любая ошибка проверки → молча без баннера (Q&A латентно-чувствителен, проверка
+  свежести его не должна задерживать/ломать).
+
+## Тестирование
+
+### Unit (фейки, без сети) — `tests/services/test_status.py`
+
+- `test_render_status_json` — построить `RepoStatus` с ветками всех видов (fresh `drift=0`, behind
+  `drift>0`, not-indexed `indexed_sha=None`, neo4j-down `graph_nodes=None`, no-git `drift=None`) +
+  overlay; `json.loads(render_status_json(rep))`; проверить: `drift` по веткам, `null`-ы для
+  None-полей, `updated_at` в ISO, **полный** (не усечённый) SHA, overlays.
+- `test_status_command_json` — CLI-smoke через `CliRunner().invoke(cli, ["status", ".", "--repo",
+  "a/x", "--json"])` (с `monkeypatch` `build_status_report`, как `test_status_command_smoke`):
+  `exit_code == 0`, `json.loads(res.output)` парсится.
+
+### Guard-тесты контента скилов — `tests/skills/test_preflight_guardrail.py` (новый)
+
+Паттерн `tests/skills/test_sync_tasks_guardrail.py` (читать `SKILL.md`, ассертить подстроки):
+
+- `solve-task/SKILL.md` содержит: маркер Step 0 / Preflight, `reviewer status`, `--json`,
+  `sync_board(`, делегирование в `reviewer_sync-codebase`.
+- `ask/SKILL.md` содержит: warn-баннер про дрейф и `--json`; **не** содержит блокировки/`sync_board`
+  (страховка от копипасты строгого поведения solve-task в ask).
+
+### Прогон
+
+`ruff check .` без новых замечаний; `pytest -q` зелёный (integration по умолчанию исключён).
+
+## Порядок реализации (TDD)
+
+1. **Часть 1** — `render_status_json` + флаг `--json` в CLI; сразу unit-тесты (`test_render_status_json`,
+   `test_status_command_json`).
+2. **Часть 2** — Step 0 в `solve-task/SKILL.md`.
+3. **Часть 3** — warn-only в `ask/SKILL.md`.
+4. **Тесты** — guard-тесты `tests/skills/test_preflight_guardrail.py`.
+5. `ruff check .` + `pytest -q`.
+
+## Критерии приёмки (из задачи)
+
+- [ ] `reviewer status --json` отдаёт валидный JSON с `drift` по веткам; покрыт unit-тестом на фейках.
+- [ ] `solve-task` Step 0: при `drift > 0` показывает дрейф и спрашивает подтверждение; «Да» →
+  reindex через `sync-codebase`; недоступность сервисов → отчёт в стиле `sync-codebase`, fail-open.
+- [ ] `solve-task`: `sync_board` на старте; ненастроенная доска → подсказка + продолжение board-less.
+- [ ] `ask`: на первом code-вопросе сессии при `drift > 0` выводит warn-баннер; не блокирует, не
+  реиндексирует, не зовёт `sync_board`; на последующих вопросах не перепроверяет.
+- [ ] Язык кода/сообщений — русский; `ruff check .` без новых замечаний; `pytest -q` зелёный.
+
+## Затронутые файлы
+
+| Файл | Изменение |
+|---|---|
+| `reviewer/services/status.py` | + `render_status_json(report)` |
+| `reviewer/entrypoints/cli.py` | + флаг `--json` у команды `status`, ветвление вывода |
+| `plugin/skills/solve-task/SKILL.md` | + Step 0 Preflight |
+| `plugin/skills/ask/SKILL.md` | + warn-only проверка свежести |
+| `tests/services/test_status.py` | + `test_render_status_json`, `test_status_command_json` |
+| `tests/skills/test_preflight_guardrail.py` | новый — guard-тесты обоих скилов |

--- a/plugin/skills/ask/SKILL.md
+++ b/plugin/skills/ask/SKILL.md
@@ -37,6 +37,16 @@ Plus the harness file tools (`Read`, `Grep`, `Glob`) to read source from the loc
    - `branch`: `git branch --show-current`. Pass it only if it is in `REVIEW_BRANCHES`; if the
      user named a branch, use that; otherwise omit it (the server uses the primary branch).
 
+   **Freshness check (first code question of the session only).** After resolving repo/branch and
+   ONLY on the first code question in this conversation — rely on conversation memory: if you have
+   already checked index freshness earlier in this session, skip this — run
+   `uvx --from rag-reviewer reviewer status <path> --branch <branch> --json` and read `drift`. If
+   `drift > 0`, emit exactly **one banner line**, in Russian:
+   «⚠ индекс отстаёт на N коммитов, ответ может не учитывать свежие изменения → `/reviewer_sync-codebase`».
+   Do NOT block, reindex, ask for confirmation, or call `sync_board` — this is warn-only. Cost ≈ 0
+   Voyage (reads `index_meta` + local git). **Fail-open:** any error → skip the banner silently
+   (Q&A is latency-sensitive).
+
 2. **Search.** Call `search_codebase(repo, "<question>", branch=…)`. Parse the
    `path#fqn (path:start-end)` headers to get candidate symbols (`node_id`) and line ranges.
    If the result is `(ничего не найдено)`, go to Fallback.

--- a/plugin/skills/solve-task/SKILL.md
+++ b/plugin/skills/solve-task/SKILL.md
@@ -17,6 +17,32 @@ brief to `superpowers:brainstorming` (which leads to writing-plans → subagent-
 
 ## Pipeline
 
+0. **Preflight (index freshness + task-corpus warm-up).** Run this BEFORE anything else.
+   First resolve, once, the repo path (`git rev-parse --show-toplevel`) and the working branch
+   (`git branch --show-current`; if it is in `REVIEW_BRANCHES` use it, else the primary branch) —
+   step 3 reuses the same branch for `search_codebase`.
+
+   1. **Base-index freshness.** Run
+      `uvx --from rag-reviewer reviewer status <path> --branch <branch> --json` and read `drift`
+      for that branch:
+      - `drift == 0` → continue;
+      - `drift > 0` → tell the user (in Russian) «индекс отстаёт на N коммитов» and **ask for
+        confirmation**: reindex now? **Yes** → delegate to `/reviewer_sync-codebase`
+        (`--path <path> --ref <branch>`), which reindexes and reports problems, then continue;
+        **No** → continue on the stale index and record the gap under **Constraints / open
+        questions** in the brief;
+      - `drift == null` (no clone / no index record) → do not block; note it in the brief.
+   2. **Problem report — in the style of `sync-codebase`.** If `reviewer status` fails (Postgres /
+      reviewer MCP / Neo4j unreachable, no index, or `uvx` missing): tell the user (in Russian)
+      what is missing and the command to fix it. **Fail-open** — never abort; continue on the
+      stale/unknown index.
+   3. **Warm the task corpus.** Call `sync_board(board=null, limit=null, purge_orphaned=false)` —
+      incremental (timestamp watermark), cheap when the corpus is warm. Board not configured or
+      `status=error` → print the `TASK_BOARD_*` hint and continue board-less.
+
+   Decisions: stale → confirmation, never auto (Voyage free tier is 3 RPM / 10K TPM); failures →
+   reported like `sync-codebase`; `sync_board` runs incrementally at start.
+
 1. **Config.** Resolve the `task_board` block (`type`, `mcp`, `key_pattern`): first from the repo's
    `.review.yml`, and if there is no block there, from the deploy-wide default via
    `get_board_config()` (reviewer MCP) — so a per-repo `.review.yml` is not required when the board

--- a/reviewer/entrypoints/cli.py
+++ b/reviewer/entrypoints/cli.py
@@ -15,7 +15,7 @@ from reviewer.graph.store import GraphStore
 from reviewer.index.freshness import update_base
 from reviewer.index.refs import base_ref
 from reviewer.index.store import ChunkStore
-from reviewer.services.status import build_status_report, render_status
+from reviewer.services.status import build_status_report, render_status, render_status_json
 
 log = logging.getLogger(__name__)
 
@@ -236,7 +236,10 @@ def search(query: str, repo_tag: str | None, branch_opt: str | None) -> None:
               help="owner/name тег индекса; по умолчанию из git remote origin")
 @click.option("--branch", "branch_opt", default=None,
               help="одна ветка; по умолчанию все из REVIEW_BRANCHES")
-def status(path: str, repo_tag: str | None, branch_opt: str | None) -> None:
+@click.option("--json", "as_json", is_flag=True, default=False,
+              help="машиночитаемый JSON вместо текста")
+def status(path: str, repo_tag: str | None, branch_opt: str | None,
+           as_json: bool) -> None:
     """Показать здоровье/свежесть base-индекса по веткам (не тратит Voyage)."""
     s = Settings()
     repo = _resolve_repo(repo_tag, path, s)
@@ -250,6 +253,9 @@ def status(path: str, repo_tag: str | None, branch_opt: str | None) -> None:
     finally:
         store.close()
         graph.close()
+    if as_json:
+        click.echo(render_status_json(report))
+        return
     backend = ("scip-python (точный)" if _shutil.which("scip-python")
                else "tree-sitter (fallback, scip-python не найден)")
     click.echo(render_status(report, backend))

--- a/reviewer/services/status.py
+++ b/reviewer/services/status.py
@@ -5,6 +5,7 @@
 """
 from __future__ import annotations
 
+import json
 from dataclasses import dataclass
 from datetime import datetime
 
@@ -69,6 +70,32 @@ def build_status_report(store, graph, repo: str, branches: list[str],
         if not r.startswith("base:")
     ]
     return RepoStatus(repo=repo, branches=branch_statuses, overlays=overlays)
+
+
+def render_status_json(report: RepoStatus) -> str:
+    """Машиночитаемый JSON по RepoStatus (для скилов-потребителей).
+
+    Полный SHA (не усечён — потребитель машинный), datetime → ISO 8601,
+    None → null. `backend` в JSON не включается: это подсказка только для
+    текстового вывода, в список требуемых полей не входит.
+    """
+    payload = {
+        "repo": report.repo,
+        "branches": [
+            {
+                "branch": b.branch,
+                "ref": b.ref,
+                "indexed_sha": b.indexed_sha,
+                "updated_at": b.updated_at.isoformat() if b.updated_at else None,
+                "chunks": b.chunks,
+                "graph_nodes": b.graph_nodes,
+                "drift": b.drift,
+            }
+            for b in report.branches
+        ],
+        "overlays": [{"ref": o.ref, "chunks": o.chunks} for o in report.overlays],
+    }
+    return json.dumps(payload, ensure_ascii=False, indent=2)
 
 
 def _fmt_dt(dt: datetime | None) -> str:

--- a/tests/services/test_status.py
+++ b/tests/services/test_status.py
@@ -1,7 +1,8 @@
+import json
 from datetime import datetime
 
 import reviewer.services.status as status_mod
-from reviewer.services.status import build_status_report, OverlayStatus, render_status, RepoStatus, BranchStatus
+from reviewer.services.status import build_status_report, OverlayStatus, render_status, render_status_json, RepoStatus, BranchStatus
 from click.testing import CliRunner
 import reviewer.entrypoints.cli as cli_mod
 
@@ -91,3 +92,43 @@ def test_status_command_smoke(monkeypatch):
     assert res.exit_code == 0, res.output
     assert "Ветка main" in res.output
     assert "✓ свежо" in res.output
+
+
+def test_render_status_json_shapes_payload():
+    dt = datetime(2026, 6, 18, 14, 2)
+    rep = RepoStatus(
+        repo="a/x",
+        branches=[
+            BranchStatus("main", "base:main", "abc1234567def", dt, 1843, 1207, 0),
+            BranchStatus("dev", "base:dev", "def5678901abc", dt, 1850, None, 12),
+            BranchStatus("old", "base:old", None, None, 0, None, None),
+            BranchStatus("nogit", "base:nogit", "aaa1111222bbb", dt, 10, 5, None),
+        ],
+        overlays=[OverlayStatus("pr:24", 18)])
+    payload = json.loads(render_status_json(rep))
+    assert payload["repo"] == "a/x"
+    by = {b["branch"]: b for b in payload["branches"]}
+    assert by["main"]["drift"] == 0
+    assert by["main"]["indexed_sha"] == "abc1234567def"      # полный SHA, не усечён
+    assert by["main"]["updated_at"] == "2026-06-18T14:02:00"  # ISO 8601
+    assert by["dev"]["drift"] == 12
+    assert by["dev"]["graph_nodes"] is None                   # Neo4j недоступен → null
+    assert by["old"]["indexed_sha"] is None                   # не проиндексирована
+    assert by["old"]["updated_at"] is None
+    assert by["nogit"]["drift"] is None                       # дрейф неизвестен
+    assert payload["overlays"] == [{"ref": "pr:24", "chunks": 18}]
+
+
+def test_status_command_json(monkeypatch):
+    dt = datetime(2026, 6, 18, 14, 2)
+    rep = RepoStatus(
+        repo="a/x",
+        branches=[BranchStatus("main", "base:main", "abc1234567def", dt, 5, 3, 0)],
+        overlays=[])
+    monkeypatch.setattr(cli_mod, "build_status_report", lambda *a, **k: rep)
+    res = CliRunner().invoke(cli_mod.cli, ["status", ".", "--repo", "a/x", "--json"])
+    assert res.exit_code == 0, res.output
+    payload = json.loads(res.output)
+    assert payload["repo"] == "a/x"
+    assert payload["branches"][0]["drift"] == 0
+    assert payload["branches"][0]["indexed_sha"] == "abc1234567def"

--- a/tests/skills/test_preflight_guardrail.py
+++ b/tests/skills/test_preflight_guardrail.py
@@ -1,0 +1,20 @@
+"""Guardrail: скилы solve-task и ask проверяют свежесть base-индекса (PRI-141).
+
+solve-task — блокирующий Step 0 Preflight (drift → подтверждение → reindex,
++ sync_board прогрев корпуса задач). ask — облегчённый warn-only баннер,
+без sync_board/reindex/блокировки.
+"""
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+SOLVE = ROOT / "plugin" / "skills" / "solve-task" / "SKILL.md"
+ASK = ROOT / "plugin" / "skills" / "ask" / "SKILL.md"
+
+
+def test_solve_task_has_preflight():
+    text = SOLVE.read_text(encoding="utf-8")
+    assert "Preflight" in text                              # Step 0 добавлен
+    assert "reviewer status" in text and "--json" in text   # читает машиночитаемый статус
+    assert "drift" in text                                  # проверяет дрейф
+    assert "sync_board(" in text                            # прогрев корпуса задач
+    assert "reviewer_sync-codebase" in text                 # делегирование reindex

--- a/tests/skills/test_preflight_guardrail.py
+++ b/tests/skills/test_preflight_guardrail.py
@@ -18,3 +18,12 @@ def test_solve_task_has_preflight():
     assert "drift" in text                                  # проверяет дрейф
     assert "sync_board(" in text                            # прогрев корпуса задач
     assert "reviewer_sync-codebase" in text                 # делегирование reindex
+
+
+def test_ask_has_warn_only_freshness():
+    text = ASK.read_text(encoding="utf-8")
+    assert "--json" in text and "reviewer status" in text   # читает машиночитаемый статус
+    assert "отстаёт на" in text                             # warn-баннер про дрейф (рус.)
+    assert "reviewer_sync-codebase" in text                 # баннер указывает на reindex-скил
+    # облегчённый режим: НЕ зовёт sync_board и не реиндексирует
+    assert "sync_board(" not in text


### PR DESCRIPTION
## Задача

PRI-141 — session-less скилы (`solve-task`, `ask`) собирали контекст на base-индексе, **не проверяя его свежесть**, и молча работали по устаревшему коду. Ревью-скилы (`review-pr`/`maintainability`/`performance`) не затронуты — у них досинк уже встроен в `prepare_review`.

## Что сделано

**1. Общая инфра — `reviewer status --json`**
Новый чистый рендер `render_status_json(report)` + флаг `--json` у CLI-команды `status`. Машиночитаемый `drift`/`chunks`/`graph_nodes`/`indexed_sha`/`updated_at`/`ref` по веткам + overlays. Полный SHA, `updated_at` в ISO 8601, `None`→`null`, `backend` исключён. Текстовый путь без регрессии (early-return до `_shutil.which`).

**2. `solve-task` — Step 0 Preflight** (с подтверждением)
Проверка дрейфа через `reviewer status --branch <b> --json`: `drift>0` → показать дрейф и **спросить** переиндексацию (Да → делегирование в `/reviewer_sync-codebase`; Нет → продолжить, отметив gap). Недоступность сервисов → отчёт в стиле `sync-codebase`, **fail-open**. Прогрев корпуса задач `sync_board(...)` на старте. Reindex строго с подтверждением (бережём Voyage 3 RPM / 10K TPM).

**3. `ask` — warn-only баннер**
На первом code-вопросе сессии (опора на память разговора) при `drift>0` — одна строка-баннер. Без блокировки/авто-reindex/подтверждения/`sync_board`, fail-open.

## Тесты

- Unit на фейках: `render_status_json` (все виды веток + overlay) + CLI-smoke `--json`.
- Guard-тесты содержимого обоих скилов (`tests/skills/test_preflight_guardrail.py`).
- `ruff check` чисто на изменённых путях; `pytest -q` → **490 passed** (integration deselected; `tests/web` исключён — pre-existing отсутствие `fastapi`).

## Документы

- Спек: `docs/superpowers/specs/2026-06-20-index-freshness-preflight-design.md`
- План: `docs/superpowers/plans/2026-06-20-index-freshness-preflight.md`

## Критерии приёмки

- [x] `reviewer status --json` — валидный JSON с `drift` по веткам; unit-тест на фейках
- [x] `solve-task` Step 0: дрейф + подтверждение; Да → reindex через `sync-codebase`; недоступность → отчёт, fail-open
- [x] `solve-task`: `sync_board` на старте; ненастроенная доска → подсказка + board-less
- [x] `ask`: первый code-вопрос при `drift>0` → warn-баннер; не блокирует/не реиндексирует/не зовёт `sync_board`
- [x] Русский язык сообщений; `ruff` без новых замечаний; `pytest -q` зелёный