### PR TITLE
feat(agent): нормализация текста перед dedup и fingerprint находок (PRI-152)

### DIFF
--- a/reviewer/agent/dedup.py
+++ b/reviewer/agent/dedup.py
@@ -2,8 +2,10 @@
 
 Алгоритм:
 1. Точные дубли по ключу (file, line, category, message) — оставляем первый.
+   message нормализуется перед сравнением (регистр, пробелы, пунктуация), поэтому
+   near-duplicate с дрейфом формулировки LLM схлопываются на этом шаге.
 2. Fuzzy-дубли внутри группы (file, category): строки совпадают или отличаются ≤2,
-   и SequenceMatcher ratio ≥ similarity — это дубль.
+   и SequenceMatcher ratio по нормализованным message ≥ similarity — это дубль.
 3. Выживает находка с максимальным severity; при равенстве — с максимальным confidence.
    Если у выжившей нет fix/replacement, а у дубля есть — fix-поля переносятся с дубля.
 """
@@ -12,6 +14,8 @@ from __future__ import annotations
 import difflib
 import logging
 from typing import TYPE_CHECKING
+
+from reviewer.vcs.base import normalize_message
 
 if TYPE_CHECKING:
     from reviewer.vcs.base import Finding
@@ -50,18 +54,21 @@ def _better(a: "Finding", b: "Finding") -> "Finding":
 
 
 def _fuzzy_match(m1: str, m2: str, similarity: float) -> bool:
-    return difflib.SequenceMatcher(None, m1.lower(), m2.lower()).ratio() >= similarity
+    return difflib.SequenceMatcher(None, normalize_message(m1), normalize_message(m2)).ratio() >= similarity
 
 
 def dedup_findings(findings: list, similarity: float = 0.9) -> list:
     """Схлопнуть дубли находок без LLM/эмбеддингов. Порядок выживших — как во входе.
+
+    message нормализуется (регистр, пробелы, пунктуация) перед точным и fuzzy-сравнением,
+    поэтому мелкий дрейф формулировки LLM между прогонами не плодит дубли.
 
     Parameters
     ----------
     findings:
         Список объектов :class:`~reviewer.vcs.base.Finding`.
     similarity:
-        Порог SequenceMatcher ratio для fuzzy-совпадения сообщений (0..1).
+        Порог SequenceMatcher ratio для fuzzy-совпадения нормализованных сообщений (0..1).
 
     Returns
     -------
@@ -76,7 +83,7 @@ def dedup_findings(findings: list, similarity: float = 0.9) -> list:
     after_exact: list = []             # уже без точных дублей, индексы исходного списка
 
     for idx, f in enumerate(findings):
-        key = (f.file, f.line, f.category, f.message)
+        key = (f.file, f.line, f.category, normalize_message(f.message))
         if key in exact_seen:
             survivor_idx = exact_seen[key]
             survivor = after_exact[survivor_idx]

--- a/reviewer/vcs/base.py
+++ b/reviewer/vcs/base.py
@@ -1,5 +1,16 @@
+import re
 from dataclasses import dataclass
 from typing import Literal, Protocol
+
+def normalize_message(message: str) -> str:
+    """Нормализовать текст находки для dedup/fingerprint: устранить незначимые
+    различия формулировки (регистр, пробелы, пунктуация), чтобы near-duplicate
+    схлопывались и повторный прогон не плодил дубли."""
+    s = message.casefold()              # юникод-корректный lower
+    s = re.sub(r"[^\w\s]", " ", s)      # пунктуация → пробел (\w юникодный: кириллица/латиница/цифры/_)
+    s = re.sub(r"\s+", " ", s).strip()  # схлопнуть пробелы + тримминг
+    return s
+
 
 @dataclass
 class PullRequest:
@@ -46,7 +57,7 @@ class Finding:
 
     def fingerprint(self) -> str:
         import hashlib
-        key = f"{self.file}|{self.line}|{self.side}|{self.category}|{self.message}"
+        key = f"{self.file}|{self.line}|{self.side}|{self.category}|{normalize_message(self.message)}"
         return hashlib.sha256(key.encode()).hexdigest()[:16]
 
 class VCSProvider(Protocol):

--- a/tests/agent/test_dedup.py
+++ b/tests/agent/test_dedup.py
@@ -231,3 +231,49 @@ def test_order_after_dedup_preserved():
     assert result[0] is f1
     assert result[1] is f2
     assert result[2] is f3
+
+
+# ---------------------------------------------------------------------------
+# Нормализация message в точном dedup (PRI-152)
+# ---------------------------------------------------------------------------
+
+def test_exact_dedup_collapses_on_case_difference():
+    """Находки, различающиеся ТОЛЬКО регистром и пунктуацией, схлопываются на точном шаге.
+
+    similarity=1.0 отключает fuzzy-шаг для этой пары (SequenceMatcher ratio < 1.0
+    из-за точки), поэтому дубль должен пойматься именно точным шагом по нормализации.
+    """
+    f1 = make_finding(message="Баг X.", line=5)
+    f2 = make_finding(message="баг x", line=5)
+    result = dedup_findings([f1, f2], similarity=1.0)
+    assert len(result) == 1
+
+
+def test_exact_dedup_collapses_on_trailing_punctuation():
+    """Находки, различающиеся ТОЛЬКО финальной точкой в message, схлопываются на точном шаге.
+
+    similarity=1.0 отключает fuzzy — дубль должен пойматься именно точным шагом.
+    """
+    f1 = make_finding(message="небезопасная функция", line=5)
+    f2 = make_finding(message="небезопасная функция.", line=5)
+    result = dedup_findings([f1, f2], similarity=1.0)
+    assert len(result) == 1
+
+
+def test_exact_dedup_collapses_on_extra_spaces():
+    """Находки, различающиеся ТОЛЬКО лишним пробелом в message, схлопываются на точном шаге.
+
+    similarity=1.0 отключает fuzzy — дубль должен пойматься именно точным шагом.
+    """
+    f1 = make_finding(message="переменная не используется", line=5)
+    f2 = make_finding(message="переменная  не используется", line=5)
+    result = dedup_findings([f1, f2], similarity=1.0)
+    assert len(result) == 1
+
+
+def test_fuzzy_dedup_uses_normalized_messages():
+    """Fuzzy-dedup для соседних строк с дрейфом регистра/пунктуации схлопывает находки."""
+    f1 = make_finding(message="небезопасный вызов функции func", line=10)
+    f2 = make_finding(message="Небезопасный вызов функции func.", line=11)
+    result = dedup_findings([f1, f2], similarity=0.9)
+    assert len(result) == 1

--- a/tests/vcs/test_finding_fingerprint.py
+++ b/tests/vcs/test_finding_fingerprint.py
@@ -1,0 +1,180 @@
+"""Тесты для normalize_message и Finding.fingerprint() из reviewer/vcs/base.py.
+
+Проверяет, что нормализация устраняет незначимые различия (регистр, пробелы,
+пунктуация) и fingerprint стабилен к дрейфу формулировки LLM.
+"""
+from reviewer.vcs.base import Finding, normalize_message
+
+
+# ---------------------------------------------------------------------------
+# Вспомогательная фабрика
+# ---------------------------------------------------------------------------
+
+def make_finding(
+    file: str = "a.py",
+    line: int | None = 10,
+    side: str = "RIGHT",
+    category: str = "correctness",
+    message: str = "проблема",
+) -> Finding:
+    return Finding(
+        category=category,
+        severity="medium",
+        file=file,
+        line=line,
+        side=side,
+        message=message,
+        suggestion=None,
+        confidence=0.8,
+    )
+
+
+# ---------------------------------------------------------------------------
+# normalize_message: юнит-тесты
+# ---------------------------------------------------------------------------
+
+def test_normalize_lowercase_ascii():
+    """Регистр ASCII приводится к нижнему."""
+    assert normalize_message("Bug X") == normalize_message("bug x")
+
+
+def test_normalize_lowercase_cyrillic():
+    """Регистр кириллицы приводится к нижнему (casefold)."""
+    assert normalize_message("Баг X") == normalize_message("баг x")
+
+
+def test_normalize_collapses_spaces():
+    """Множественные пробелы схлопываются в один."""
+    assert normalize_message("a   b") == "a b"
+
+
+def test_normalize_punctuation_to_space():
+    """Пунктуация заменяется пробелом."""
+    # «eval().» и «eval» должны дать одинаковый нормализованный вид
+    assert normalize_message("eval().") == normalize_message("eval")
+
+
+def test_normalize_trims_whitespace():
+    """Пробелы по краям удаляются."""
+    assert normalize_message("  x  ") == "x"
+
+
+def test_normalize_preserves_cyrillic_letters():
+    """Кириллические буквы (\\w) сохраняются после нормализации."""
+    result = normalize_message("Использование eval() небезопасно.")
+    assert "использование" in result
+    assert "eval" in result
+    assert "небезопасно" in result
+
+
+def test_normalize_trailing_dot_equivalent():
+    """Сообщение с финальной точкой и без — одинаковая нормализованная форма."""
+    assert normalize_message("баг найден.") == normalize_message("баг найден")
+
+
+def test_normalize_extra_spaces_around_punctuation():
+    """Пробелы вокруг пунктуации не создают артефактов."""
+    result = normalize_message("  Баг ,  пробел.  ")
+    assert result == normalize_message("Баг пробел")
+
+
+def test_normalize_different_meaningful_messages_stay_different():
+    """Содержательно разные сообщения остаются разными после нормализации."""
+    a = normalize_message("утечка памяти в цикле")
+    b = normalize_message("SQL-инъекция в запросе")
+    assert a != b
+
+
+# ---------------------------------------------------------------------------
+# Finding.fingerprint: стабильность к дрейфу формулировки
+# ---------------------------------------------------------------------------
+
+def test_fingerprint_stable_to_case():
+    """Регистровый дрейф не создаёт новый fingerprint."""
+    f1 = make_finding(message="Баг X")
+    f2 = make_finding(message="баг x")
+    assert f1.fingerprint() == f2.fingerprint()
+
+
+def test_fingerprint_stable_to_trailing_punctuation():
+    """Финальная точка не создаёт новый fingerprint."""
+    f1 = make_finding(message="баг найден")
+    f2 = make_finding(message="баг найден.")
+    assert f1.fingerprint() == f2.fingerprint()
+
+
+def test_fingerprint_stable_to_extra_spaces():
+    """Лишние пробелы не создают новый fingerprint."""
+    f1 = make_finding(message="баг  в  коде")
+    f2 = make_finding(message="баг в коде")
+    assert f1.fingerprint() == f2.fingerprint()
+
+
+def test_fingerprint_differs_for_different_message():
+    """Содержательно разные message дают разный fingerprint."""
+    f1 = make_finding(message="утечка памяти")
+    f2 = make_finding(message="SQL-инъекция")
+    assert f1.fingerprint() != f2.fingerprint()
+
+
+def test_fingerprint_differs_for_different_file():
+    """Разный file → разный fingerprint (нормализация не схлопнула координаты)."""
+    f1 = make_finding(file="a.py", message="баг")
+    f2 = make_finding(file="b.py", message="баг")
+    assert f1.fingerprint() != f2.fingerprint()
+
+
+def test_fingerprint_differs_for_different_line():
+    """Разная line → разный fingerprint."""
+    f1 = make_finding(line=10, message="баг")
+    f2 = make_finding(line=20, message="баг")
+    assert f1.fingerprint() != f2.fingerprint()
+
+
+def test_fingerprint_differs_for_different_category():
+    """Разная category → разный fingerprint."""
+    f1 = make_finding(category="correctness", message="баг")
+    f2 = make_finding(category="security", message="баг")
+    assert f1.fingerprint() != f2.fingerprint()
+
+
+def test_fingerprint_differs_for_different_side():
+    """Разный side → разный fingerprint."""
+    f1 = make_finding(side="RIGHT", message="баг")
+    f2 = make_finding(side="LEFT", message="баг")
+    assert f1.fingerprint() != f2.fingerprint()
+
+
+# ---------------------------------------------------------------------------
+# Идемпотентность: повторный прогон не плодит дубли
+# ---------------------------------------------------------------------------
+
+def test_idempotency_case_drift():
+    """Первый прогон создаёт fingerprint; второй с дрейфом регистра возвращает тот же.
+
+    Моделируем ситуацию: LLM во втором прогоне вернула тот же баг, но с иным регистром.
+    fingerprint второй находки должен совпадать с уже опубликованным из первого прогона.
+    """
+    f1 = make_finding(message="Баг в функции eval")   # первый прогон
+    f2 = make_finding(message="баг в функции eval")   # второй прогон — дрейф регистра
+
+    existing_fps = {f1.fingerprint()}
+    assert f2.fingerprint() in existing_fps
+
+
+def test_idempotency_punctuation_drift():
+    """Финальная точка в сообщении второго прогона не создаёт новый fingerprint."""
+    f1 = make_finding(message="небезопасная функция")
+    f2 = make_finding(message="небезопасная функция.")
+
+    existing_fps = {f1.fingerprint()}
+    assert f2.fingerprint() in existing_fps
+
+
+def test_idempotency_space_drift():
+    """Лишний пробел в сообщении второго прогона не создаёт новый fingerprint."""
+    f1 = make_finding(message="переменная не используется")
+    f2 = make_finding(message="переменная  не используется")  # два пробела
+
+    existing_fps = {f1.fingerprint()}
+    assert f2.fingerprint() in existing_fps


### PR DESCRIPTION
## Задача
PRI-152 / ID-152 — Нормализация текста перед dedup и fingerprint находок (меньше дублей-комментариев).

`dedup_findings` сравнивал сообщения через `SequenceMatcher` без нормализации, а `Finding.fingerprint()` хэшировал сырой `message`. Мелкая правка формулировки LLM (регистр, лишний пробел, финальная пунктуация) проходила dedup и давала фантомный повтор комментария между прогонами — ломалась идемпотентность.

## Что сделано
- Добавлена `normalize_message()` в `reviewer/vcs/base.py`: `casefold` (юникод-корректный lower) + замена пунктуации на пробел (`[^\w\s]`, `\w` юникодный — кириллица сохраняется) + схлопывание пробелов + тримминг.
- Применена в трёх точках:
  - `Finding.fingerprint()` — message нормализуется в составе ключа хэша;
  - `dedup.py` точный ключ — `(file, line, category, normalize_message(message))`;
  - `dedup.py` `_fuzzy_match` — нормализация вместо `.lower()`.
- Координаты (`file`/`line`/`side`/`category`) в fingerprint не трогаются.

## Критерии приёмки
- ✅ Near-duplicate находки схлопываются (на точном и fuzzy шагах).
- ✅ Повторный прогон не плодит дубли при незначительно изменённой формулировке (fingerprint стабилен к дрейфу регистра/пробелов/пунктуации).

## Тесты
- `tests/vcs/test_finding_fingerprint.py` (новый): `normalize_message` (регистр ASCII/кириллица, пробелы, пунктуация, тримминг), стабильность `fingerprint()` к дрейфу + различение по координатам, идемпотентность.
- `tests/agent/test_dedup.py` (+4): схлопывание на точном шаге по регистру/пунктуации/пробелам, fuzzy с дрейфом.
- Юнит-набор: **579 passed**; ruff по изменённым файлам — чисто.

## ⚠️ Разовая миграционная цена
Смена алгоритма `fingerprint()` меняет хэш у всех находок. Первый прогон после деплоя может не сматчить старые опубликованные маркеры `<!-- ai-review:hash -->` и единично повторить комментарий по уже открытым PR. Неизбежно и оправдано задачей; дальше идемпотентность только улучшается.