### PR TITLE
feat(agent): надёжный grounding строк при дублированном коде (PRI-151)

### DIFF
--- a/reviewer/agent/assemble.py
+++ b/reviewer/agent/assemble.py
@@ -19,14 +19,33 @@ from reviewer.vcs.diff import commentable_lines
 # Вспомогательные функции грунтовки строк
 # ---------------------------------------------------------------------------
 
+def _pick_nearest(matches: list[int], line: int | None) -> int | None:
+    """Из строк-совпадений цитаты выбрать ближайшую к заявленной line.
+
+    - нет совпадений → None (вызывающий пробует следующий уровень поиска);
+    - одно совпадение → оно (line не нужен);
+    - несколько и line задан → ближайшее (тай-брейк: меньший номер строки);
+    - несколько и line is None → None (близость неопределена — не угадываем).
+    """
+    if not matches:
+        return None
+    if len(matches) == 1:
+        return matches[0]
+    if line is None:
+        return None
+    return min(matches, key=lambda i: (abs(i - line), i))
+
+
 def ground_line(source: str | None, code_quote: str | None, line: int | None) -> int | None:
     """Уточнить номер строки по точной цитате из исходника (анти-галлюцинация).
 
     Алгоритм:
     1. Ищем строки с точным совпадением (после strip).
-    2. Если единственное совпадение — возвращаем его.
-    3. Если нет ни одного точного совпадения — ищем подстроку.
-    4. Если единственное совпадение — возвращаем его.
+    2. Если одно совпадение — возвращаем его.
+    3. Если несколько совпадений и line задан — возвращаем ближайшее к line
+       (тай-брейк: меньший номер строки); если line is None — возвращаем None.
+    4. Если нет ни одного точного совпадения — ищем подстроку и применяем
+       ту же логику выбора ближайшего.
     5. Во всех остальных случаях возвращаем исходный ``line`` как есть.
 
     Parameters
@@ -50,12 +69,14 @@ def ground_line(source: str | None, code_quote: str | None, line: int | None) ->
         return line
     lines = source.splitlines()
     exact = [i for i, ln in enumerate(lines, 1) if ln.strip() == needle]
-    if len(exact) == 1:
-        return exact[0]
+    picked = _pick_nearest(exact, line)
+    if picked is not None:
+        return picked
     if not exact:
         sub = [i for i, ln in enumerate(lines, 1) if needle in ln]
-        if len(sub) == 1:
-            return sub[0]
+        picked = _pick_nearest(sub, line)
+        if picked is not None:
+            return picked
     return line
 
 

--- a/reviewer/config/settings.py
+++ b/reviewer/config/settings.py
@@ -47,6 +47,7 @@ class Settings(BaseSettings):
     review_categories: str = ""                    # CSV вайтлист категорий; пусто = все
     review_suggestions: SuggestionsMode = "apply"             # apply = applyable ```suggestion; text = только текстом
     review_max_files: int = 50                    # кап файлов PR на ревью; остальные — в сводку как пропущенные
+    review_grounding_max_distance: int = 5        # макс. дистанция снапа строки к commentable при grounding
     max_tool_result_chars: int = 8000             # максимальная длина результата tool-вызова в промпт
     review_output_language: str = "ru"            # язык текста находок в публикуемом ревью
     review_skip_drafts: bool = True               # не ревьюить draft-PR

--- a/reviewer/mcp/service.py
+++ b/reviewer/mcp/service.py
@@ -565,6 +565,7 @@ class MCPReviewService:
             if f.line is not None and f.side == "RIGHT" and f.file in _commentable_cache:
                 f.line = snap_to_commentable(
                     f.line, f.side, f.code_quote, _commentable_cache[f.file], p.sources.get(f.file, ""),
+                    max_distance=p.policy.grounding_max_distance,
                 )
             parsed.append(f)
 

--- a/reviewer/policy/policy.py
+++ b/reviewer/policy/policy.py
@@ -18,6 +18,7 @@ class ReviewPolicy:
     min_confidence: float = 0.5
     output_language: str = "ru"                                  # язык текста находок в публикуемом ревью
     task_board: dict | None = None                               # конфиг доски задач из .review.yml (None = выкл.)
+    grounding_max_distance: int = 5                              # макс. дистанция снапа строки к commentable при grounding
 
     @classmethod
     def from_yaml(cls, text: str | None) -> "ReviewPolicy":
@@ -35,6 +36,7 @@ class ReviewPolicy:
             min_confidence=data.get("min_confidence", 0.5),
             output_language=str(data.get("output_language", "ru")),
             task_board=data.get("task_board") or None,
+            grounding_max_distance=data.get("grounding_max_distance", 5),
         )
 
     @classmethod
@@ -47,6 +49,7 @@ class ReviewPolicy:
             min_confidence=settings.review_min_confidence,
             output_language=settings.review_output_language,
             task_board=settings.task_board_default(),   # глобальный env-дефолт доски
+            grounding_max_distance=settings.review_grounding_max_distance,
         )
 
     @classmethod
@@ -74,6 +77,8 @@ class ReviewPolicy:
             policy.output_language = str(data["output_language"])
         if "task_board" in data:
             policy.task_board = data["task_board"] or None
+        if "grounding_max_distance" in data:
+            policy.grounding_max_distance = data["grounding_max_distance"]
         return policy
 
     def category_enabled(self, category: str) -> bool:

--- a/tests/agent/test_assemble.py
+++ b/tests/agent/test_assemble.py
@@ -148,6 +148,37 @@ def test_snap_wrong_side_no_candidates():
     assert snap_to_commentable(11, "LEFT", None, commentable, _SNAP_SOURCE) == 11
 
 
+def test_ground_line_picks_nearest_on_duplicate_quote():
+    """При нескольких точных совпадениях выбирается ближайшее к заявленной строке."""
+    src = "\n".join(["x = compute()", "a", "b", "x = compute()", "c", "x = compute()"])
+    # совпадения на строках 1, 4, 6
+    assert ground_line(src, "x = compute()", 5) == 4   # ближайшее к 5 — строка 4
+    assert ground_line(src, "x = compute()", 6) == 6   # точное попадание
+    assert ground_line(src, "x = compute()", 2) == 1   # ближайшее к 2 — строка 1
+
+
+def test_ground_line_duplicate_quote_line_none_returns_original():
+    """При нескольких совпадениях и line=None близость неопределена → возвращаем None."""
+    src = "\n".join(["dup", "x", "dup"])
+    assert ground_line(src, "dup", None) is None
+
+
+def test_ground_line_substring_picks_nearest():
+    """Нет точных совпадений, но несколько подстрочных → ближайшее."""
+    src = "\n".join(["foo(bar)", "z", "z", "foo(bar, baz)"])
+    # подстрока "foo(bar" на строках 1 и 4
+    assert ground_line(src, "foo(bar", 4) == 4
+    assert ground_line(src, "foo(bar", 1) == 1
+
+
+def test_snap_max_distance_configurable():
+    """Кандидат дальше дефолтных 5, но в пределах увеличенного max_distance."""
+    commentable = {"RIGHT": {18}, "LEFT": set()}
+    # line=10, кандидат 18 (расстояние 8): при дефолте 5 — не снапаем, при 10 — снапаем
+    assert snap_to_commentable(10, "RIGHT", None, commentable, _SNAP_SOURCE) == 10
+    assert snap_to_commentable(10, "RIGHT", None, commentable, _SNAP_SOURCE, max_distance=10) == 18
+
+
 def test_centrality_breaks_severity_tie_and_survives_cap():
     # Обе находки: severity=high, confidence=0.9, строка 2 (в диффе). Различает центральность.
     leaf = _f(message="leaf", centrality=0.0)

--- a/tests/policy/test_policy.py
+++ b/tests/policy/test_policy.py
@@ -150,3 +150,10 @@ def test_min_confidence_gate_predictable_set():
     assert p.gate(F("correctness", "high", confidence=0.49)) is False
     assert p.gate(F("correctness", "high", confidence=0.5)) is True
     assert p.gate(F("correctness", "high", confidence=0.8)) is True
+
+
+def test_policy_grounding_max_distance_default_and_yaml():
+    """Дефолт grounding_max_distance == 5; .review.yml с grounding_max_distance: 12 даёт 12."""
+    assert ReviewPolicy().grounding_max_distance == 5
+    p = ReviewPolicy.from_yaml("grounding_max_distance: 12")
+    assert p.grounding_max_distance == 12


### PR DESCRIPTION
## Задача
PRI-151 / ID-151 — «Надёжный grounding строк при дублированном коде (`ground_line` / `snap_to_commentable`)».

На дублированном коде `ground_line`/`snap_to_commentable` при нескольких совпадениях `code_quote` не учитывали близость к заявленной строке → inline-комментарий мог сесть не туда. `max_distance=5` был зашит жёстко.

## Что сделано
- **`ground_line`** (`reviewer/agent/assemble.py`): при нескольких совпадениях `code_quote` выбирается ближайшее к заявленной строке (тай-брейк — меньший номер строки), а не отбрасывается выбор с возвратом исходного `line`. Та же логика применяется к подстрочным совпадениям. При `line=None` близость неопределена → сохранён консервативный fallback. Логика вынесена в `_pick_nearest`. Distance-cap в `ground_line` намеренно не вводится — совпадения уже верифицированы дословной цитатой.
- **Настраиваемый `max_distance`**: новое поле `ReviewPolicy.grounding_max_distance` (env-дефолт `review_grounding_max_distance`, дефолт 5; переопределяется в `.review.yml`). `publish_review` плюмит его в `snap_to_commentable`. Поведение по умолчанию не меняется (дефолт 5).

## Тесты
- `tests/agent/test_assemble.py`: коллизии цитат — выбор ближайшего точного/подстрочного совпадения, `line=None`-кейс, настраиваемая дистанция снапа.
- `tests/policy/test_policy.py`: дефолт `grounding_max_distance` и переопределение из `.review.yml`.
- Весь unit-сьют зелёный (555 passed); ruff чист на затронутых файлах.

_(Коллекция `tests/web` падает из-за отсутствия `fastapi` (extra `[web]` не установлен) — pre-existing, не связано с изменением.)_