### PR TITLE
feat: калибровка confidence в промптах ревью + согласование гейта (PRI-144)

### DIFF
--- a/docs/superpowers/plans/2026-06-21-confidence-calibration.md
+++ b/docs/superpowers/plans/2026-06-21-confidence-calibration.md
@@ -1,0 +1,325 @@
+# Confidence Calibration Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Дать находкам ревью осмысленный `confidence` (явная шкала, привязанная к grounding) и сделать `min_confidence`-гейт предсказуемым.
+
+**Architecture:** Две стороны. (1) Промпты: единая 3-уровневая шкала калибровки в общем `_common/findings-schema.md` (включается в 4 dimension-промпта), плюс короткие dimension-надстройки; blast-radius помечается как частный случай. (2) Код: парсер LLM-вывода больше не коэрцит «нет оценки» в проходное `0.5`, а клампит и опускает в `0.1`; дефолты порога выравниваются на `0.5`.
+
+**Tech Stack:** Python 3.11–3.13, pytest, dataclasses; промпты — Markdown с include-маркерами `<!-- include: _common/<file>.md -->`.
+
+## Global Constraints
+
+- Язык проекта — **русский**: комментарии, докстринги, сообщения. Текст промптов — английский (как в существующих файлах), но правила остаются на английском в `.md`.
+- Коммиты — **Conventional Commits на русском**, без self-attribution (никаких `Co-Authored-By`/упоминаний Claude).
+- Тесты — `.venv/bin/pytest -q` (unit, integration исключены по умолчанию). Unit не трогают Postgres/Neo4j/Voyage.
+- `line-length 100`, `ruff check .` (target py311).
+- НЕ менять: `ReviewPolicy.gate()` логику сравнения (`policy.py:91`), env-дефолт `review_min_confidence` (`settings.py:45` остаётся `0.5`).
+- Guard-инвариант: `findings-schema.md:16` (`"confidence": 0.0`) и числа шкалы blast-radius (`0.8`) сохраняются дословно — на них опираются `tests/skills/test_assembled_prompts.py`.
+
+---
+
+### Task 1: Коэрция `confidence` — fallback `0.1` + clamp `[0,1]`
+
+**Files:**
+- Modify: `reviewer/mcp/service.py:61` (докстринг), `reviewer/mcp/service.py:76-79` (коэрция)
+- Test: `tests/mcp/test_service.py`
+
+**Interfaces:**
+- Consumes: `_finding_from_dict(d: dict) -> Finding | None` (`reviewer/mcp/service.py:49`), `Finding` (`reviewer/vcs/base.py:30`).
+- Produces: после изменения `_finding_from_dict` возвращает `Finding.confidence`, гарантированно в `[0.0, 1.0]`; отсутствующий/`None`/нечисловой `confidence` → `0.1`.
+
+- [ ] **Step 1: Write the failing test**
+
+В конец `tests/mcp/test_service.py` добавить (импорт `_finding_from_dict` — в блок импортов файла: `from reviewer.mcp.service import MCPReviewService, _finding_from_dict`):
+
+```python
+def test_finding_confidence_coercion_and_clamp():
+    base = {"file": "a.py", "severity": "high", "message": "m", "line": 1, "code_quote": "x = 1"}
+    # валидные значения проходят как есть
+    assert _finding_from_dict({**base, "confidence": 0.9}).confidence == 0.9
+    assert _finding_from_dict({**base, "confidence": 0.5}).confidence == 0.5
+    # не оценено / None / мусор → 0.1 (ниже честного потолка спекулятивной зоны 0.4)
+    assert _finding_from_dict(base).confidence == 0.1
+    assert _finding_from_dict({**base, "confidence": None}).confidence == 0.1
+    assert _finding_from_dict({**base, "confidence": "abc"}).confidence == 0.1
+    # clamp в [0,1]
+    assert _finding_from_dict({**base, "confidence": 1.5}).confidence == 1.0
+    assert _finding_from_dict({**base, "confidence": -0.2}).confidence == 0.0
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `.venv/bin/pytest tests/mcp/test_service.py::test_finding_confidence_coercion_and_clamp -q`
+Expected: FAIL — текущий код даёт `0.5` для отсутствующего/`None`/`"abc"` (ожидается `0.1`) и `1.5` для `1.5` (ожидается `1.0`, clamp отсутствует).
+
+- [ ] **Step 3: Write minimal implementation**
+
+В `reviewer/mcp/service.py` заменить блок коэрции (строки 76-79):
+
+```python
+    try:
+        confidence = float(d.get("confidence"))
+    except (TypeError, ValueError):
+        confidence = 0.5
+```
+
+на:
+
+```python
+    try:
+        confidence = float(d.get("confidence"))
+    except (TypeError, ValueError):
+        confidence = 0.1   # не оценено = спекулятивно (ниже честного потолка 0.4) → отсекается гейтом
+    confidence = max(0.0, min(1.0, confidence))   # clamp в [0,1]
+```
+
+И обновить строку докстринга `service.py:61`:
+
+```
+    - ``confidence``: float-коэрция, None/мусор → 0.5;
+```
+
+на:
+
+```
+    - ``confidence``: float-коэрция, None/мусор → 0.1; значение клампится в [0.0, 1.0];
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `.venv/bin/pytest tests/mcp/test_service.py::test_finding_confidence_coercion_and_clamp -q`
+Expected: PASS
+
+- [ ] **Step 5: Run the full service test file (regression)**
+
+Run: `.venv/bin/pytest tests/mcp/test_service.py tests/mcp/test_publish.py -q`
+Expected: PASS (ни один существующий тест не полагался на fallback `0.5`).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add reviewer/mcp/service.py tests/mcp/test_service.py
+git commit -m "fix(mcp): коэрция confidence — fallback 0.1 и clamp в [0,1] (PRI-144)"
+```
+
+---
+
+### Task 2: Выравнивание дефолтов `min_confidence` на `0.5` + предсказуемый гейт
+
+**Files:**
+- Modify: `reviewer/policy/policy.py:18` (dataclass-дефолт), `reviewer/policy/policy.py:35` (`from_yaml`-дефолт)
+- Test: `tests/policy/test_policy.py`
+
+**Interfaces:**
+- Consumes: `ReviewPolicy` (`reviewer/policy/policy.py:11`), хелпер `F(cat, sev, file="a.py", confidence=0.9)` (`tests/policy/test_policy.py:5`), `Settings` (`reviewer/config/settings.py`).
+- Produces: `ReviewPolicy().min_confidence == 0.5`, `ReviewPolicy.from_yaml(None).min_confidence == 0.5`; `gate()` логика не меняется.
+
+- [ ] **Step 1: Write the failing test**
+
+В конец `tests/policy/test_policy.py` добавить:
+
+```python
+def test_min_confidence_default_aligned_to_0_5():
+    # dataclass-дефолт и from_yaml-дефолт согласованы с env (0.5)
+    assert ReviewPolicy().min_confidence == 0.5
+    assert ReviewPolicy.from_yaml(None).min_confidence == 0.5
+
+
+def test_min_confidence_gate_predictable_set():
+    # набор примеров приёмки: порог 0.5 отсекает предсказуемо
+    p = ReviewPolicy(min_confidence=0.5)
+    assert p.gate(F("correctness", "high", confidence=0.4)) is False
+    assert p.gate(F("correctness", "high", confidence=0.49)) is False
+    assert p.gate(F("correctness", "high", confidence=0.5)) is True
+    assert p.gate(F("correctness", "high", confidence=0.8)) is True
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `.venv/bin/pytest tests/policy/test_policy.py::test_min_confidence_default_aligned_to_0_5 -q`
+Expected: FAIL — текущий dataclass-дефолт `0.0` (assert ждёт `0.5`). (Второй тест `test_min_confidence_gate_predictable_set` уже проходит — `ReviewPolicy(min_confidence=0.5)` задаёт порог явно; он фиксирует критерий приёмки.)
+
+- [ ] **Step 3: Write minimal implementation**
+
+В `reviewer/policy/policy.py` строка 18:
+
+```python
+    min_confidence: float = 0.0
+```
+
+→
+
+```python
+    min_confidence: float = 0.5
+```
+
+И в `from_yaml` строка 35:
+
+```python
+            min_confidence=data.get("min_confidence", 0.0),
+```
+
+→
+
+```python
+            min_confidence=data.get("min_confidence", 0.5),
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `.venv/bin/pytest tests/policy/test_policy.py::test_min_confidence_default_aligned_to_0_5 tests/policy/test_policy.py::test_min_confidence_gate_predictable_set -q`
+Expected: PASS
+
+- [ ] **Step 5: Run the full policy test file (regression)**
+
+Run: `.venv/bin/pytest tests/policy/test_policy.py -q`
+Expected: PASS — существующие тесты используют `F(..., confidence=0.9)` (проходит при `0.5`) либо задают `min_confidence` явно; подъём дефолта `0.0 → 0.5` их не ломает.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add reviewer/policy/policy.py tests/policy/test_policy.py
+git commit -m "fix(policy): выровнять дефолт min_confidence на 0.5 (PRI-144)"
+```
+
+---
+
+### Task 3: Шкала калибровки в промптах
+
+**Files:**
+- Modify: `plugin/skills/_common/findings-schema.md:29` (строка `confidence` → блок шкалы)
+- Modify: `plugin/skills/review-pr/references/blast-radius-prompt.md:31` (пометить как частный случай общей шкалы)
+- Modify: `plugin/skills/review-pr/references/requirements-prompt.md` (надстройка после include findings-schema, строка 40)
+- Modify: `plugin/skills/performance-review/SKILL.md` (надстройка после include findings-schema, строка 53)
+- Modify: `plugin/skills/maintainability-review/SKILL.md` (надстройка после include findings-schema, строка 105)
+- Test: `tests/skills/` (существующие guard — должны остаться зелёными; новых не добавляем)
+
+**Interfaces:**
+- Consumes: include-механизм `<!-- include: _common/findings-schema.md -->` (разворачивается оркестратором).
+- Produces: собранные промпты содержат шкалу калибровки; `'"confidence": 0.0'` (пример) и `0.8` (blast-radius) сохранены для guard.
+
+- [ ] **Step 1: Заменить семантику `confidence` в общей схеме**
+
+В `plugin/skills/_common/findings-schema.md` строку 29:
+
+```
+- `confidence` — float `0.0..1.0`; it feeds the publish gate, so be honest.
+```
+
+заменить на блок (пример на строке 16 — `"confidence": 0.0` — НЕ трогать):
+
+```
+- `confidence` — float `0.0..1.0`; it feeds the publish gate (`min_confidence`),
+  so be honest. Calibrate against grounding + reproducibility:
+  - 0.8–1.0 — grounded AND verified: an exact `code_quote` from the new file AND
+    the problem is confirmed via tools (read_file/search_code showed the handling
+    is truly absent / the call graph confirms the impact). An unambiguous, real defect.
+  - 0.5–0.7 — grounded but context-dependent: a valid `code_quote`, the issue is
+    plausible, but reproducibility depends on runtime data / unchecked branches /
+    caller context. Phrase as "verify that…", not a categorical claim.
+  - ≤ 0.4 — speculative: no solid grounding, not verified with tools, or a guess about
+    intent. Below the 0.5 gate → it will be dropped. Prefer dropping it yourself
+    (an empty findings list is valid).
+```
+
+- [ ] **Step 2: Пометить шкалу blast-radius как частный случай**
+
+В `plugin/skills/review-pr/references/blast-radius-prompt.md` строку 31:
+
+```
+- Set `confidence` (a float; it feeds the publish gate — be honest) by this scale:
+```
+
+заменить на (подпункты `0.8–0.9 / 0.5–0.6 / ≤ 0.4` ниже — НЕ трогать, число `0.8` обязано сохраниться для guard):
+
+```
+- Set `confidence` by the shared scale in findings-schema (grounding + reproducibility);
+  for blast radius that scale concretely means:
+```
+
+- [ ] **Step 3: Добавить dimension-надстройки (по одной строке)**
+
+В `plugin/skills/review-pr/references/requirements-prompt.md` сразу после строки 40
+(`<!-- include: _common/findings-schema.md -->`) добавить:
+
+```
+- Calibrate `confidence` by how explicitly the acceptance criterion is broken: an exact,
+  quoted criterion clearly violated → 0.8+; an inferred/implicit requirement → 0.5–0.7;
+  a guess about intent → ≤ 0.4 (drop).
+```
+
+В `plugin/skills/performance-review/SKILL.md` сразу после строки 53
+(`<!-- include: _common/findings-schema.md -->`) добавить:
+
+```
+- Calibrate `confidence` against a measurable, reproducible effect: a hot path you can point
+  to (loop bound, query inside a loop) → 0.8+; a plausible but data-dependent cost → 0.5–0.7;
+  no measurable/reproducible effect → ≤ 0.4 (drop).
+```
+
+В `plugin/skills/maintainability-review/SKILL.md` сразу после строки 105
+(`<!-- include: _common/findings-schema.md -->`) добавить:
+
+```
+- Calibrate `confidence` against concrete, grounded evidence: a duplicated block you can quote
+  or a real complexity hotspot → 0.8+; a subjective readability concern → 0.5–0.7; pure taste
+  → ≤ 0.4 (drop).
+```
+
+(`analyze-prompt.md` отдельной надстройки не получает — общей шкалы из включённого
+`findings-schema.md` достаточно.)
+
+- [ ] **Step 4: Run skills guard tests**
+
+Run: `.venv/bin/pytest tests/skills -q`
+Expected: PASS — пример `"confidence": 0.0` и blast-radius `0.8` сохранены; токен `confidence` присутствует в схеме.
+
+Если падает `test_assembled_prompts.py` на `'"confidence": 0.0'` или `"0.8"` — значит был случайно изменён пример/шкала; вернуть их дословно (надстройки добавляются, а не заменяют пример/числа).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add plugin/skills/_common/findings-schema.md \
+        plugin/skills/review-pr/references/blast-radius-prompt.md \
+        plugin/skills/review-pr/references/requirements-prompt.md \
+        plugin/skills/performance-review/SKILL.md \
+        plugin/skills/maintainability-review/SKILL.md
+git commit -m "feat(skills): шкала калибровки confidence в dimension-промптах (PRI-144)"
+```
+
+---
+
+### Task 4: Финальная проверка (вся сюита + линт)
+
+**Files:** —
+
+- [ ] **Step 1: Run full unit suite**
+
+Run: `.venv/bin/pytest -q`
+Expected: PASS (integration исключены по умолчанию).
+
+- [ ] **Step 2: Lint**
+
+Run: `.venv/bin/ruff check reviewer/mcp/service.py reviewer/policy/policy.py tests/mcp/test_service.py tests/policy/test_policy.py`
+Expected: чисто на изменённых файлах. (Repo-wide `ruff check .` может быть не чист на main — не гнаться за этим, проверять только тронутые файлы.)
+
+- [ ] **Step 3: Проверка критерия приёмки вручную (sanity)**
+
+Убедиться, что инвариант выполнен: fallback `0.1 < 0.5` (порог) → неоценённая находка отсекается; grounded `≥ 0.5` → проходит. Подтверждено тестами Task 1 (коэрция) и Task 2 (gate).
+
+## Self-Review
+
+**Spec coverage:**
+- Шкала калибровки (spec §1) → Task 3 Step 1. ✔
+- blast-radius как частный случай (spec §2) → Task 3 Step 2. ✔
+- Dimension-надстройки (spec §3) → Task 3 Step 3. ✔
+- Коэрция fallback `0.1` + clamp (spec §4.1) → Task 1. ✔
+- Дефолты порога `0.5` (spec §4.2) → Task 2. ✔
+- `gate()`/env не трогаем (spec §4.3) → Global Constraints + Task 2 Step 3 (только дефолты). ✔
+- Тесты приёмки (spec «Проверка приёмки») → Task 1 Step 1, Task 2 Step 1. ✔
+- Guard-совместимость (spec «Совместимость с guard-тестами») → Global Constraints + Task 3 Step 4. ✔
+
+**Placeholder scan:** нет TBD/«add error handling»; весь код приведён дословно. ✔
+
+**Type/name consistency:** `_finding_from_dict`, `ReviewPolicy`, `F`, `Finding.confidence` — имена сверены с кодом (`service.py:49`, `policy.py:11`, `test_policy.py:5`, `base.py:39`). ✔

--- a/docs/superpowers/specs/2026-06-21-confidence-calibration-design.md
+++ b/docs/superpowers/specs/2026-06-21-confidence-calibration-design.md
@@ -1,0 +1,168 @@
+# Калибровка `confidence` в промптах ревью — дизайн
+
+- **Задача:** PRI-144 (canonical ID-144) — «Калибровка confidence в промптах ревью (привязка к grounding и min_confidence-гейту)».
+- **Дата:** 2026-06-21
+- **Оценка:** S
+- **Ссылка:** https://ru.yougile.com/team/686c049c8af8/#PRI-144
+
+## Контекст и проблема
+
+Поле `confidence` (`0.0..1.0`) есть в JSON-контракте находок и кормит publish-гейт
+(`min_confidence` в `ReviewPolicy.gate`), но **нет правил калибровки**: не определено, что
+значит 0.5 против 0.9 и как привязать оценку к grounding. Из-за этого:
+
+1. **В промптах** субагенты выставляют `confidence` произвольно — только `blast-radius-prompt.md`
+   имеет явную шкалу; в `analyze`/`performance`/`maintainability` слово `confidence` не упомянуто
+   вовсе, в `requirements` — без шкалы.
+2. **В коде** парсер LLM-вывода коэрцит отсутствующий/мусорный `confidence` ровно в `0.5`
+   (`reviewer/mcp/service.py:76-79`), а порог гейта по умолчанию тоже `0.5`
+   (`review_min_confidence`, `reviewer/config/settings.py:45`). `0.5 >= 0.5` → находка **без
+   честной оценки проходит гейт**. Это и есть «гейт работает по случайным значениям».
+3. Дефолт порога рассинхронен: dataclass `ReviewPolicy.min_confidence = 0.0`
+   (`reviewer/policy/policy.py:18`) и `from_yaml` (`policy.py:35`) против env `0.5`
+   (`from_settings`). Рабочий путь — `ReviewPolicy.load → from_settings` (`0.5`), поэтому
+   рассинхрон — «спящая ловушка» при прямом конструировании `ReviewPolicy(...)`
+   (`session_serde`, тесты), а не активный баг.
+
+## Цель и критерий приёмки
+
+- Находки получают **осмысленный** `confidence`, привязанный к grounding и воспроизводимости.
+- Гейт по `min_confidence` отсекает **предсказуемо** (проверка на наборе примеров).
+
+## Граница задачи
+
+В scope: **промпты + согласование кода**. Из scope исключены: guard-тесты на сборку промптов,
+изменение самого `gate()`, изменение env-дефолта `review_min_confidence`.
+
+## Дизайн
+
+### 1. Единая шкала калибровки (`_common/findings-schema.md`)
+
+Заменить в `plugin/skills/_common/findings-schema.md` одну строку про `confidence` (строка 29)
+на блок с 3-уровневой шкалой, привязанной к **grounding** (есть ли точный `code_quote` из
+реального кода) и **воспроизводимости** (подтверждена ли проблема инструментами):
+
+```
+- `confidence` — float `0.0..1.0`; it feeds the publish gate (`min_confidence`),
+  so be honest. Calibrate against grounding + reproducibility:
+  - 0.8–1.0 — grounded AND verified: an exact `code_quote` from the new file AND
+    the problem is confirmed via tools (read_file/search_code showed the handling
+    is truly absent / the call graph confirms the impact). An unambiguous, real defect.
+  - 0.5–0.7 — grounded but context-dependent: a valid `code_quote`, the issue is
+    plausible, but reproducibility depends on runtime data / unchecked branches /
+    caller context. Phrase as "verify that…", not a categorical claim.
+  - ≤ 0.4 — speculative: no solid grounding, not verified with tools, or a guess about
+    intent. Below the 0.5 gate → it will be dropped. Prefer dropping it yourself
+    (an empty findings list is valid).
+```
+
+Правила привязки:
+- **Grounding задаёт потолок.** Нет валидного `code_quote` ⇒ `confidence ≤ 0.4` (отсекается).
+  Смыкается с `_common/anti-hallucination.md:20-22` («каждая находка обязана нести точный
+  `code_quote`»).
+- **Воспроизводимость задаёт уровень** внутри grounded-зоны: подтверждено инструментами → `0.8+`,
+  контекстно-зависимо → `0.5–0.7`.
+- **Порог `0.5`** ложится на границу «спекулятивное / grounded»: догадки выпадают, обоснованное
+  публикуется — гейт предсказуем.
+
+Пример в `findings-schema.md:16` (`"confidence": 0.0`) **оставляем без изменений**: это
+format-плейсхолдер JSON-шаблона (показывает тип поля), и на него опираются guard-тесты
+`tests/skills/test_assembled_prompts.py:34,62,68` (`'"confidence": 0.0' in ...`). Подмена на
+«рекомендованное» число ввела бы ложный дефолт и сломала бы guard. Калибровка живёт в семантике
+поля (блок выше), а не в примере. *(Отклонение от первоначального дизайна: ранее планировалась
+правка примера `0.0 → 0.7`; отменено после обнаружения связи guard-тестов с текстом.)*
+
+### 2. `blast-radius-prompt.md` — согласование
+
+`plugin/skills/review-pr/references/blast-radius-prompt.md:31-44` уже содержит verification-шкалу
+(`0.8–0.9 / 0.5–0.6 / ≤0.4`) — это более узкое **подмножество** общей шкалы (`0.8–1.0 / 0.5–0.7 /
+≤0.4`): те же зоны и тот же порог `0.5`, но уже верхние границы под cross-file-специфику. Зоны
+непротиворечивы — оставляем специфику blast-radius (read caller + `get_changed_file_diff`), но
+помечаем её как **частный случай** общей шкалы (короткая ссылка на findings-schema). Содержательно
+шкала не меняется.
+
+### 3. Dimension-надстройки (по 1 строке)
+
+Поверх общей шкалы, в соответствующих промптах/скилах:
+- `requirements-prompt.md` — привязка к тому, насколько явно нарушен критерий приёмки.
+- `performance-review/SKILL.md`, `maintainability-review/SKILL.md` — нет измеримого/
+  воспроизводимого эффекта ⇒ `≤0.4`.
+- `analyze-prompt.md` — общей шкалы из включённого `findings-schema.md` достаточно; отдельная
+  надстройка не требуется (надстройку добавлять только если потребуется по факту).
+
+### 4. Согласование кода
+
+**4.1 Коэрция `confidence` — `reviewer/mcp/service.py:76-79` (главный фикс).**
+
+```python
+try:
+    confidence = float(d.get("confidence"))
+except (TypeError, ValueError):
+    confidence = 0.1          # не оценено = спекулятивно (ниже честного потолка 0.4) → отсекается
+confidence = max(0.0, min(1.0, confidence))   # clamp в [0,1]
+```
+
+- Fallback `0.5 → 0.1`: неоценённая/мусорная находка больше не протискивается через гейт. `0.1`
+  (а не `0.4`) сознательно ниже честного потолка спекулятивной зоны — это **отличает** «модель
+  промолчала» (`0.1`) от «модель честно оценила слабую находку» (`0.4`). Неоценённое всплывёт
+  только при осознанно низком пороге.
+- Clamp `[0,1]`: `1.5 → 1.0`, `-0.2 → 0.0`, `95 → 1.0` — `confidence` всегда в диапазоне.
+- Обновить докстринг `service.py:61` (`None/мусор → 0.5` → `→ 0.1; значения клампятся в [0,1]`).
+
+**4.2 Дефолты порога — `reviewer/policy/policy.py:18,35` (выравнивание).**
+
+dataclass-дефолт `ReviewPolicy.min_confidence` и дефолт в `from_yaml` привести к `0.5` —
+чтобы «честный» порог был единым независимо от пути конструирования. Рабочий путь
+(`load → from_settings`) уже `0.5`; сохранённые сессии десериализуются с явным значением и
+не затрагиваются.
+
+**4.3 Что НЕ трогаем.** `gate()` (`policy.py:91`) уже корректно сравнивает
+`confidence < min_confidence`; env `review_min_confidence` остаётся `0.5`.
+
+### Инвариант
+
+Связка fallback `0.1` + порог `0.5`: неоценённая находка строго ниже порога → отсекается.
+Граница grounded-зоны (`0.5`) совпадает с порогом → grounded-находки проходят.
+
+## Файлы к изменению
+
+| Файл | Изменение |
+|---|---|
+| `plugin/skills/_common/findings-schema.md` | шкала калибровки (стр. 29 → блок); пример стр. 16 НЕ трогаем (guard) |
+| `plugin/skills/review-pr/references/blast-radius-prompt.md` | пометить шкалу как частный случай общей |
+| `plugin/skills/review-pr/references/requirements-prompt.md` | надстройка (1 строка) |
+| `plugin/skills/performance-review/SKILL.md` | надстройка (1 строка) |
+| `plugin/skills/maintainability-review/SKILL.md` | надстройка (1 строка) |
+| `reviewer/mcp/service.py` | fallback `0.5→0.1` + clamp `[0,1]` + докстринг |
+| `reviewer/policy/policy.py` | dataclass- и `from_yaml`-дефолт `min_confidence` → `0.5` |
+| тесты `mcp/service` (коэрция) | юнит на набор примеров коэрции `confidence` |
+| `tests/policy/test_policy.py` | юнит на `gate()` по набору примеров `confidence` |
+
+## Проверка приёмки (юниты на изменённый код)
+
+Не guard-тесты на промпты — юниты на тот код, что меняется (гоняются обычным `pytest -q`,
+без Postgres/Neo4j/Voyage):
+
+1. **Коэрция `confidence`** (тесты `mcp/service`): `0.9→0.9`, `0.5→0.5`, отсутствует/`None`/
+   `"abc"`→`0.1`, `1.5→1.0`, `-0.2→0.0`.
+2. **`gate()` по набору примеров** (`tests/policy/test_policy.py`): при `min_confidence=0.5` —
+   `confidence` `0.4 / 0.49 / 0.5 / 0.8` → отсек/отсек/проход/проход.
+
+## Совместимость с guard-тестами
+
+`tests/skills/` опираются на конкретный текст собранных промптов:
+- `test_assembled_prompts.py:34,62,68` — `'"confidence": 0.0'` в analyze/performance/maintainability
+  ⇒ пример в `findings-schema.md:16` сохраняем дословно.
+- `test_assembled_prompts.py:50` — `"0.8"` в blast-radius ⇒ числа его шкалы сохраняем.
+- `test_common_blocks.py:46-57` — токен `confidence` присутствует в `findings-schema.md` ⇒ новый
+  блок шкалы это требование выполняет.
+
+Новые guard-тесты на промпты не добавляем (вне scope). Существующие должны остаться зелёными —
+после правок промптов обязателен прогон `.venv/bin/pytest tests/skills -q`.
+
+## Связанные задачи
+
+- **ID-142** «Общие reference-блоки» — шкала кладётся в `_common/findings-schema.md`, в духе
+  уже внедрённой инфраструктуры include-маркеров.
+- **ID-143** «Унификация performance/maintainability-скилов» — оба `SKILL.md` уже на
+  `_common`-блоках; надстройки встраиваются тем же include-механизмом.

--- a/plugin/skills/_common/findings-schema.md
+++ b/plugin/skills/_common/findings-schema.md
@@ -26,6 +26,16 @@ Field semantics:
 - `code_quote` — exact line copied verbatim from the NEW file; it grounds the line number. `null` only when `line` is null. An inaccurate quote is worse than no quote.
 - `message` / `suggestion` — written in the orchestrator's output language.
 - `fix` — exact replacement for a contiguous line range in the new file (`start_line`/`end_line`/`replacement`), or `null` when unsure.
-- `confidence` — float `0.0..1.0`; it feeds the publish gate, so be honest.
+- `confidence` — float `0.0..1.0`; it feeds the publish gate (`min_confidence`),
+  so be honest. Calibrate against grounding + reproducibility:
+  - 0.8–1.0 — grounded AND verified: an exact `code_quote` from the new file AND
+    the problem is confirmed via tools (read_file/search_code showed the handling
+    is truly absent / the call graph confirms the impact). An unambiguous, real defect.
+  - 0.5–0.7 — grounded but context-dependent: a valid `code_quote`, the issue is
+    plausible, but reproducibility depends on runtime data / unchecked branches /
+    caller context. Phrase as "verify that…", not a categorical claim.
+  - ≤ 0.4 — speculative: no solid grounding, not verified with tools, or a guess about
+    intent. Below the 0.5 gate → it will be dropped. Prefer dropping it yourself
+    (an empty findings list is valid).
 
 Write `message` and `suggestion` in the output language given by the orchestrator.

--- a/plugin/skills/maintainability-review/SKILL.md
+++ b/plugin/skills/maintainability-review/SKILL.md
@@ -103,6 +103,9 @@ Return ONLY the findings JSON used by the review pipeline, with
 `"category": "maintainability"`:
 
 <!-- include: _common/findings-schema.md -->
+- Calibrate `confidence` against concrete, grounded evidence: a duplicated block you can quote
+  or a real complexity hotspot → 0.8+; a subjective readability concern → 0.5–0.7; pure taste
+  → ≤ 0.4 (drop).
 Set "category" to "maintainability"; "side" is always "RIGHT".
 
 The `suggestion` field replaces what in the original Codex format appeared after

--- a/plugin/skills/performance-review/SKILL.md
+++ b/plugin/skills/performance-review/SKILL.md
@@ -51,6 +51,9 @@ Return ONLY the findings JSON used by the review pipeline, with
 `"category": "performance"`:
 
 <!-- include: _common/findings-schema.md -->
+- Calibrate `confidence` against a measurable, reproducible effect: a hot path you can point
+  to (loop bound, query inside a loop) → 0.8+; a plausible but data-dependent cost → 0.5–0.7;
+  no measurable/reproducible effect → ≤ 0.4 (drop).
 Set "category" to "performance"; "side" is always "RIGHT".
 
 <!-- include: _common/dimension-output-tail.md -->

--- a/plugin/skills/review-pr/references/blast-radius-prompt.md
+++ b/plugin/skills/review-pr/references/blast-radius-prompt.md
@@ -28,7 +28,8 @@ Confidence & graph completeness (mandatory):
     "nothing else is impacted", based on the list. A caller absent from the report is
     NOT evidence that no such caller exists.
   - Do NOT lower `severity` to benign because the caller list is empty or short.
-- Set `confidence` (a float; it feeds the publish gate — be honest) by this scale:
+- Set `confidence` by the shared scale in findings-schema (grounding + reproducibility);
+  for blast radius that scale concretely means:
   - 0.8–0.9 — the caller was read via `read_file` AND confirmed NOT updated via
     `get_changed_file_diff`, AND the break is unambiguous (a new REQUIRED parameter
     with no default, a removed/renamed parameter, or a changed parameter order that

--- a/plugin/skills/review-pr/references/requirements-prompt.md
+++ b/plugin/skills/review-pr/references/requirements-prompt.md
@@ -38,4 +38,7 @@ Use the PR-session tools above.
   fill a quota.
 
 <!-- include: _common/findings-schema.md -->
+- Calibrate `confidence` by how explicitly the acceptance criterion is broken: an exact,
+  quoted criterion clearly violated → 0.8+; an inferred/implicit requirement → 0.5–0.7;
+  a guess about intent → ≤ 0.4 (drop).
 category MUST be exactly "requirements". Set "fix" to null. "code_quote" may be null when "line" is null.

--- a/reviewer/mcp/service.py
+++ b/reviewer/mcp/service.py
@@ -58,7 +58,7 @@ def _finding_from_dict(d) -> Finding | None:
 
     - не-dict или dict без ``file`` → None (вызывающий считает invalid);
     - ``line``: int-коэрция, мусор → None;
-    - ``confidence``: float-коэрция, None/мусор → 0.5;
+    - ``confidence``: float-коэрция, None/мусор → 0.1; значение клампится в [0.0, 1.0];
     - ``severity`` вне {low,medium,high,critical} → "medium";
     - ``side`` вне {RIGHT,LEFT} → "RIGHT";
     - ``suggestion``: не-строка → None (не попадает в тело комментария как repr);
@@ -76,7 +76,8 @@ def _finding_from_dict(d) -> Finding | None:
     try:
         confidence = float(d.get("confidence"))
     except (TypeError, ValueError):
-        confidence = 0.5
+        confidence = 0.1   # не оценено = спекулятивно (ниже честного потолка 0.4) → отсекается гейтом
+    confidence = max(0.0, min(1.0, confidence))   # clamp в [0,1]
     fix = d.get("fix")
     fix_start = fix_end = replacement = None
     if isinstance(fix, dict):

--- a/reviewer/policy/policy.py
+++ b/reviewer/policy/policy.py
@@ -15,7 +15,7 @@ class ReviewPolicy:
     severity_threshold: SeverityLevel = "low"
     ignore: list[str] = field(default_factory=list)
     max_comments: int = 25
-    min_confidence: float = 0.0
+    min_confidence: float = 0.5
     output_language: str = "ru"                                  # язык текста находок в публикуемом ревью
     task_board: dict | None = None                               # конфиг доски задач из .review.yml (None = выкл.)
 
@@ -32,7 +32,7 @@ class ReviewPolicy:
             severity_threshold=sev,
             ignore=(data.get("paths") or {}).get("ignore", []),
             max_comments=data.get("max_comments", 25),
-            min_confidence=data.get("min_confidence", 0.0),
+            min_confidence=data.get("min_confidence", 0.5),
             output_language=str(data.get("output_language", "ru")),
             task_board=data.get("task_board") or None,
         )

--- a/tests/mcp/test_publish.py
+++ b/tests/mcp/test_publish.py
@@ -287,7 +287,7 @@ def test_publish_history_failsoft(_ov, _ch) -> None:
 @patch("reviewer.services.review_service.build_overlay")
 def test_publish_coerces_malformed_llm_findings(_ov, _ch) -> None:
     """Кривые dict'ы от LLM не валят publish: без file — скип (invalid),
-    line="42" — int-коэрция (+грунтовка), confidence=None → 0.5,
+    line="42" — int-коэрция (+грунтовка), confidence=None → 0.1 (ниже порога → отсекается),
     severity="urgent" → "medium". Валидные публикуются."""
     svc, vcs, _ = _make_mcp_service_with_publish()
     svc.prepare_review("o/r", 7)
@@ -295,14 +295,14 @@ def test_publish_coerces_malformed_llm_findings(_ov, _ch) -> None:
         {"category": "correctness", "severity": "high",
          "message": "no file", "confidence": 0.9},          # без file → invalid
         dict(RAW, line="42", message="bug A"),               # int-коэрция строки
-        dict(RAW, confidence=None, message="bug B"),         # None → 0.5 (порог 0.5 проходит)
+        dict(RAW, confidence=None, message="bug B"),         # None → 0.1 (ниже порога 0.5 → dropped)
         dict(RAW, severity="urgent", message="bug C"),       # вне enum → medium
     ]
     report = svc.publish_review("o/r", 7, summary="s", findings=pack)
     assert report["posted"] is True
     assert report["invalid"] == 1
-    assert report["dropped_by_gate"] == 0
-    assert len(report["inline"]) == 3
+    assert report["dropped_by_gate"] == 1                    # bug B (confidence=0.1) отсекается
+    assert len(report["inline"]) == 2
     assert all(c["line"] == 2 for c in report["inline"])     # все загрунтованы по цитате
 
 

--- a/tests/mcp/test_service.py
+++ b/tests/mcp/test_service.py
@@ -11,7 +11,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from reviewer.config.settings import Settings
-from reviewer.mcp.service import MCPReviewService
+from reviewer.mcp.service import MCPReviewService, _finding_from_dict
 from reviewer.vcs.base import (
     ChangedFile,
     PullRequest,
@@ -660,3 +660,21 @@ def test_get_pr_diff_empty_files_note():
     vcs.get_changed_files.return_value = []
     svc = MCPReviewService(_settings(), _components(), vcs_factory=lambda o, r: vcs)
     assert svc.get_pr_diff("o/r", 7) == "(PR без изменённых файлов)"
+
+
+# ---------------------------------------------------------------------------
+# Тесты Task 1 (PRI-144): коэрция confidence — fallback 0.1 + clamp [0,1]
+# ---------------------------------------------------------------------------
+
+def test_finding_confidence_coercion_and_clamp():
+    base = {"file": "a.py", "severity": "high", "message": "m", "line": 1, "code_quote": "x = 1"}
+    # валидные значения проходят как есть
+    assert _finding_from_dict({**base, "confidence": 0.9}).confidence == 0.9
+    assert _finding_from_dict({**base, "confidence": 0.5}).confidence == 0.5
+    # не оценено / None / мусор → 0.1 (ниже честного потолка спекулятивной зоны 0.4)
+    assert _finding_from_dict(base).confidence == 0.1
+    assert _finding_from_dict({**base, "confidence": None}).confidence == 0.1
+    assert _finding_from_dict({**base, "confidence": "abc"}).confidence == 0.1
+    # clamp в [0,1]
+    assert _finding_from_dict({**base, "confidence": 1.5}).confidence == 1.0
+    assert _finding_from_dict({**base, "confidence": -0.2}).confidence == 0.0

--- a/tests/policy/test_policy.py
+++ b/tests/policy/test_policy.py
@@ -135,3 +135,18 @@ def test_requirements_respects_severity_and_confidence():
     assert p.gate(F("requirements", "high", confidence=0.9)) is True
     assert p.gate(F("requirements", "low", confidence=0.9)) is False
     assert p.gate(F("requirements", "high", confidence=0.5)) is False
+
+
+def test_min_confidence_default_aligned_to_0_5():
+    # dataclass-дефолт и from_yaml-дефолт согласованы с env (0.5)
+    assert ReviewPolicy().min_confidence == 0.5
+    assert ReviewPolicy.from_yaml(None).min_confidence == 0.5
+
+
+def test_min_confidence_gate_predictable_set():
+    # набор примеров приёмки: порог 0.5 отсекает предсказуемо
+    p = ReviewPolicy(min_confidence=0.5)
+    assert p.gate(F("correctness", "high", confidence=0.4)) is False
+    assert p.gate(F("correctness", "high", confidence=0.49)) is False
+    assert p.gate(F("correctness", "high", confidence=0.5)) is True
+    assert p.gate(F("correctness", "high", confidence=0.8)) is True


### PR DESCRIPTION
## Задача

PRI-144 (ID-144) — Калибровка confidence в промптах ревью (привязка к grounding и `min_confidence`-гейту).
https://ru.yougile.com/team/686c049c8af8/#PRI-144

**Проблема:** поле `confidence` есть в JSON-контракте находок, но нет правил калибровки (что значит 0.5 vs 0.9, как связать с grounding) — из-за чего `min_confidence`-гейт в `publish_review` отсекал по фактически случайным значениям.

## Что сделано

**Промпты:**
- Единая 3-уровневая шкала калибровки в `_common/findings-schema.md`: `0.8–1.0` grounded+verified / `0.5–0.7` grounded+контекст / `≤0.4` спекулятивно. Потолок задаёт grounding (нет `code_quote` ⇒ `≤0.4`), уровень — воспроизводимость.
- `blast-radius-prompt.md` — его verification-шкала помечена как частный случай общей (числа не менялись).
- Однострочные надстройки в `requirements`/`performance`/`maintainability` промптах.

**Код (согласование гейта):**
- `reviewer/mcp/service.py` — коэрция `confidence`: fallback неоценённого значения `0.5 → 0.1` + clamp в `[0,1]`. Раньше `None`/мусор → `0.5` (= порог) → находка проходила гейт.
- `reviewer/policy/policy.py` — dataclass- и `from_yaml`-дефолт `min_confidence` выровнены `0.0 → 0.5` (рабочий env-путь уже был `0.5`).

**Инвариант:** `fallback 0.1 < порог 0.5 ≤ grounded` — неоценённые находки отсекаются предсказуемо. Логика `gate()` и env `review_min_confidence` не менялись.

## Проверка

- Unit: **538 passed** (`pytest -q --ignore=tests/web`; web исключены — нет `fastapi`/`[web]` в окружении, pre-existing).
- `ruff` clean на тронутых файлах.
- Guard-тесты `tests/skills` зелёные — пример `"confidence": 0.0` и blast-radius `0.8` сохранены дословно.
- Новые юниты: коэрция `confidence` (7 кейсов) + `gate()` по набору примеров (`0.4/0.49/0.5/0.8` → отсек/отсек/проход/проход).

## Документы

- Спека: `docs/superpowers/specs/2026-06-21-confidence-calibration-design.md`
- План: `docs/superpowers/plans/2026-06-21-confidence-calibration.md`

Известный косметический Minor (не блокирует): нет пустой строки-разделителя между dimension add-on и следующей инструкцией в собранном промпте.