### PR TITLE
refactor(skills): общие reference-блоки промптов ревью в _common/ (PRI-142)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -110,6 +110,7 @@ MCP-сессия (PreparedReview + ToolContext) живёт в процессе `
 - **Наблюдаемость (`reviewer/web/`)**: каждый `publish_review` пишет в Postgres итоги прогона (`review_runs`/`review_findings`, гейт `REVIEW_HISTORY`) — fail-soft. Веб-админка (FastAPI `reviewer serve` или сервис `web` в docker-compose) читает **ту же** БД.
 - **MCP-сессия живёт в процессе сервера** между `prepare_review` и `publish_review` одного PR: `_Session(prepared, ctx)` в `MCPReviewService._sessions`. При повторном `prepare_review` для того же (repo, pr) сессия перезаписывается, старый VCS-провайдер закрывается (fail-soft).
 - **Плагин** находится в `plugin/` в корне репозитория — это корень Claude Code-плагина для скилла `/rag-reviewer:reviewer_review-pr`.
+- **Общие reference-блоки промптов** вынесены в `plugin/skills/_common/` (единый источник: `findings-schema.md`, `anti-hallucination.md`, `tool-usage.md`, `branch-selection.md`). Скиллы и reference-промпты подключают их маркером `<!-- include: _common/<file>.md -->` (путь от `plugin/skills/`), который LLM-оркестратор разворачивает verbatim при сборке промпта субагента; скилл-специфичные части остаются в самих скиллах. Соответствие findings-schema ↔ `Finding` (`reviewer/vcs/base.py`) и корректность сборки промптов охраняют guard-тесты в `tests/skills/`.
 
 ## Соглашения
 

--- a/docs/superpowers/plans/2026-06-21-pri-142-common-reference-blocks.md
+++ b/docs/superpowers/plans/2026-06-21-pri-142-common-reference-blocks.md
@@ -1,0 +1,592 @@
+# Общие reference-блоки промптов ревью (PRI-142) — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Вынести 4 дублирующихся блока инструкций (findings-schema, anti-hallucination, tool-usage, branch-selection) в `plugin/skills/_common/` как единый источник правды; перевести скилы из скоупа на runtime-include.
+
+**Architecture:** Маркер `<!-- include: _common/X.md -->` в reference/SKILL заменяет вырезанный общий блок; оркестратор/скилл при сборке промпта субагента подставляет содержимое файла (путь от `plugin/skills/`). В `_common` идёт только инвариантное ядро — скилл-специфичные хвосты остаются в скиллах. Guard-тест резолвит include-маркеры и проверяет, что собранный промпт содержит все ключевые правила.
+
+**Tech Stack:** Python 3.11+, pytest (unit, `-m 'not integration'` по умолчанию), ruff (line-length 100). Скилы — markdown в `plugin/skills/`.
+
+## Global Constraints
+
+- Язык проекта — русский: комментарии/докстринги/CLI на русском. Тела скилл-промптов — на английском (токены), но скилл инструктирует отвечать пользователю по-русски.
+- Коммиты: Conventional Commits на русском, **без** self-attribution (`Co-Authored-By`/упоминаний Claude).
+- Линт: `.venv/bin/ruff check .` — line-length 100, target py311.
+- Тесты unit: `.venv/bin/pytest -q` (integration исключены `addopts = -m 'not integration'`).
+- Include-маркер: ровно `<!-- include: _common/<file>.md -->`, путь относительно `plugin/skills/`.
+- `_common/findings-schema.md` обязан по полям совпадать с `Finding` (`reviewer/vcs/base.py:30`).
+- Скоуп: НЕ трогать `sync-codebase`, `sync-tasks`.
+
+---
+
+### Task 1: Создать `plugin/skills/_common/` (4 файла) + guard-тесты контента
+
+**Files:**
+- Create: `plugin/skills/_common/findings-schema.md`
+- Create: `plugin/skills/_common/anti-hallucination.md`
+- Create: `plugin/skills/_common/tool-usage.md`
+- Create: `plugin/skills/_common/branch-selection.md`
+- Test: `tests/skills/test_common_blocks.py`
+
+**Interfaces:**
+- Consumes: `Finding` dataclass (`reviewer/vcs/base.py:30`) — поля `category, severity, file, line, side, message, suggestion, confidence, fix_start, fix_end, replacement, code_quote`.
+- Produces: 4 файла `_common/*.md`; тест-хелпер `_skills_dir()` и набор guard-проверок, на которые опираются Task 3/4.
+
+- [ ] **Step 1: Написать падающий тест контента `_common`**
+
+Create `tests/skills/test_common_blocks.py`:
+
+```python
+from pathlib import Path
+
+SKILLS_DIR = Path(__file__).resolve().parents[2] / "plugin" / "skills"
+COMMON = SKILLS_DIR / "_common"
+
+
+def _read(name: str) -> str:
+    return (COMMON / name).read_text(encoding="utf-8")
+
+
+def test_all_four_common_files_exist_nonempty():
+    for name in (
+        "findings-schema.md",
+        "anti-hallucination.md",
+        "tool-usage.md",
+        "branch-selection.md",
+    ):
+        assert (COMMON / name).is_file(), f"нет {name}"
+        assert len(_read(name).strip()) > 0, f"{name} пустой"
+
+
+def test_findings_schema_matches_finding_dataclass():
+    # Каждое публичное поле Finding должно присутствовать в схеме.
+    from reviewer.vcs.base import Finding
+    import dataclasses
+
+    schema = _read("findings-schema.md")
+    field_to_token = {
+        "category": "category",
+        "severity": "severity",
+        "file": "file",
+        "line": "line",
+        "side": "side",
+        "message": "message",
+        "suggestion": "suggestion",
+        "confidence": "confidence",
+        "code_quote": "code_quote",
+        # fix_start/fix_end/replacement сворачиваются в JSON-объект "fix"
+        "fix_start": "fix",
+        "fix_end": "fix",
+        "replacement": "replacement",
+    }
+    for f in dataclasses.fields(Finding):
+        token = field_to_token.get(f.name)
+        if token is None:
+            continue
+        assert token in schema, f"поле {f.name} (токен {token}) отсутствует в findings-schema.md"
+
+
+def test_anti_hallucination_has_core_principles():
+    text = _read("anti-hallucination.md").lower()
+    assert "code_quote" in text
+    assert "hallucinat" in text          # «a hallucinated absence is worse…»
+    assert "empty findings list" in text  # пустой список — валидный результат
+
+
+def test_tool_usage_has_both_tool_families():
+    text = _read("tool-usage.md")
+    # PR-session
+    assert "search_code" in text and "get_changed_file_diff" in text and "get_impact" in text
+    # session-less
+    assert "search_codebase" in text and "related_symbols" in text and "definition" in text
+
+
+def test_branch_selection_has_review_branches_logic():
+    text = _read("branch-selection.md")
+    assert "REVIEW_BRANCHES" in text
+    assert "git branch --show-current" in text
+```
+
+- [ ] **Step 2: Запустить тест — убедиться, что падает**
+
+Run: `.venv/bin/pytest tests/skills/test_common_blocks.py -q`
+Expected: FAIL (FileNotFoundError / каталог `_common` отсутствует).
+
+- [ ] **Step 3: Создать `_common/findings-schema.md`**
+
+```markdown
+Findings output schema (shared). The calling skill sets `category`.
+
+Return ONLY a JSON object (no prose around it):
+
+```json
+{"findings": [{
+  "category": "<set by the calling skill>",
+  "severity": "low|medium|high|critical",
+  "file": "<path of the reviewed file>",
+  "line": <line number in the NEW file, or null>,
+  "side": "RIGHT|LEFT",
+  "code_quote": "<exact line from the new file, or null when line is null>",
+  "message": "<what is wrong and why it matters>",
+  "suggestion": "<short advice or null>",
+  "fix": {"start_line": N, "end_line": M, "replacement": "<new code>"} | null,
+  "confidence": 0.0
+}]}
+```
+
+Field semantics:
+- `category` — set by the calling skill (see its own instructions).
+- `severity` — `low|medium|high|critical`.
+- `file` — path of the reviewed file.
+- `line` — line number in the NEW file, or `null` (a null line lands in the summary, not inline).
+- `side` — `RIGHT` (new version) or `LEFT` (old version).
+- `code_quote` — exact line copied verbatim from the NEW file; it grounds the line number. `null` only when `line` is null. An inaccurate quote is worse than no quote.
+- `message` / `suggestion` — written in the orchestrator's output language.
+- `fix` — exact replacement for a contiguous line range in the new file (`start_line`/`end_line`/`replacement`), or `null` when unsure.
+- `confidence` — float `0.0..1.0`; it feeds the publish gate, so be honest.
+
+Write `message` and `suggestion` in the output language given by the orchestrator.
+```
+
+- [ ] **Step 4: Создать `_common/anti-hallucination.md`**
+
+```markdown
+Anti-noise / anti-hallucination rules (shared core; follow strictly):
+
+1. Report only problems RELATED to the changed lines. Unchanged code is out of
+   scope even if imperfect.
+2. Before claiming "missing error handling / missing None check / missing
+   validation", verify through tools (`read_file` / `search_code` /
+   `search_codebase`) that the handling truly is absent — not a line above/below
+   or at the call site. A hallucinated absence is worse than a missed finding.
+3. Do not duplicate the same observation across multiple lines: one problem →
+   one finding with the most representative line.
+4. Style, naming and formatting are NOT findings unless they affect program
+   behaviour (line length, single-letter variable in a comprehension, import
+   order, etc.). Category `style` is only valid for real logic-readability
+   problems.
+5. Do not suggest refactoring for its own sake. If code works correctly and does
+   not violate its contract, do not report it.
+6. Do not invent issues to fill a quota; an empty findings list is a valid
+   result.
+
+Every finding MUST carry an exact `code_quote` — one line copied verbatim from
+the NEW version of the file. It grounds the line number; an inaccurate quote is
+worse than no quote.
+```
+
+- [ ] **Step 5: Создать `_common/tool-usage.md`**
+
+```markdown
+Tool discipline (shared):
+
+- Use tools BEFORE claiming cross-file effects.
+- Targeted search: make each tool call answer ONE specific question; do not
+  browse a file as a whole. Identical calls return cached results instantly;
+  still avoid redundant calls — each call should answer a new question. Stop
+  calling tools once you can decide.
+- If a signature or contract changes, locate all call sites and verify (via
+  `read_file` / `get_changed_file_diff`) that they stay consistent.
+
+## PR-session tools (inside `/reviewer_review-pr`)
+
+- `search_code` — usages of a symbol/string;
+- `get_related_symbols` — graph neighbours (calls / implementations / tests);
+- `find_callers` — callers impacted by a change;
+- `get_definition` — a symbol's definition;
+- `read_file` — exact source context;
+- `get_changed_file_diff` — other changed files of this PR;
+- `get_impact` — callers of a changed signature that live outside the diff.
+
+## Session-less tools (`ask` / `solve-task`, no PR session)
+
+- `search_codebase(repo, query, branch?)` — hybrid semantic+lexical search;
+- `related_symbols(repo, node_id, branch?)` — graph neighbours;
+- `callers(repo, node_id, branch?)` — direct callers (impact);
+- `definition(repo, symbol, branch?)` — where a symbol is defined.
+```
+
+- [ ] **Step 6: Создать `_common/branch-selection.md`**
+
+```markdown
+Branch selection for code search (shared):
+
+- Determine the current git branch: `git branch --show-current`.
+- If it is in `REVIEW_BRANCHES` (the tracked branches list), pass it as the
+  `branch` parameter — the search uses that branch's index.
+- If the user explicitly named a branch, use that one instead.
+- Otherwise omit `branch` entirely — the server uses the primary branch (the
+  first entry in `REVIEW_BRANCHES`).
+- Pass the same `branch` to the graph tools (`callers` / `related_symbols` /
+  `definition`) — identically (or omit it identically).
+```
+
+- [ ] **Step 7: Запустить тест — убедиться, что проходит**
+
+Run: `.venv/bin/pytest tests/skills/test_common_blocks.py -q`
+Expected: PASS (5 тестов).
+
+- [ ] **Step 8: Линт + коммит**
+
+```bash
+.venv/bin/ruff check tests/skills/test_common_blocks.py
+git add plugin/skills/_common tests/skills/test_common_blocks.py
+git commit -m "feat(skills): _common reference-блоки промптов ревью (PRI-142)"
+```
+
+---
+
+### Task 2: install — поддержка общего каталога `_common`
+
+**Files:**
+- Modify: `reviewer/install.py:34-37` (константа `SKILL_NAMES`)
+- Test: `tests/install/test_common_shared_dir.py`
+
+**Interfaces:**
+- Consumes: `extract_skills(tar_bytes, dest)` → `list[str]`; `_skill_file_hashes(skills_dir)` → `dict[str,str]` (существующие, обходят подкаталоги без требования `SKILL.md`).
+- Produces: `SKILL_NAMES` с добавленным `"_common"` (документирующая регистрация).
+
+**Контекст:** `SKILL_NAMES` нигде не читается (grep по `reviewer/`+`tests/` — только определение); распаковка/хэширование идут по обходу подкаталогов. Поэтому код менять не требуется — задача фиксирует поддержку `_common` регресс-тестом и регистрирует его в документирующей константе.
+
+- [ ] **Step 1: Написать падающий тест поддержки `_common`**
+
+Create `tests/install/test_common_shared_dir.py`:
+
+```python
+import io
+import tarfile
+
+from reviewer import install as inst
+
+
+def _tar(members: dict[str, bytes]) -> bytes:
+    buf = io.BytesIO()
+    with tarfile.open(fileobj=buf, mode="w:gz") as tf:
+        for name, data in members.items():
+            info = tarfile.TarInfo(name)
+            info.size = len(data)
+            tf.addfile(info, io.BytesIO(data))
+    return buf.getvalue()
+
+
+def test_common_dir_extracted_and_hashed(tmp_path):
+    # _common не имеет SKILL.md — проверяем, что обход подкаталогов его не теряет.
+    tar = _tar({
+        "r/plugin/skills/review-pr/SKILL.md": b"# review",
+        "r/plugin/skills/_common/findings-schema.md": b"# schema",
+    })
+    names = inst.extract_skills(tar, tmp_path)
+    assert "_common" in names
+    assert (tmp_path / "_common" / "findings-schema.md").is_file()
+
+    hashes = inst._skill_file_hashes(tmp_path)
+    assert "_common" in hashes
+    assert hashes["_common"].startswith("sha256:")
+
+
+def test_common_registered_in_skill_names():
+    assert "_common" in inst.SKILL_NAMES
+```
+
+- [ ] **Step 2: Запустить тест — убедиться, что падает**
+
+Run: `.venv/bin/pytest tests/install/test_common_shared_dir.py -q`
+Expected: `test_common_dir_extracted_and_hashed` PASS (код уже поддерживает обход), `test_common_registered_in_skill_names` FAIL (`_common` не в `SKILL_NAMES`).
+
+- [ ] **Step 3: Зарегистрировать `_common` в `SKILL_NAMES`**
+
+Modify `reviewer/install.py:34-37`:
+
+```python
+SKILL_NAMES = (
+    "review-pr", "solve-task", "sync-codebase",
+    "sync-tasks", "performance-review", "maintainability-review",
+    "_common",  # общий каталог reference-блоков (без своего SKILL.md), PRI-142
+)
+```
+
+- [ ] **Step 4: Запустить тест — убедиться, что проходит**
+
+Run: `.venv/bin/pytest tests/install/test_common_shared_dir.py -q`
+Expected: PASS (2 теста).
+
+- [ ] **Step 5: Прогнать существующие install-тесты (регресс)**
+
+Run: `.venv/bin/pytest tests/install -q`
+Expected: PASS (все — они на tmp-фикстурах, реальный `_common` их не задевает).
+
+- [ ] **Step 6: Линт + коммит**
+
+```bash
+.venv/bin/ruff check reviewer/install.py tests/install/test_common_shared_dir.py
+git add reviewer/install.py tests/install/test_common_shared_dir.py
+git commit -m "feat(install): регистрация общего каталога _common (PRI-142)"
+```
+
+---
+
+### Task 3: Перевести review-pipeline на include (analyze / requirements / blast-radius / review-pr SKILL)
+
+**Files:**
+- Modify: `plugin/skills/review-pr/references/analyze-prompt.md` (вырезать findings-схему стр.82-97, anti-noise ядро стр.18-33, tool-usage ядро стр.8-17 → маркеры)
+- Modify: `plugin/skills/review-pr/references/requirements-prompt.md` (findings-схема стр.38-53, tool-usage упоминание стр.23-25 → маркеры)
+- Modify: `plugin/skills/review-pr/references/blast-radius-prompt.md` (tool-usage → маркер; findings-схема уже ссылочная)
+- Modify: `plugin/skills/review-pr/references/verify-prompt.md` (tool-usage стр.4-5 → маркер; `verdicts`-схему НЕ трогать)
+- Modify: `plugin/skills/review-pr/SKILL.md` (шаги 3–5: инструкция резолвить include-маркеры)
+- Test: `tests/skills/test_assembled_prompts.py`
+
+**Interfaces:**
+- Consumes: `_common/{findings-schema,anti-hallucination,tool-usage}.md` (Task 1).
+- Produces: тест-хелпер `assemble(rel_path)` (резолвит `<!-- include: ... -->` от `plugin/skills/`), используемый и в Task 4.
+
+- [ ] **Step 1: Написать падающий тест сборки review-pipeline промптов**
+
+Create `tests/skills/test_assembled_prompts.py`:
+
+```python
+import re
+from pathlib import Path
+
+SKILLS_DIR = Path(__file__).resolve().parents[2] / "plugin" / "skills"
+_INCLUDE = re.compile(r"<!-- include: (\S+\.md) -->")
+
+
+def assemble(rel_path: str) -> str:
+    """Собрать промпт как оркестратор: подставить содержимое include-маркеров.
+
+    Путь в маркере — относительно plugin/skills/. Резолв нерекурсивный
+    (в _common-файлах маркеров нет).
+    """
+    text = (SKILLS_DIR / rel_path).read_text(encoding="utf-8")
+
+    def repl(m: re.Match) -> str:
+        return (SKILLS_DIR / m.group(1)).read_text(encoding="utf-8")
+
+    out = _INCLUDE.sub(repl, text)
+    assert "<!-- include:" not in out, f"неразрешённый include в {rel_path}"
+    return out
+
+
+def test_analyze_has_include_markers():
+    raw = (SKILLS_DIR / "review-pr/references/analyze-prompt.md").read_text("utf-8")
+    assert "<!-- include: _common/findings-schema.md -->" in raw
+    assert "<!-- include: _common/anti-hallucination.md -->" in raw
+    assert "<!-- include: _common/tool-usage.md -->" in raw
+
+
+def test_analyze_assembled_has_all_rules():
+    a = assemble("review-pr/references/analyze-prompt.md")
+    assert "code_quote" in a                       # из findings-schema / anti-halluc
+    assert '"confidence": 0.0' in a                # из findings-schema
+    assert "empty findings list" in a.lower()      # из anti-hallucination
+    assert "get_impact" in a                       # из tool-usage
+    # analyze-специфичный хвост остался на месте
+    assert "commentable_right" in a
+
+
+def test_requirements_assembled_has_schema_and_category():
+    r = assemble("review-pr/references/requirements-prompt.md")
+    assert '"severity": "low|medium|high|critical"' in r
+    assert "requirements" in r                     # фиксированная категория скилла
+
+
+def test_blast_radius_assembled_has_tooling_and_confidence_tail():
+    b = assemble("review-pr/references/blast-radius-prompt.md")
+    assert "get_impact" in b
+    assert "0.8" in b                              # confidence-scale хвост остался
+
+
+def test_verify_keeps_verdicts_schema_and_tools():
+    v = assemble("review-pr/references/verify-prompt.md")
+    assert '{"verdicts":' in v.replace(" ", "")    # своя схема не тронута
+    assert "find_callers" in v                      # tool-usage подставлен
+```
+
+- [ ] **Step 2: Запустить тест — убедиться, что падает**
+
+Run: `.venv/bin/pytest tests/skills/test_assembled_prompts.py -q`
+Expected: FAIL (`test_*_has_include_markers` — маркеров ещё нет).
+
+- [ ] **Step 3: Заменить блоки в `analyze-prompt.md` на маркеры**
+
+В `plugin/skills/review-pr/references/analyze-prompt.md`:
+- Строки 8-17 (tool-usage «Use tools BEFORE…» + targeted search) заменить на:
+  `<!-- include: _common/tool-usage.md -->` + строку контекста
+  `Use the PR-session tools above.`
+- Строки 18-33 (anti-noise rules 1-6) заменить на `<!-- include: _common/anti-hallucination.md -->`.
+  Строки 34-46 (line/commentable/`fix`/intent — analyze-специфика) **оставить**.
+- Строки 82-97 (JSON-схема) заменить на:
+  `<!-- include: _common/findings-schema.md -->` + строку
+  `Set "category" to one of: correctness|security|performance|maintainability|style.`
+- Блок `## Examples` (47-80) **оставить** (analyze-специфичные примеры).
+
+- [ ] **Step 4: Заменить блоки в `requirements-prompt.md` на маркеры**
+
+В `plugin/skills/review-pr/references/requirements-prompt.md`:
+- Строки 23-25 (упоминание tool-usage) заменить на `<!-- include: _common/tool-usage.md -->` + `Use the PR-session tools above.` (правила «judge only stated requirements» стр.15-22, 26-36 **оставить**).
+- Строки 38-53 (JSON-схема) заменить на `<!-- include: _common/findings-schema.md -->` + `category MUST be exactly "requirements". Set "fix" to null. "code_quote" may be null when "line" is null.`
+
+- [ ] **Step 5: Заменить tool-usage в `blast-radius-prompt.md` и `verify-prompt.md`**
+
+В `blast-radius-prompt.md`: после заголовка `Method:` добавить строку
+`<!-- include: _common/tool-usage.md -->` + `Use the PR-session tools above (especially get_impact).`
+Строки confidence-scale (20-42), anchoring (44-51) и ссылку на схему analyze (53-55) **оставить**.
+
+В `verify-prompt.md`: строки 4-5 (`Use tools (...) to verify...`) заменить на
+`<!-- include: _common/tool-usage.md -->` + `Use the PR-session tools above to verify doubtful claims — do not guess.`
+Схему `{"verdicts": [...]}` (стр.42) и правила is_real (7-22), примеры (24-41) **оставить**.
+
+- [ ] **Step 6: Обновить `review-pr/SKILL.md` — инструкция резолва include**
+
+В `plugin/skills/review-pr/SKILL.md`, в начале шага 3 (Analyze, перед списком «the contents of references/analyze-prompt.md…») добавить абзац:
+
+```markdown
+   When you read a `references/*-prompt.md` file, it may contain
+   `<!-- include: _common/<file>.md -->` markers. Before putting the prompt into
+   a subagent, replace each marker with the verbatim contents of that file
+   (path is relative to `plugin/skills/`). These `_common/*.md` files are the
+   single source of the shared findings-schema / anti-hallucination / tool-usage
+   blocks.
+```
+
+- [ ] **Step 7: Запустить тест — убедиться, что проходит**
+
+Run: `.venv/bin/pytest tests/skills/test_assembled_prompts.py -q`
+Expected: PASS (5 тестов).
+
+- [ ] **Step 8: Линт + коммит**
+
+```bash
+.venv/bin/ruff check tests/skills/test_assembled_prompts.py
+git add plugin/skills/review-pr tests/skills/test_assembled_prompts.py
+git commit -m "refactor(skills): review-pipeline промпты через _common include (PRI-142)"
+```
+
+---
+
+### Task 4: Перевести standalone-скилы на include + финальная верификация
+
+**Files:**
+- Modify: `plugin/skills/performance-review/SKILL.md` (tool-usage стр.24-26/48-49 → маркер; findings-схема стр.68-81 → маркер)
+- Modify: `plugin/skills/maintainability-review/SKILL.md` (tool-usage стр.23-26 → маркер; findings-схема стр.120-133 → маркер; «What Not To Flag» оставить)
+- Modify: `plugin/skills/ask/SKILL.md` (tool-usage стр.21-31 → session-less маркер; branch-selection стр.36-49 → маркер; grounding-contract стр.73-80 оставить)
+- Modify: `plugin/skills/solve-task/SKILL.md` (tool-usage + branch-selection блоки → маркеры)
+- Test: `tests/skills/test_assembled_prompts.py` (расширить)
+
+**Interfaces:**
+- Consumes: `_common/*.md` (Task 1); `assemble()` (Task 3).
+- Produces: финально — зелёный полный прогон `pytest -q` + `ruff check .`.
+
+- [ ] **Step 1: Дописать падающие тесты для standalone-скилов**
+
+Append to `tests/skills/test_assembled_prompts.py`:
+
+```python
+def test_performance_assembled_schema_and_goal():
+    p = assemble("performance-review/SKILL.md")
+    assert '"category": "performance"' in p or "performance" in p
+    assert '"confidence": 0.0' in p                 # из findings-schema
+    assert "N+1" in p                               # perf-специфичный хвост остался
+
+
+def test_maintainability_assembled_schema_and_whatnot():
+    m = assemble("maintainability-review/SKILL.md")
+    assert '"confidence": 0.0' in m                 # из findings-schema
+    assert "What Not To Flag" in m                  # maint-специфичный хвост остался
+
+
+def test_ask_assembled_has_sessionless_tools_and_branch():
+    a = assemble("ask/SKILL.md")
+    assert "search_codebase" in a                   # session-less tool-usage
+    assert "REVIEW_BRANCHES" in a                   # branch-selection
+    assert "Grounding contract" in a                # ask-специфичный хвост остался
+
+
+def test_solve_task_assembled_has_branch_and_tools():
+    s = assemble("solve-task/SKILL.md")
+    assert "REVIEW_BRANCHES" in s
+    assert "search_codebase" in s
+```
+
+- [ ] **Step 2: Запустить — убедиться, что падает**
+
+Run: `.venv/bin/pytest tests/skills/test_assembled_prompts.py -q`
+Expected: FAIL (4 новых теста — маркеров в standalone-скилах ещё нет).
+
+- [ ] **Step 3: `performance-review/SKILL.md` — маркеры**
+
+- Строки 24-26 («Call the reviewer MCP tools…») заменить на
+  `<!-- include: _common/tool-usage.md -->` + `Use the PR-session tools above.`
+- Строки 68-81 (JSON-схема) заменить на `<!-- include: _common/findings-schema.md -->` +
+  `Set "category" to "performance"; "side" is always "RIGHT".`
+- Goal/Method/Severity (perf-специфика, в т.ч. «N+1 queries») **оставить**.
+
+- [ ] **Step 4: `maintainability-review/SKILL.md` — маркеры**
+
+- Строки 23-26 заменить на `<!-- include: _common/tool-usage.md -->` + `Use the PR-session tools above.`
+- Строки 120-133 (JSON-схема) заменить на `<!-- include: _common/findings-schema.md -->` +
+  `Set "category" to "maintainability"; "side" is always "RIGHT".`
+- Goal/Repository Context/Method/Simplification Heuristics/**What Not To Flag**/Severity **оставить**.
+
+- [ ] **Step 5: `ask/SKILL.md` — маркеры**
+
+- Раздел `## Tools` (строки 21-31): после первой строки вставить
+  `<!-- include: _common/tool-usage.md -->` + `Use the session-less tools above.`
+  (детальные описания session-less тулов можно заменить ссылкой на блок).
+- Branch-resolution в шаге 1 (строки 36-49, часть про `branch`) заменить на
+  `<!-- include: _common/branch-selection.md -->`, оставив freshness-check (warn-banner) как ask-специфику.
+- `## Grounding contract` (73-80) **оставить**.
+
+- [ ] **Step 6: `solve-task/SKILL.md` — маркеры**
+
+- Блок «Branch selection for search_codebase» (в шаге 3) заменить на
+  `<!-- include: _common/branch-selection.md -->`.
+- Перечень session-less тулов (callers/related_symbols/definition в шаге 3) дополнить/заменить
+  на `<!-- include: _common/tool-usage.md -->` + `Use the session-less tools above.`
+- Логику пайплайна solve-task (preflight, store-first, distill) **оставить**.
+
+- [ ] **Step 7: Запустить тесты сборки — убедиться, что проходят**
+
+Run: `.venv/bin/pytest tests/skills/test_assembled_prompts.py -q`
+Expected: PASS (9 тестов всего).
+
+- [ ] **Step 8: Полный прогон unit + линт (финальная верификация)**
+
+Run: `.venv/bin/pytest -q`
+Expected: PASS (вкл. `tests/skills/`, `tests/install/`; integration исключены).
+
+Run: `.venv/bin/ruff check .`
+Expected: без новых ошибок в изменённых файлах (на main ruff не обязан быть repo-wide чист — сверять только свои файлы).
+
+- [ ] **Step 9: Золотой слепок «поведение не изменилось» (ручная сверка)**
+
+Для каждого скилла из скоупа собрать промпт `assemble(...)` и глазами/диффом сверить, что
+итоговый набор правил совпадает с версией до рефакторинга (контент тот же, только источник —
+`_common`). Зафиксировать вывод в описании PR (что собранные промпты эквивалентны по правилам).
+
+- [ ] **Step 10: Коммит**
+
+```bash
+git add plugin/skills tests/skills/test_assembled_prompts.py
+git commit -m "refactor(skills): standalone-скилы через _common include (PRI-142)"
+```
+
+---
+
+## Self-Review (выполнено автором плана)
+
+**Spec coverage:**
+- 4 файла `_common` → Task 1. ✓
+- runtime-include механизм + маркер → Task 3 (Step 6 review-pr) / Task 4. ✓
+- findings-schema ↔ Finding → Task 1 (Step 1 тест). ✓
+- install/`SKILL_NAMES` (+ авто-обход) → Task 2. ✓
+- guard-тест собранных промптов + золотой слепок → Task 3/4 (+ Task 4 Step 9). ✓
+- скоуп (review-pr/SKILL.md включён, sync-* нет; verify только tool-usage) → Task 3/4. ✓
+- existing install-тесты не сломаны → Task 2 Step 5; полный прогон → Task 4 Step 8. ✓
+
+**Placeholder scan:** код во всех code-steps реальный; нет TBD/«handle edge cases». ✓
+
+**Type consistency:** хелпер `assemble(rel_path)` определён в Task 3 и переиспользуется в Task 4 (то же имя/сигнатура). Include-маркер единого формата `<!-- include: _common/<file>.md -->` во всех задачах и в Global Constraints. `_skill_file_hashes` возвращает `dict` с префиксом `sha256:` (сверено с `tests/install/test_skills_stamp.py`). ✓
+
+**Примечание по номерам строк:** диапазоны строк указаны по состоянию на 89a0b7d; реализатор сверяет их перед правкой (файлы небольшие, блоки опознаются по тексту).

--- a/docs/superpowers/specs/2026-06-21-pri-142-common-reference-blocks-design.md
+++ b/docs/superpowers/specs/2026-06-21-pri-142-common-reference-blocks-design.md
@@ -1,0 +1,171 @@
+# PRI-142 / ID-142 — общие reference-блоки для промптов ревью
+
+**Дата:** 2026-06-21
+**Статус:** дизайн одобрен, готов к плану
+**Задача:** [PRI-142](https://ru.yougile.com/team/686c049c8af8/#PRI-142) — «Общие reference-блоки для промптов ревью (findings-schema / anti-hallucination / tools / branch-select)»
+
+## Проблема
+
+Одни и те же блоки инструкций для субагентов ревью **дублируются** по нескольким
+скилл-промптам и **дрейфят** при правках → непредсказуемое поведение ревью. Это
+**maintainability** (единый источник правды), а **не** экономия рантайм-токенов:
+субагент всё равно получает правила инлайном (иначе не сможет следовать схеме).
+
+**Карта дублирования (grep по `plugin/skills/`):**
+
+| Блок | Где дублируется (по факту чтения файлов) |
+|---|---|
+| **findings JSON-схема** | дословно (с вариацией `category`/`side`/`fix`) в `analyze-prompt.md`, `requirements-prompt.md`, `performance-review/SKILL.md`, `maintainability-review/SKILL.md`. `blast-radius-prompt.md` уже **ссылается** «schema of analyze-prompt.md»; `verify-prompt.md` имеет **свою** схему `verdicts`; `review-pr/SKILL.md` только **упоминает** схему (ссылки) |
+| **anti-hallucination / anti-noise** | общее ядро в `analyze`, `requirements`, `performance`, `maintainability`, `blast-radius`, `ask` — но у каждого свои хвосты |
+| **tool-usage** | почти везде, но **двумя разными наборами тулов**: PR-сессия (`search_code`/`get_related_symbols`/`find_callers`/`get_definition`/`read_file`/`get_changed_file_diff`/`get_impact`) vs session-less (`search_codebase`/`related_symbols`/`callers`/`definition`) у `ask`/`solve-task` |
+| **branch-selection** | реально общий лишь у `ask` и `solve-task` (git branch → `REVIEW_BRANCHES` → `branch`-param). В `review-pr/SKILL.md` `REVIEW_BRANCHES` — про **skip PR**, другой смысл, **не выносим** |
+
+**Что выяснили по коду:**
+
+- **Механизм сборки промптов** — `review-pr/SKILL.md` (шаги 3–5): оркестратор
+  **читает reference `.md` и включает verbatim** в промпт субагента (Task tool).
+  Markdown без нативного include → склейку делает LLM-оркестратор. Это точка, куда
+  встраивается чтение `_common/*.md`.
+- **Источник правды для findings-схемы** — `Finding` dataclass (`reviewer/vcs/base.py:30`:
+  `category/severity/file/line/side/message/suggestion/confidence/fix_*/code_quote`).
+  `_common/findings-schema.md` обязан ему соответствовать (иначе разойдётся с парсингом
+  в `reviewer/agent/assemble.py`).
+- **Установка скиллов** — `reviewer/install.py`:
+  - `SKILL_NAMES` (стр.34-37) — явный кортеж 6 скиллов (`ask` в нём **отсутствует** и
+    сейчас);
+  - `_unpack_skills` (стр.589) и `_skill_file_hashes` (стр.664) обходят **все**
+    подкаталоги `plugin/skills/*` → `_common/` распакуется и захэшируется автоматически,
+    но в `SKILL_NAMES` его нет (рассогласование «распаковывается, но не зарегистрирован»).
+- **Похожих задач в корпусе нет** (`search_tasks` пуст); графовые/Python-тулы нерелевантны
+  — задача про markdown-скилы.
+
+## Решение (обзор)
+
+Создать `plugin/skills/_common/` с 4 reference-файлами (только **общее ядро**) и перевести
+скилы из скоупа на **runtime-include**: оркестратор/скилы читают `_common/*.md` и склеивают
+в промпт субагента на лету. Скилл-специфичные хвосты (line-grounding, confidence-scale,
+What-Not-To-Flag, `verdicts`-схема, конкретные имена тулов) **остаются в скиллах**.
+
+### Принятые решения (брейншторм)
+
+| Развилка | Решение | Почему |
+|---|---|---|
+| Механизм единого источника | **Runtime-include** (скилы/оркестратор читают `_common/*.md` и склеивают в промпт субагента) | Настоящий single-source: правка `_common` сразу везде, без build-шага. Дистрибутив `_common` уже распаковывается install'ом. Формулировка задачи «включение при сборке субагент-промпта» прямо указывает на рантайм |
+| Гранулярность блоков | **Общее ядро в `_common` + скилл-специфичные хвосты остаются в скиллах** | Прямо защищает критерий «поведение субагентов не изменилось»: чужие правила не вливаются в промпт, где их не было. Альтернатива (полный параметризуемый блок, макс DRY) отвергнута — риск дрейфа поведения |
+| Скоуп файлов | Файлы из задачи **+ `review-pr/SKILL.md`**; `sync-codebase`/`sync-tasks` **не трогаем** | `review-pr/SKILL.md` — часть review-pipeline и тоже дублирует; у `sync-*` иной session-less набор тулов и мало общего → больше риска, меньше выгоды |
+| `verify` | **Вне** findings-схемы — у него своя `verdicts`-схема, остаётся как есть | Это не findings; общий блок ему не подходит |
+| `branch-selection` | Общий блок только для `ask` + `solve-task` | В `review-pr/SKILL.md` `REVIEW_BRANCHES` имеет другой смысл (skip PR) |
+
+## Архитектура — `plugin/skills/_common/` (4 файла)
+
+Каждый файл несёт **инвариантную часть**; скилл подставляет свою специфику/контекст.
+
+### 1. `_common/findings-schema.md`
+
+- JSON-каркас `{"findings":[{category,severity,file,line,side,code_quote,message,suggestion,fix,confidence}]}`
+  + семантика каждого поля.
+- `category` — **плейсхолдер**; скилл указывает своё значение
+  (`correctness|security|performance|maintainability|style` для analyze;
+  фиксированное `requirements`/`performance`/`maintainability`/`correctness` — для соответствующих).
+- Должен **по полям совпадать** с `Finding` (`reviewer/vcs/base.py:30`).
+- Включают: `analyze`, `requirements`, `performance`, `maintainability`
+  (`blast-radius` — через ссылку на `analyze`; `verify` — **не** включает).
+
+### 2. `_common/anti-hallucination.md`
+
+- Принципы-ядро: проверь тулами **прежде** чем заявлять об отсутствии
+  (handler/None-check/validation); галлюцинированное отсутствие хуже пропуска; один
+  дефект → один finding; стиль/нейминг — не finding, если не влияет на поведение; не
+  выдумывай ради квоты, пустой список — валидный результат; точный `code_quote`.
+- Скилл-специфичные хвосты **остаются в скиллах**: line-grounding/`commentable_*`
+  (analyze), confidence-scale + graph-completeness (blast-radius), «What Not To Flag»
+  (maintainability), grounding-contract Q&A (ask).
+- Включают: `analyze`, `requirements`, `performance`, `maintainability`, `blast-radius`, `ask`.
+
+### 3. `_common/tool-usage.md`
+
+- **Общая дисциплина поиска:** делай каждый вызов отвечающим на ОДИН вопрос; не
+  просматривай файл целиком; идентичные вызовы кэшируются; останавливайся, когда можешь
+  решить; используй тулы ПЕРЕД заявлением о кросс-файловых эффектах.
+- **Две справочные таблицы тулов** под подзаголовками: «PR-session» и «session-less».
+- Скилл одной строкой указывает свой контекст («use the PR-session tools» /
+  «use the session-less tools»). Имена тулов берутся по контексту, лишняя таблица —
+  безобидная справка.
+- Включают: все промпты из скоупа, где есть обращение к тулам — в т.ч. `verify`
+  (PR-session набор), хотя findings-схему он не включает.
+
+### 4. `_common/branch-selection.md`
+
+- `git branch --show-current` → если в `REVIEW_BRANCHES` передать как `branch`; если
+  пользователь назвал ветку — её; иначе omit (сервер берёт primary). Тот же `branch` —
+  для graph-тулов (`callers`/`related_symbols`/`definition`).
+- Включают: `ask`, `solve-task`.
+
+## Механизм включения (runtime-include)
+
+- **`review-pr/SKILL.md`** (оркестратор), шаги 3–5: инструкция «прочитай
+  `_common/{findings-schema,anti-hallucination,tool-usage}.md` один раз и включи verbatim
+  в промпт субагента вместе с `references/<dim>-prompt.md`».
+- **Standalone-скилы** (`performance`, `maintainability`, `ask`, `solve-task`): в их
+  SKILL.md — «при сборке промпта субагента / в работе включи соответствующие
+  `_common/*.md`».
+- **Reference-файлы** (`analyze`, `requirements`, `blast-radius`) и SKILL.md **худеют**:
+  вырезанный блок заменяется строкой-маркером
+  «(общий блок: `_common/X.md` — включается оркестратором)», чтобы человек видел, что блок
+  не потерян и где он теперь.
+
+## Install / staleness — `reviewer/install.py`
+
+- `_unpack_skills` (стр.589) и `_skill_file_hashes` (стр.664) уже обходят все подкаталоги →
+  `_common/` распакуется и захэшируется **автоматически**.
+- **`SKILL_NAMES` (стр.34-37):** добавить `"_common"` — иначе рассогласование
+  «распаковывается/хэшируется, но не зарегистрирован».
+- **Проверить трактовку `SKILL_NAMES`:** если где-то он используется как «список
+  вызываемых скиллов, у каждого есть `SKILL.md`» (у `_common` его нет), ввести отдельную
+  константу `SHARED_DIRS` и учитывать её в установке/штампе вместо засорения `SKILL_NAMES`.
+  Решение между «добавить в `SKILL_NAMES`» и «`SHARED_DIRS`» принять на этапе плана по
+  фактическому использованию константы.
+- `ask` отсутствует в `SKILL_NAMES` и сейчас — **вне скоупа** PRI-142 (только отметить,
+  не чинить здесь).
+
+## Тестирование / верификация «поведение не изменилось»
+
+- **Новый guard-тест** (`tests/skills/`): для каждого скилла из скоупа собрать промпт
+  «как оркестратор» (reference + включённые `_common/*.md`) и проверить, что итог содержит
+  все ключевые правила (по маркерам/фразам), а `_common/findings-schema.md` по полям
+  соответствует `Finding` (`reviewer/vcs/base.py:30`).
+- **Золотой слепок:** снять снимок собранных промптов скиллов **до** рефакторинга; после —
+  сверить смысловую эквивалентность (автоснимок в тесте + ручная диффа в PR-описании).
+- **Обновить** существующие guard-тесты установки под `_common`:
+  `tests/install/test_skills_stamp.py`, `test_skills_staleness.py`,
+  `test_install_skills_cli.py` (а также проверить `tests/skills/test_preflight_guardrail.py`,
+  `test_sync_tasks_guardrail.py` — не сломались ли от похудевших скиллов).
+- Прогон: `.venv/bin/pytest -q` (unit, integration исключены по умолчанию) + `ruff check .`.
+
+## Скоуп
+
+**В работе:** `review-pr/references/{analyze,requirements,blast-radius}-prompt.md`,
+`review-pr/SKILL.md`, `performance-review/SKILL.md`, `maintainability-review/SKILL.md`,
+`ask/SKILL.md`, `solve-task/SKILL.md`, `reviewer/install.py`, тесты.
+`verify-prompt.md` — затронут только если в нём есть общий tool-usage/anti-halluc хвост
+(findings-схему не трогаем).
+**Не трогаем:** `sync-codebase`, `sync-tasks`.
+
+## Что НЕ делаем (YAGNI / границы)
+
+- Без build-шага/генератора (выбран runtime-include).
+- Без «полного параметризуемого блока» — общее ядро + хвосты в скиллах.
+- Не выносим `verdicts`-схему verify и branch-skip-логику review-pr (другой смысл).
+- Не чиним отсутствие `ask` в `SKILL_NAMES` (вне скоупа).
+- Не трогаем `sync-codebase`/`sync-tasks`.
+
+## Инварианты / зависимости
+
+- **Критерии приёмки:** единый источник у блоков; правка правила меняет все промпты
+  разом; guard-тесты контента зелёные; поведение субагентов не изменилось.
+- `_common/findings-schema.md` ↔ `Finding` (`reviewer/vcs/base.py:30`) ↔ парсинг в
+  `reviewer/agent/assemble.py` — должны оставаться согласованными.
+- Runtime-include требует, чтобы install распространял `_common/` всем клиентам (уже
+  делает через обход подкаталогов; нужно лишь зарегистрировать в `SKILL_NAMES`/`SHARED_DIRS`).
+- Связанные работы (контекстно, прямой связи в графе нет): **PRI-160** (solve-task
+  store-first), **PRI-114** (skill staleness/stamp — затрагивает те же install-механизмы).

--- a/plugin/skills/_common/anti-hallucination.md
+++ b/plugin/skills/_common/anti-hallucination.md
@@ -1,0 +1,22 @@
+Anti-noise / anti-hallucination rules (shared core; follow strictly):
+
+1. Report only problems RELATED to the changed lines. Unchanged code is out of
+   scope even if imperfect.
+2. Before claiming "missing error handling / missing None check / missing
+   validation", verify through tools (`read_file` / `search_code` /
+   `search_codebase`) that the handling truly is absent — not a line above/below
+   or at the call site. A hallucinated absence is worse than a missed finding.
+3. Do not duplicate the same observation across multiple lines: one problem →
+   one finding with the most representative line.
+4. Style, naming and formatting are NOT findings unless they affect program
+   behaviour (line length, single-letter variable in a comprehension, import
+   order, etc.). Category `style` is only valid for real logic-readability
+   problems.
+5. Do not suggest refactoring for its own sake. If code works correctly and does
+   not violate its contract, do not report it.
+6. Do not invent issues to fill a quota; an empty findings list is a valid
+   result.
+
+Every finding MUST carry an exact `code_quote` — one line copied verbatim from
+the NEW version of the file. It grounds the line number; an inaccurate quote is
+worse than no quote.

--- a/plugin/skills/_common/branch-selection.md
+++ b/plugin/skills/_common/branch-selection.md
@@ -1,0 +1,10 @@
+Branch selection for code search (shared):
+
+- Determine the current git branch: `git branch --show-current`.
+- If it is in `REVIEW_BRANCHES` (the tracked branches list), pass it as the
+  `branch` parameter — the search uses that branch's index.
+- If the user explicitly named a branch, use that one instead.
+- Otherwise omit `branch` entirely — the server uses the primary branch (the
+  first entry in `REVIEW_BRANCHES`).
+- Pass the same `branch` to the graph tools (`callers` / `related_symbols` /
+  `definition`) — identically (or omit it identically).

--- a/plugin/skills/_common/findings-schema.md
+++ b/plugin/skills/_common/findings-schema.md
@@ -1,0 +1,31 @@
+Findings output schema (shared). The calling skill sets `category`.
+
+Return ONLY a JSON object (no prose around it):
+
+```json
+{"findings": [{
+  "category": "<set by the calling skill>",
+  "severity": "low|medium|high|critical",
+  "file": "<path of the reviewed file>",
+  "line": <line number in the NEW file, or null>,
+  "side": "RIGHT|LEFT",
+  "code_quote": "<exact line from the new file, or null when line is null>",
+  "message": "<what is wrong and why it matters>",
+  "suggestion": "<short advice or null>",
+  "fix": {"start_line": N, "end_line": M, "replacement": "<new code>"} | null,
+  "confidence": 0.0
+}]}
+```
+
+Field semantics:
+- `category` — set by the calling skill (see its own instructions).
+- `severity` — `low|medium|high|critical`.
+- `file` — path of the reviewed file.
+- `line` — line number in the NEW file, or `null` (a null line lands in the summary, not inline).
+- `side` — `RIGHT` (new version) or `LEFT` (old version).
+- `code_quote` — exact line copied verbatim from the NEW file; it grounds the line number. `null` only when `line` is null. An inaccurate quote is worse than no quote.
+- `message` / `suggestion` — written in the orchestrator's output language.
+- `fix` — exact replacement for a contiguous line range in the new file (`start_line`/`end_line`/`replacement`), or `null` when unsure.
+- `confidence` — float `0.0..1.0`; it feeds the publish gate, so be honest.
+
+Write `message` and `suggestion` in the output language given by the orchestrator.

--- a/plugin/skills/_common/tool-usage.md
+++ b/plugin/skills/_common/tool-usage.md
@@ -1,0 +1,26 @@
+Tool discipline (shared):
+
+- Use tools BEFORE claiming cross-file effects.
+- Targeted search: make each tool call answer ONE specific question; do not
+  browse a file as a whole. Identical calls return cached results instantly;
+  still avoid redundant calls — each call should answer a new question. Stop
+  calling tools once you can decide.
+- If a signature or contract changes, locate all call sites and verify (via
+  `read_file` / `get_changed_file_diff`) that they stay consistent.
+
+## PR-session tools (inside `/reviewer_review-pr`)
+
+- `search_code` — usages of a symbol/string;
+- `get_related_symbols` — graph neighbours (calls / implementations / tests);
+- `find_callers` — callers impacted by a change;
+- `get_definition` — a symbol's definition;
+- `read_file` — exact source context;
+- `get_changed_file_diff` — other changed files of this PR;
+- `get_impact` — callers of a changed signature that live outside the diff.
+
+## Session-less tools (`ask` / `solve-task`, no PR session)
+
+- `search_codebase(repo, query, branch?)` — hybrid semantic+lexical search;
+- `related_symbols(repo, node_id, branch?)` — graph neighbours;
+- `callers(repo, node_id, branch?)` — direct callers (impact);
+- `definition(repo, symbol, branch?)` — where a symbol is defined.

--- a/plugin/skills/_common/tool-usage.md
+++ b/plugin/skills/_common/tool-usage.md
@@ -5,8 +5,8 @@ Tool discipline (shared):
   browse a file as a whole. Identical calls return cached results instantly;
   still avoid redundant calls — each call should answer a new question. Stop
   calling tools once you can decide.
-- If a signature or contract changes, locate all call sites and verify (via
-  `read_file` / `get_changed_file_diff`) that they stay consistent.
+- If a signature or contract changes, use `find_callers` to locate all call
+  sites and verify with `read_file` / `get_changed_file_diff` that they stay consistent.
 
 ## PR-session tools (inside `/reviewer_review-pr`)
 

--- a/plugin/skills/ask/SKILL.md
+++ b/plugin/skills/ask/SKILL.md
@@ -19,13 +19,8 @@ Tool calls, code identifiers, and `path:line` citations stay verbatim.
 
 ## Tools
 
-Session-less reviewer MCP tools (no PR / `prepare_review` needed):
-- `search_codebase(repo, query, top_k?, branch?)` — hybrid semantic+lexical search; already
-  includes 1-hop graph expansion + rerank. Returns chunks headed by `path#fqn (path:start-end)`.
-- `related_symbols(repo, node_id, branch?)` — graph neighbors (calls/implements/tests) of a
-  `node_id` ('path#fqn').
-- `callers(repo, node_id, branch?)` — direct callers of a `node_id` (impact).
-- `definition(repo, symbol, branch?)` — where a symbol is defined + its source.
+<!-- include: _common/tool-usage.md -->
+Use the session-less tools above.
 
 Plus the harness file tools (`Read`, `Grep`, `Glob`) to read source from the local clone on disk.
 
@@ -34,8 +29,9 @@ Plus the harness file tools (`Read`, `Grep`, `Glob`) to read source from the loc
 1. **Resolve repo/branch.**
    - `repo`: `git remote get-url origin` → strip a trailing `.git`, take the last two path
      segments (`owner/name`). Pass `""` to let the server use `DEFAULT_REPO` if origin is missing.
-   - `branch`: `git branch --show-current`. Pass it only if it is in `REVIEW_BRANCHES`; if the
-     user named a branch, use that; otherwise omit it (the server uses the primary branch).
+   - `branch`:
+
+<!-- include: _common/branch-selection.md -->
 
    **Freshness check (first code question of the session only).** After resolving repo/branch and
    ONLY on the first code question in this conversation — rely on conversation memory: if you have

--- a/plugin/skills/maintainability-review/SKILL.md
+++ b/plugin/skills/maintainability-review/SKILL.md
@@ -21,9 +21,10 @@ Do not pick a scope yourself unless the user already made it clear. If the
 resulting diff is empty, stop and say there is nothing to review.
 
 Inside `/reviewer_review-pr`: the orchestrator provides the diffs of all units (path + patch)
-— review those. Call the reviewer MCP tools as needed (`search_code`,
-`get_related_symbols`, `read_file`, `get_definition`, `find_callers`,
-`get_changed_file_diff`) to check repository context and verify findings.
+— review those.
+
+<!-- include: _common/tool-usage.md -->
+Use the PR-session tools above.
 
 ## Goal
 
@@ -117,20 +118,8 @@ Return only actionable findings.
 Return ONLY the findings JSON used by the review pipeline, with
 `"category": "maintainability"`:
 
-```json
-{"findings": [{
-  "category": "maintainability",
-  "severity": "low|medium|high|critical",
-  "file": "<path of the reviewed file>",
-  "line": <line number in the NEW file or null>,
-  "side": "RIGHT",
-  "code_quote": "<exact line from the new file>",
-  "message": "<what increases maintenance cost or conflicts with project practice>",
-  "suggestion": "<concrete simpler alternative that preserves behavior, or null>",
-  "fix": {"start_line": N, "end_line": M, "replacement": "<new code>"} | null,
-  "confidence": 0.0
-}]}
-```
+<!-- include: _common/findings-schema.md -->
+Set "category" to "maintainability"; "side" is always "RIGHT".
 
 The `suggestion` field replaces what in the original Codex format appeared after
 `Simplification:` — put the concrete simplifying alternative there.

--- a/plugin/skills/performance-review/SKILL.md
+++ b/plugin/skills/performance-review/SKILL.md
@@ -21,9 +21,10 @@ Do not pick a scope yourself unless the user already made it clear. If the
 resulting diff is empty, stop and say there is nothing to review.
 
 Inside `/reviewer_review-pr`: the orchestrator provides the diffs of all units (path + patch)
-— review those. Call the reviewer MCP tools as needed (`search_code`,
-`get_related_symbols`, `read_file`, `get_definition`, `find_callers`,
-`get_changed_file_diff`) to verify whether a path is truly performance-sensitive.
+— review those.
+
+<!-- include: _common/tool-usage.md -->
+Use the PR-session tools above.
 
 ## Goal
 
@@ -65,20 +66,8 @@ Return only actionable findings.
 Return ONLY the findings JSON used by the review pipeline, with
 `"category": "performance"`:
 
-```json
-{"findings": [{
-  "category": "performance",
-  "severity": "low|medium|high|critical",
-  "file": "<path of the reviewed file>",
-  "line": <line number in the NEW file or null>,
-  "side": "RIGHT",
-  "code_quote": "<exact line from the new file>",
-  "message": "<what is wrong and why it matters>",
-  "suggestion": "<short advice or null>",
-  "fix": {"start_line": N, "end_line": M, "replacement": "<new code>"} | null,
-  "confidence": 0.0
-}]}
-```
+<!-- include: _common/findings-schema.md -->
+Set "category" to "performance"; "side" is always "RIGHT".
 
 Standalone runs may additionally render the findings as a readable list after the JSON.
 

--- a/plugin/skills/review-pr/SKILL.md
+++ b/plugin/skills/review-pr/SKILL.md
@@ -53,9 +53,16 @@ of posting.
    dimension in step 4. All of this is best-effort: if `index_task`/`get_task_context`/`search_tasks`
    return a "(… unavailable)" note or error, continue — never abort the review.
 
-3. **Analyze (fan-out).** For each unit in `units`, dispatch a subagent (Task tool,
+3. **Analyze (fan-out).** When you read a `references/*-prompt.md` file, it may contain
+   `<!-- include: _common/<file>.md -->` markers. Before putting the prompt into
+   a subagent, replace each marker with the verbatim contents of that file
+   (path is relative to `plugin/skills/`). These `_common/*.md` files are the
+   single source of the shared findings-schema / anti-hallucination / tool-usage
+   blocks.
+
+   For each unit in `units`, dispatch a subagent (Task tool,
    run independent subagents in parallel; batch units if there are more than ~10) with:
-   - the contents of `references/analyze-prompt.md` (read it once, include verbatim);
+   - the contents of `references/analyze-prompt.md` (read it once, resolve includes, include verbatim);
    - the unit's `path`, `patch`, `commentable_right` (sorted list of new-file line numbers
      available for inline), `commentable_left` (sorted list of old-file line numbers available
      for inline), and the PR `title`/`body`;

--- a/plugin/skills/review-pr/SKILL.md
+++ b/plugin/skills/review-pr/SKILL.md
@@ -15,6 +15,15 @@ Parse from $ARGUMENTS: target PR as `owner/repo#N`, `owner/repo N`, or a GitHub 
 `--dry-run` flag → pass `dry_run=true` to publish_review and show the report instead
 of posting.
 
+**Include resolution (applies to all steps below).** When you read any
+`references/*-prompt.md` file to dispatch a subagent (steps 3, 4, and 5 —
+analyze, requirements, blast-radius, verify), it may contain
+`<!-- include: _common/<file>.md -->` markers. Before putting the prompt into
+the subagent, replace each marker with the verbatim contents of that file
+(path is relative to `plugin/skills/`). These `_common/*.md` files are the
+single source of the shared findings-schema / anti-hallucination / tool-usage
+blocks.
+
 ## Pipeline
 
 1. **Prepare.** Call `prepare_review(repo, pr)`. The payload contains:
@@ -53,14 +62,7 @@ of posting.
    dimension in step 4. All of this is best-effort: if `index_task`/`get_task_context`/`search_tasks`
    return a "(… unavailable)" note or error, continue — never abort the review.
 
-3. **Analyze (fan-out).** When you read a `references/*-prompt.md` file, it may contain
-   `<!-- include: _common/<file>.md -->` markers. Before putting the prompt into
-   a subagent, replace each marker with the verbatim contents of that file
-   (path is relative to `plugin/skills/`). These `_common/*.md` files are the
-   single source of the shared findings-schema / anti-hallucination / tool-usage
-   blocks.
-
-   For each unit in `units`, dispatch a subagent (Task tool,
+3. **Analyze (fan-out).** For each unit in `units`, dispatch a subagent (Task tool,
    run independent subagents in parallel; batch units if there are more than ~10) with:
    - the contents of `references/analyze-prompt.md` (read it once, resolve includes, include verbatim);
    - the unit's `path`, `patch`, `commentable_right` (sorted list of new-file line numbers

--- a/plugin/skills/review-pr/references/analyze-prompt.md
+++ b/plugin/skills/review-pr/references/analyze-prompt.md
@@ -5,32 +5,9 @@ Rules:
   Pre-existing issues in untouched code are out of scope.
 - Report only real problems: bugs, edge cases, security issues, broken
   contracts, cross-file inconsistencies.
-- Use tools BEFORE claiming cross-file effects: `search_code` for usages,
-  `get_related_symbols` / `find_callers` for impacted callers, `get_definition`
-  for a symbol's definition, `read_file` for exact context,
-  `get_changed_file_diff` for other files of this PR.
-  If a signature or contract changes, use `find_callers` to locate all call sites
-  and verify with `read_file` / `get_changed_file_diff` that they are consistent.
-- Targeted search: make each tool call answer ONE specific question about the
-  diff; do not browse the file as a whole. Identical calls return cached results
-  instantly; still avoid redundant calls — make each call answer a new question.
-  Stop calling tools once you can decide.
-- Anti-noise rules (follow strictly):
-  1. Only report problems RELATED to the changed lines. Unchanged code is out of
-     scope even if imperfect.
-  2. Before claiming "missing error handling / missing None check / missing
-     validation", verify through `read_file` or `search_code` that the handling
-     truly is absent — not a line above/below or at the call site. A hallucinated
-     absence is worse than a missed finding.
-  3. Do not duplicate the same observation across multiple lines: one problem →
-     one finding with the most representative line.
-  4. Style, naming and formatting are NOT findings unless they affect program
-     behaviour (line length, single-letter variable in a comprehension, import
-     order, etc.). Category `style` is only valid for real logic-readability
-     problems.
-  5. Do not suggest refactoring for its own sake. If code works correctly and
-     does not violate its contract, do not report it.
-  6. Do not invent issues to fill quota; an empty findings list is a valid result.
+<!-- include: _common/tool-usage.md -->
+Use the PR-session tools above.
+<!-- include: _common/anti-hallucination.md -->
 - Every finding MUST carry an exact `code_quote` — one line copied verbatim from
   the NEW version of the file. It is used to ground the line number; an
   inaccurate quote is worse than no quote.
@@ -79,21 +56,5 @@ result = [x for x in items if x > 0]
 Action: do NOT report "variable `x` is too short" or "line exceeds 79 chars" —
 these are stylistic preferences with no behavioural impact.
 
-Return ONLY a JSON object (no prose around it):
-
-```json
-{"findings": [{
-  "category": "correctness|security|performance|maintainability|style",
-  "severity": "low|medium|high|critical",
-  "file": "<path of the reviewed file>",
-  "line": <line number in the NEW file or null>,
-  "side": "RIGHT|LEFT",
-  "code_quote": "<exact line from the new file>",
-  "message": "<what is wrong and why it matters>",
-  "suggestion": "<short advice or null>",
-  "fix": {"start_line": N, "end_line": M, "replacement": "<new code>"} | null,
-  "confidence": 0.0
-}]}
-```
-
-Write `message` and `suggestion` in the output language given by the orchestrator.
+<!-- include: _common/findings-schema.md -->
+Set "category" to one of: correctness|security|performance|maintainability|style.

--- a/plugin/skills/review-pr/references/blast-radius-prompt.md
+++ b/plugin/skills/review-pr/references/blast-radius-prompt.md
@@ -4,6 +4,8 @@ contract breaks that per-file review misses. A changed function signature can br
 its callers in OTHER files that the diff never touched.
 
 Method:
+<!-- include: _common/tool-usage.md -->
+Use the PR-session tools above (especially get_impact).
 - Call `get_impact(repo, pr)` ONCE. It returns, for each symbol whose signature
   actually changed (gated base-vs-head), the old/new signature and the callers that
   live OUTSIDE the diff (`path:line` of the calling symbol + its header).

--- a/plugin/skills/review-pr/references/requirements-prompt.md
+++ b/plugin/skills/review-pr/references/requirements-prompt.md
@@ -20,9 +20,11 @@ Rules:
   with how linked/similar tasks were implemented. Never invent a requirement that exists only in the
   related context and not in this task's `description`/`criteria`.
 - The diffs are the source of truth for what the PR does. Before claiming a requirement is "not
-  implemented", use the reviewer MCP tools (`search_code`, `find_callers`, `read_file`,
-  `get_definition`, `get_changed_file_diff`) to verify it is not implemented elsewhere in the
+  implemented", use the reviewer MCP tools to verify it is not implemented elsewhere in the
   change or already present in the codebase. A hallucinated gap is worse than a missed one.
+
+<!-- include: _common/tool-usage.md -->
+Use the PR-session tools above.
 - One requirement → at most one finding. Do not split the same gap across lines.
 - Report a finding when the PR fails a requirement, contradicts it, or implements it in a way that
   breaks the stated intent.
@@ -35,22 +37,5 @@ Rules:
 - An empty findings list is a valid result (the PR satisfies the task). Do not invent findings to
   fill a quota.
 
-Return ONLY a JSON object (no prose around it):
-
-```json
-{"findings": [{
-  "category": "requirements",
-  "severity": "low|medium|high|critical",
-  "file": "<a changed file path most relevant to the requirement>",
-  "line": <line number in the NEW file, or null>,
-  "side": "RIGHT|LEFT",
-  "code_quote": "<exact line from the new file, or null when line is null>",
-  "message": "<which requirement is unmet/contradicted and why it matters>",
-  "suggestion": "<short advice or null>",
-  "fix": null,
-  "confidence": 0.0
-}]}
-```
-
-`category` MUST be exactly `"requirements"`. Write `message` and `suggestion` in the output
-language given by the orchestrator.
+<!-- include: _common/findings-schema.md -->
+category MUST be exactly "requirements". Set "fix" to null. "code_quote" may be null when "line" is null.

--- a/plugin/skills/review-pr/references/verify-prompt.md
+++ b/plugin/skills/review-pr/references/verify-prompt.md
@@ -1,8 +1,8 @@
 You are a skeptical review verifier. Input: a numbered list of candidate findings
 and the PR diffs. Your job is to kill FALSE POSITIVES, not to find new issues.
 
-Use tools (`read_file`, `find_callers`, `get_definition`, `search_code`, `get_impact`) to verify
-doubtful claims against the actual code — do not guess.
+<!-- include: _common/tool-usage.md -->
+Use the PR-session tools above to verify doubtful claims — do not guess.
 
 For each finding decide `is_real`:
 

--- a/plugin/skills/solve-task/SKILL.md
+++ b/plugin/skills/solve-task/SKILL.md
@@ -81,23 +81,21 @@ brief to `superpowers:brainstorming` (which leads to writing-plans → subagent-
      mimic).
    - **Deepen via the code graph (optional — when `search_codebase` surfaced concrete symbols).**
      `search_codebase` chunks are headed by `path#fqn (path:start-end)`; feed those `node_id`s to the
-     session-less graph tools to sharpen the brief:
-
-<!-- include: _common/tool-usage.md -->
-Use the session-less tools above.
-
-     - **Lazy PR diff (optional).** `get_task_context` surfaces a task and its PRs (id form
-       `owner/name#N`); `search_tasks` surfaces similar task keys — fetch a key's context to see
-       its PRs. If a related task passed the relevance filter AND its PR is worth inspecting for
-       the implementation, parse `repo`/`number` from the PR id and call `get_pr_diff(repo, number)`
-       to see what that PR changed — pull it lazily, only when the LLM judges it useful (don't
-       fetch diffs for low-relevance tasks).
-       Fail-open: a `(diff PR недоступен)` / `(repo не задан…)` note is non-fatal — continue.
-     `search_codebase` now returns deduplicated, line-numbered, test-free snippets — keep using the
-     graph tools for blast radius, but expand only the few symbols central to the task, and cite
+     session-less graph tools to sharpen the brief. `search_codebase` now returns deduplicated,
+     line-numbered, test-free snippets — expand only the few symbols central to the task, and cite
      `path:line` from the line-numbered snippets directly (no re-Read needed for grounding).
      Pass the same `branch` you pass to `search_codebase`.
      Fail-open: a `(граф недоступен)` / `(нет связей)` / `(вызовов не найдено)` note is non-fatal — continue.
+   - **Lazy PR diff (optional).** `get_task_context` surfaces a task and its PRs (id form
+     `owner/name#N`); `search_tasks` surfaces similar task keys — fetch a key's context to see
+     its PRs. If a related task passed the relevance filter AND its PR is worth inspecting for
+     the implementation, parse `repo`/`number` from the PR id and call `get_pr_diff(repo, number)`
+     to see what that PR changed — pull it lazily, only when the LLM judges it useful (don't
+     fetch diffs for low-relevance tasks).
+     Fail-open: a `(diff PR недоступен)` / `(repo не задан…)` note is non-fatal — continue.
+
+<!-- include: _common/tool-usage.md -->
+Use the session-less tools above.
 
    **Branch selection for `search_codebase`.**
 

--- a/plugin/skills/solve-task/SKILL.md
+++ b/plugin/skills/solve-task/SKILL.md
@@ -82,9 +82,10 @@ brief to `superpowers:brainstorming` (which leads to writing-plans → subagent-
    - **Deepen via the code graph (optional — when `search_codebase` surfaced concrete symbols).**
      `search_codebase` chunks are headed by `path#fqn (path:start-end)`; feed those `node_id`s to the
      session-less graph tools to sharpen the brief:
-     - `callers(repo, node_id, branch?)` → who depends on the code you would change (blast radius — what not to break);
-     - `related_symbols(repo, node_id, branch?)` → neighbors (calls / implementations / tests) to touch or mimic;
-     - `definition(repo, symbol, branch?)` → exact source of a symbol to follow as a pattern.
+
+<!-- include: _common/tool-usage.md -->
+Use the session-less tools above.
+
      - **Lazy PR diff (optional).** `get_task_context` surfaces a task and its PRs (id form
        `owner/name#N`); `search_tasks` surfaces similar task keys — fetch a key's context to see
        its PRs. If a related task passed the relevance filter AND its PR is worth inspecting for
@@ -98,13 +99,9 @@ brief to `superpowers:brainstorming` (which leads to writing-plans → subagent-
      Pass the same `branch` you pass to `search_codebase`.
      Fail-open: a `(граф недоступен)` / `(нет связей)` / `(вызовов не найдено)` note is non-fatal — continue.
 
-   **Branch selection for `search_codebase`.** Before calling `search_codebase`, determine the
-   current git branch of the project: `git branch --show-current`. If it is in `REVIEW_BRANCHES`
-   (the tracked branches list), pass it as the `branch` parameter — the search will use that
-   branch's index. If the user explicitly stated which branch to work from, use that branch instead.
-   Otherwise, omit `branch` entirely and the server will use the primary branch (the first entry in
-   `REVIEW_BRANCHES`).
-   The same branch applies to `callers` / `related_symbols` / `definition` — pass it (or omit it) identically.
+   **Branch selection for `search_codebase`.**
+
+<!-- include: _common/branch-selection.md -->
 
 4. **Distill the solution brief.** Write a structured markdown brief. Apply a strict relevance
    filter: include an item ONLY if it directly informs the implementation; drop the rest and note how

--- a/reviewer/install.py
+++ b/reviewer/install.py
@@ -34,6 +34,7 @@ SKILLS_TARBALL = "https://github.com/mimfort/rag_for_git/archive/refs/heads/main
 SKILL_NAMES = (
     "review-pr", "solve-task", "sync-codebase",
     "sync-tasks", "performance-review", "maintainability-review",
+    "_common",  # общий каталог reference-блоков (без своего SKILL.md), PRI-142
 )
 
 # Шаблон .env (встроен, чтобы `reviewer init` работал из published-wheel без

--- a/tests/install/test_common_shared_dir.py
+++ b/tests/install/test_common_shared_dir.py
@@ -1,0 +1,33 @@
+import io
+import tarfile
+
+from reviewer import install as inst
+
+
+def _tar(members: dict[str, bytes]) -> bytes:
+    buf = io.BytesIO()
+    with tarfile.open(fileobj=buf, mode="w:gz") as tf:
+        for name, data in members.items():
+            info = tarfile.TarInfo(name)
+            info.size = len(data)
+            tf.addfile(info, io.BytesIO(data))
+    return buf.getvalue()
+
+
+def test_common_dir_extracted_and_hashed(tmp_path):
+    # _common не имеет SKILL.md — проверяем, что обход подкаталогов его не теряет.
+    tar = _tar({
+        "r/plugin/skills/review-pr/SKILL.md": b"# review",
+        "r/plugin/skills/_common/findings-schema.md": b"# schema",
+    })
+    names = inst.extract_skills(tar, tmp_path)
+    assert "_common" in names
+    assert (tmp_path / "_common" / "findings-schema.md").is_file()
+
+    hashes = inst._skill_file_hashes(tmp_path)
+    assert "_common" in hashes
+    assert hashes["_common"].startswith("sha256:")
+
+
+def test_common_registered_in_skill_names():
+    assert "_common" in inst.SKILL_NAMES

--- a/tests/skills/test_assembled_prompts.py
+++ b/tests/skills/test_assembled_prompts.py
@@ -54,3 +54,29 @@ def test_verify_keeps_verdicts_schema_and_tools():
     v = assemble("review-pr/references/verify-prompt.md")
     assert '{"verdicts":' in v.replace(" ", "")    # своя схема не тронута
     assert "find_callers" in v                      # tool-usage подставлен
+
+
+def test_performance_assembled_schema_and_goal():
+    p = assemble("performance-review/SKILL.md")
+    assert '"category": "performance"' in p or "performance" in p
+    assert '"confidence": 0.0' in p                 # из findings-schema
+    assert "N+1" in p                               # perf-специфичный хвост остался
+
+
+def test_maintainability_assembled_schema_and_whatnot():
+    m = assemble("maintainability-review/SKILL.md")
+    assert '"confidence": 0.0' in m                 # из findings-schema
+    assert "What Not To Flag" in m                  # maint-специфичный хвост остался
+
+
+def test_ask_assembled_has_sessionless_tools_and_branch():
+    a = assemble("ask/SKILL.md")
+    assert "search_codebase" in a                   # session-less tool-usage
+    assert "REVIEW_BRANCHES" in a                   # branch-selection
+    assert "Grounding contract" in a                # ask-специфичный хвост остался
+
+
+def test_solve_task_assembled_has_branch_and_tools():
+    s = assemble("solve-task/SKILL.md")
+    assert "REVIEW_BRANCHES" in s
+    assert "search_codebase" in s

--- a/tests/skills/test_assembled_prompts.py
+++ b/tests/skills/test_assembled_prompts.py
@@ -1,0 +1,56 @@
+import re
+from pathlib import Path
+
+SKILLS_DIR = Path(__file__).resolve().parents[2] / "plugin" / "skills"
+_INCLUDE = re.compile(r"<!-- include: (\S+\.md) -->")
+
+
+def assemble(rel_path: str) -> str:
+    """Собрать промпт как оркестратор: подставить содержимое include-маркеров.
+
+    Путь в маркере — относительно plugin/skills/. Резолв нерекурсивный
+    (в _common-файлах маркеров нет).
+    """
+    text = (SKILLS_DIR / rel_path).read_text(encoding="utf-8")
+
+    def repl(m: re.Match) -> str:
+        return (SKILLS_DIR / m.group(1)).read_text(encoding="utf-8")
+
+    out = _INCLUDE.sub(repl, text)
+    assert "<!-- include:" not in out, f"неразрешённый include в {rel_path}"
+    return out
+
+
+def test_analyze_has_include_markers():
+    raw = (SKILLS_DIR / "review-pr/references/analyze-prompt.md").read_text("utf-8")
+    assert "<!-- include: _common/findings-schema.md -->" in raw
+    assert "<!-- include: _common/anti-hallucination.md -->" in raw
+    assert "<!-- include: _common/tool-usage.md -->" in raw
+
+
+def test_analyze_assembled_has_all_rules():
+    a = assemble("review-pr/references/analyze-prompt.md")
+    assert "code_quote" in a                       # из findings-schema / anti-halluc
+    assert '"confidence": 0.0' in a                # из findings-schema
+    assert "empty findings list" in a.lower()      # из anti-hallucination
+    assert "get_impact" in a                       # из tool-usage
+    # analyze-специфичный хвост остался на месте
+    assert "commentable_right" in a
+
+
+def test_requirements_assembled_has_schema_and_category():
+    r = assemble("review-pr/references/requirements-prompt.md")
+    assert '"severity": "low|medium|high|critical"' in r
+    assert "requirements" in r                     # фиксированная категория скилла
+
+
+def test_blast_radius_assembled_has_tooling_and_confidence_tail():
+    b = assemble("review-pr/references/blast-radius-prompt.md")
+    assert "get_impact" in b
+    assert "0.8" in b                              # confidence-scale хвост остался
+
+
+def test_verify_keeps_verdicts_schema_and_tools():
+    v = assemble("review-pr/references/verify-prompt.md")
+    assert '{"verdicts":' in v.replace(" ", "")    # своя схема не тронута
+    assert "find_callers" in v                      # tool-usage подставлен

--- a/tests/skills/test_assembled_prompts.py
+++ b/tests/skills/test_assembled_prompts.py
@@ -41,7 +41,7 @@ def test_analyze_assembled_has_all_rules():
 def test_requirements_assembled_has_schema_and_category():
     r = assemble("review-pr/references/requirements-prompt.md")
     assert '"severity": "low|medium|high|critical"' in r
-    assert "requirements" in r                     # фиксированная категория скилла
+    assert 'category MUST be exactly "requirements"' in r  # фиксированная категория скилла
 
 
 def test_blast_radius_assembled_has_tooling_and_confidence_tail():

--- a/tests/skills/test_assembled_prompts.py
+++ b/tests/skills/test_assembled_prompts.py
@@ -58,7 +58,7 @@ def test_verify_keeps_verdicts_schema_and_tools():
 
 def test_performance_assembled_schema_and_goal():
     p = assemble("performance-review/SKILL.md")
-    assert '"category": "performance"' in p or "performance" in p
+    assert '"category": "performance"' in p
     assert '"confidence": 0.0' in p                 # из findings-schema
     assert "N+1" in p                               # perf-специфичный хвост остался
 

--- a/tests/skills/test_common_blocks.py
+++ b/tests/skills/test_common_blocks.py
@@ -1,0 +1,68 @@
+from pathlib import Path
+
+SKILLS_DIR = Path(__file__).resolve().parents[2] / "plugin" / "skills"
+COMMON = SKILLS_DIR / "_common"
+
+
+def _read(name: str) -> str:
+    return (COMMON / name).read_text(encoding="utf-8")
+
+
+def test_all_four_common_files_exist_nonempty():
+    for name in (
+        "findings-schema.md",
+        "anti-hallucination.md",
+        "tool-usage.md",
+        "branch-selection.md",
+    ):
+        assert (COMMON / name).is_file(), f"нет {name}"
+        assert len(_read(name).strip()) > 0, f"{name} пустой"
+
+
+def test_findings_schema_matches_finding_dataclass():
+    # Каждое публичное поле Finding должно присутствовать в схеме.
+    from reviewer.vcs.base import Finding
+    import dataclasses
+
+    schema = _read("findings-schema.md")
+    field_to_token = {
+        "category": "category",
+        "severity": "severity",
+        "file": "file",
+        "line": "line",
+        "side": "side",
+        "message": "message",
+        "suggestion": "suggestion",
+        "confidence": "confidence",
+        "code_quote": "code_quote",
+        # fix_start/fix_end/replacement сворачиваются в JSON-объект "fix"
+        "fix_start": "fix",
+        "fix_end": "fix",
+        "replacement": "replacement",
+    }
+    for f in dataclasses.fields(Finding):
+        token = field_to_token.get(f.name)
+        if token is None:
+            continue
+        assert token in schema, f"поле {f.name} (токен {token}) отсутствует в findings-schema.md"
+
+
+def test_anti_hallucination_has_core_principles():
+    text = _read("anti-hallucination.md").lower()
+    assert "code_quote" in text
+    assert "hallucinat" in text          # «a hallucinated absence is worse…»
+    assert "empty findings list" in text  # пустой список — валидный результат
+
+
+def test_tool_usage_has_both_tool_families():
+    text = _read("tool-usage.md")
+    # PR-session
+    assert "search_code" in text and "get_changed_file_diff" in text and "get_impact" in text
+    # session-less
+    assert "search_codebase" in text and "related_symbols" in text and "definition" in text
+
+
+def test_branch_selection_has_review_branches_logic():
+    text = _read("branch-selection.md")
+    assert "REVIEW_BRANCHES" in text
+    assert "git branch --show-current" in text


### PR DESCRIPTION
## Задача

[PRI-142](https://ru.yougile.com/team/686c049c8af8/#PRI-142) — устранить дублирование 4 блоков инструкций (findings-schema / anti-hallucination / tool-usage / branch-selection), размазанных по скилл-промптам плагина, вынеся их в единый источник правды. Maintainability-рефакторинг markdown-промптов (НЕ экономия рантайм-токенов).

## Что сделано

- **`plugin/skills/_common/`** — 4 общих reference-блока как единый источник: `findings-schema.md`, `anti-hallucination.md`, `tool-usage.md` (обе таблицы тулов — PR-session и session-less), `branch-selection.md`.
- **Runtime-include**: скилы и reference-промпты подключают блоки маркером `<!-- include: _common/<file>.md -->` (путь от `plugin/skills/`); LLM-оркестратор разворачивает их verbatim при сборке промпта субагента. Скилл-специфичные хвосты остаются в самих скиллах (поведение субагентов не меняется).
- Переведены на include: review-pipeline (`analyze`/`requirements`/`blast-radius`/`verify`-prompt + `review-pr/SKILL.md`) и standalone-скилы (`performance-review`/`maintainability-review`/`ask`/`solve-task`). `verify` сохраняет собственную verdicts-схему; `requirements`/`verify` не получают generic anti-hallucination (паритет с оригиналом).
- **`reviewer/install.py`** — `_common` зарегистрирован в `SKILL_NAMES` (документационная константа; обход подкаталогов и хэш-штамп уже поддерживали каталог без SKILL.md).
- **CLAUDE.md** — задокументирован механизм `_common`/include.

## Тестирование

- Guard-тесты: `tests/skills/test_common_blocks.py` (соответствие findings-schema ↔ `Finding` dataclass), `tests/skills/test_assembled_prompts.py` (сборка include + покрытие правил собранных промптов), `tests/install/test_common_shared_dir.py` (extract/hash `_common`).
- Полный прогон: **534 passed** (без `tests/web` — pre-existing отсутствие `[web]`-extra, диффом не затронут).
- Финальное whole-branch ревью: ноль Critical/Important; рул-за-рулом подтверждено сохранение поведения субагентов.

## Критерии приёмки

- ✅ Единый источник у блоков; правка правила меняет все промпты разом.
- ✅ Guard-тесты содержимого зелёные.
- ✅ Поведение субагентов не изменилось (собранный промпт покрывает исходный набор правил).