### PR TITLE
chore(release): версия 0.2.8

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "rag-reviewer"
-version = "0.2.7"
+version = "0.2.8"
 requires-python = ">=3.11,<3.14"
 dependencies = [
     "pydantic-settings>=2.3",


### PR DESCRIPTION
Бамп версии для релиза 0.2.8 (push в main → публикация в PyPI). Включает PRI-160 (store-first solve-task, #36) и ранее смерженные в dev #33/#34/#35.