### PR TITLE
feat(tasks): relevance-score + ранг в search_tasks и блочное усечение get_task_context (PRI-153)

### DIFF
--- a/reviewer/tasks/service.py
+++ b/reviewer/tasks/service.py
@@ -218,9 +218,12 @@ class TaskService:
             return "(task search unavailable)"
         if not hits:
             return "(no similar tasks found)"
+        # Ранг-ординал — стабильный, query-независимый сигнал для relevance-фильтра
+        # (solve-task/review-pr прунят по порядку). Score даём с 4 знаками: RRF лежит
+        # в ≈0.016–0.033, и грубая точность схлопнула бы близкие задачи в одно число.
         return "\n".join(
-            f"- {h.key} [{h.status or '—'}] {h.title} (score {h.score:.2f})"
-            for h in hits)
+            f"{i}. {h.key} [{h.status or '—'}] {h.title} (score {h.score:.4f})"
+            for i, h in enumerate(hits, 1))
 
     def get_task_context(self, key: str) -> str:
         """Граф-контекст задачи: связанные задачи → их PR → код. Деградация → нота."""
@@ -332,41 +335,56 @@ class TaskService:
 
 
 def _format_task_context(ctx: dict, max_chars: int) -> str:
-    lines: list[str] = []
+    # Заголовочный блок (всегда сохраняется): задача, статус, url.
     head = f"Task {ctx.get('key')}"
     if ctx.get("status"):
         head += f" [{ctx['status']}]"
     if ctx.get("title"):
         head += f": {ctx['title']}"
-    lines.append(head)
+    head_block = [head]
     if ctx.get("url"):
-        lines.append(f"  url: {ctx['url']}")
+        head_block.append(f"  url: {ctx['url']}")
+
+    # Остальное — атомарные блоки: каждый PR и каждая связанная задача отдельным
+    # блоком; заголовок секции прикреплён к первому её блоку, чтобы при усечении
+    # на границе блока он не осиротел (а структура списка не рвалась посреди строки).
+    blocks: list[list[str]] = []
 
     prs = ctx.get("prs") or []
-    if prs:
-        lines.append("  Implemented by PRs:")
-        for p in prs:
-            line = f"    - {p.get('id')}"
-            if p.get("url"):
-                line += f" ({p['url']})"
-            touched = ", ".join(p.get("touched") or [])
-            if touched:
-                line += f" touches: {touched}"
-            lines.append(line)
+    for idx, p in enumerate(prs):
+        line = f"    - {p.get('id')}"
+        if p.get("url"):
+            line += f" ({p['url']})"
+        touched = ", ".join(p.get("touched") or [])
+        if touched:
+            line += f" touches: {touched}"
+        blocks.append(["  Implemented by PRs:", line] if idx == 0 else [line])
 
     linked = ctx.get("linked") or []
-    if linked:
-        lines.append("  Linked tasks:")
-        for n in linked:
-            ltype = n.get("type") or "relates"
-            nstatus = f" [{n['status']}]" if n.get("status") else ""
-            line = f"    - [{ltype}] {n.get('key')}{nstatus}: {n.get('title') or ''}"
-            npr = [p.get("id") for p in (n.get("prs") or []) if p.get("id")]
-            if npr:
-                line += "  PRs: " + ", ".join(npr)
-            lines.append(line)
+    for idx, n in enumerate(linked):
+        ltype = n.get("type") or "relates"
+        nstatus = f" [{n['status']}]" if n.get("status") else ""
+        line = f"    - [{ltype}] {n.get('key')}{nstatus}: {n.get('title') or ''}"
+        npr = [p.get("id") for p in (n.get("prs") or []) if p.get("id")]
+        if npr:
+            line += "  PRs: " + ", ".join(npr)
+        blocks.append(["  Linked tasks:", line] if idx == 0 else [line])
 
-    out = "\n".join(lines)
-    if len(out) > max_chars:
-        out = out[:max_chars] + "\n… (truncated)"
+    # Жадная сборка по границам блоков: голова обязательна, далее каждый блок
+    # добавляем целиком, пока влезает в бюджет; иначе стоп с нотой о хвосте.
+    out_lines = list(head_block)
+    total = len("\n".join(out_lines))
+    dropped = 0
+    for i, block in enumerate(blocks):
+        btext = "\n".join(block)
+        if total + 1 + len(btext) <= max_chars:
+            out_lines.extend(block)
+            total += 1 + len(btext)
+        else:
+            dropped = len(blocks) - i
+            break
+
+    out = "\n".join(out_lines)
+    if dropped:
+        out += f"\n… (truncated {dropped} more)"
     return out

--- a/tests/tasks/test_service.py
+++ b/tests/tasks/test_service.py
@@ -173,6 +173,23 @@ def test_search_tasks_empty():
     assert out == "(no similar tasks found)"
 
 
+def test_search_tasks_shows_rank_and_precise_score():
+    # RRF-скоры лежат в ≈0.016–0.033 — при грубой точности (.2f) близкие задачи
+    # схлопываются в одно число и прунить по score нельзя. Выдача должна показывать
+    # ранг-ординал (стабильный сигнал для relevance-фильтра) и различимый score.
+    from reviewer.tasks.store import TaskHit
+    store = _FakeStore(search_result=[
+        TaskHit("ID-1", "First", "Open", 0.0328),
+        TaskHit("ID-2", "Second", "Done", 0.0164),
+    ])
+    out = TaskService(store, _FakeGraph(), _FakeEmbedder()).search_tasks("q")
+    lines = out.splitlines()
+    assert lines[0].startswith("1. ") and "ID-1" in lines[0]
+    assert lines[1].startswith("2. ") and "ID-2" in lines[1]
+    # близкие RRF-скоры различимы (не оба «0.03»)
+    assert "0.0328" in out and "0.0164" in out
+
+
 def test_get_task_context_graph_none():
     out = TaskService(_FakeStore(), None, _FakeEmbedder()).get_task_context("ID-1")
     assert out == "(task graph unavailable)"
@@ -191,6 +208,40 @@ def test_get_task_context_formats():
     out = TaskService(_FakeStore(), _FakeGraph(context=ctx), _FakeEmbedder()).get_task_context("ID-1")
     assert "ID-1" in out and "o/r#7" in out and "a.py#foo" in out
     assert "subtask" in out and "ID-2" in out
+
+
+def test_format_task_context_truncates_on_block_boundary():
+    # Усечение не должно резать середину строки/блока: выбрасываются целые
+    # элементы (PR/связанная задача) с хвоста, заголовок секции не осиротеет.
+    from reviewer.tasks.service import _format_task_context
+    ctx = {"key": "ID-1", "title": "T", "status": "Open",
+           "prs": [{"id": "o/r#1", "touched": ["a.py#foo"]},
+                   {"id": "o/r#2", "touched": ["b.py#bar"]},
+                   {"id": "o/r#3", "touched": ["c.py#baz"]}]}
+    full = _format_task_context(ctx, 100000)
+    valid_lines = set(full.splitlines())
+    # бюджет режет ВНУТРИ строки второго PR — место, где наивный truncate оборвал
+    # бы строку посередине; блочное усечение должно выбросить весь блок PR2.
+    budget = full.index("b.py#bar")
+    out = _format_task_context(ctx, budget)
+    lines = out.splitlines()
+    assert lines[-1].startswith("… (truncated")  # нота на отдельной строке
+    for ln in lines[:-1]:                         # ни одной оборванной строки
+        assert ln in valid_lines
+    assert "o/r#1" in out                         # первый PR сохранён целиком
+    assert "b.py#bar" not in out                  # оборванный хвост не просочился
+
+
+def test_format_task_context_keeps_head_when_over_budget():
+    # Голова (ключ/статус/заголовок) обязательна и не режется посреди строки,
+    # даже если одна она превышает бюджет.
+    from reviewer.tasks.service import _format_task_context
+    ctx = {"key": "ID-1", "title": "Очень длинный заголовок " * 5,
+           "prs": [{"id": "o/r#1"}]}
+    out = _format_task_context(ctx, 5)
+    assert out.splitlines()[0].startswith("Task ID-1")  # голова цела
+    assert "o/r#1" not in out
+    assert "truncated" in out
 
 
 def test_link_review_calls_graph():


### PR DESCRIPTION
## Задача
PRI-153 — `search_tasks` отдавал top-K без пригодного для прунинга score, а `get_task_context` резался сырым `out[:max_chars]` (ломало структуру списка задач/PR — отсекалась середина строки).

## Что сделано
- **`search_tasks`**: каждая задача теперь с ранг-ординалом (`1.`, `2.`, …) и score с точностью `.4f` вместо `.2f`. RRF-скоры лежат в ≈0.016–0.033, и `.2f` схлопывал близкие задачи в одинаковые `0.02`/`0.03` — прунить было нельзя. Ранг — стабильный, query-независимый сигнал ровно для того relevance-фильтра, что использует `solve-task`/`review-pr`.
- **`get_task_context` (`_format_task_context`)**: усечение по границам атомарных блоков (целые PR / связанные задачи) вместо обрезки середины строки. Заголовок секции прикреплён к первому её блоку (не осиротеет), голова (ключ/статус/заголовок) сохраняется всегда, в конце — нота `… (truncated N more)`.

## Критерии приёмки
- ✅ В выдаче виден различимый score (+ ранг).
- ✅ Усечение не ломает структуру (выбрасываются целые блоки с хвоста).
- ✅ solve-task может отсечь low-score элементы по рангу/скору.

## Тесты
- Новые unit-тесты: ранг+точность score, блочное усечение на середине строки, сохранение головы при переполнении.
- `tests/tasks/test_service.py` — 34 passed; полный unit-набор — 582 passed; `tests/tasks/test_integration.py -m integration` — 10 passed; ruff чисто.