### PR TITLE
feat(mcp): structured outputs для findings/verdicts (PRI-156)

### DIFF
--- a/docs/superpowers/plans/2026-06-22-pri-156-structured-outputs.md
+++ b/docs/superpowers/plans/2026-06-22-pri-156-structured-outputs.md
@@ -1,0 +1,1043 @@
+# PRI-156 Structured Outputs (schema-enforced findings/verdicts) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Перевести вывод субагентов analyze/dimension/verify с free-text JSON на schema-enforced через MCP-тулы `submit_findings`/`submit_verdicts`, с единым Pydantic-источником схемы и сессионным накоплением находок.
+
+**Architecture:** Субагенты вызывают MCP-тулы (FastMCP/Pydantic валидирует аргументы по схеме → энфорс на тул-границе), находки копятся в `_Session` с server-assigned id; `publish_review` читает их из сессии (параметр `findings` убран); отсутствие verdict = keep (recall-safe структурно).
+
+**Tech Stack:** Python 3.11+, Pydantic v2, FastMCP (`mcp.server.fastmcp`), pytest.
+
+## Global Constraints
+
+- Python 3.11–3.13; ruff line-length 100, target py311 (`.venv/bin/ruff check .`).
+- Проект на русском: комментарии, докстринги, сообщения CLI.
+- Коммиты: Conventional Commits на русском (`feat(mcp): …`), **без self-attribution** (никаких Co-Authored-By/Claude).
+- `pytest` по умолчанию исключает integration (`-m 'not integration'`); все unit-тесты на фейках.
+- Guard-тесты `tests/skills/` держать зелёными.
+- Pydantic v2 (проект уже на pydantic-settings → pydantic v2).
+- Единый источник LLM-facing схемы — `FindingIn`/`VerdictIn`; коэрция **мягкая** = дословный порт `_finding_from_dict` (сохраняет PRI-144).
+- Ветка: `feat/structured-outputs-pri-156`.
+
+---
+
+### Task 1: Pydantic-схемы findings/verdicts (`reviewer/mcp/schemas.py`)
+
+Новый модуль — канонический источник LLM-facing схемы. Валидаторы — дословный порт `_finding_from_dict` (service.py:50-107): мягкая коэрция, только `file` обязателен.
+
+**Files:**
+- Create: `reviewer/mcp/schemas.py`
+- Test: `tests/mcp/test_schemas.py`
+
+**Interfaces:**
+- Produces: `FixIn`, `FindingIn`, `VerdictIn` (Pydantic BaseModel).
+  - `FindingIn` поля: `file: str` (required), `category: str="correctness"`, `severity: str="medium"`, `side: str="RIGHT"`, `line: int|None=None`, `code_quote: str|None=None`, `message: str=""`, `suggestion: str|None=None`, `confidence: float=0.1`, `fix: FixIn|None=None`.
+  - `FixIn` поля: `start_line: int|None`, `end_line: int|None`, `replacement: str|None`.
+  - `VerdictIn` поля: `id: str`, `is_real: bool`.
+
+- [ ] **Step 1: Написать падающий тест коэрции (паритет с `_finding_from_dict`)**
+
+Create `tests/mcp/test_schemas.py`:
+
+```python
+"""Тесты FindingIn/VerdictIn — мягкая коэрция (порт _finding_from_dict, PRI-144)."""
+from __future__ import annotations
+
+import pytest
+
+from reviewer.mcp.schemas import FindingIn, FixIn, VerdictIn
+
+BASE = {"file": "a.py", "severity": "high", "message": "m", "line": 1, "code_quote": "x = 1"}
+
+
+def test_confidence_coercion_and_clamp():
+    # валидные проходят как есть
+    assert FindingIn.model_validate({**BASE, "confidence": 0.9}).confidence == 0.9
+    assert FindingIn.model_validate({**BASE, "confidence": 0.5}).confidence == 0.5
+    # не оценено / None / мусор → 0.1
+    assert FindingIn.model_validate(BASE).confidence == 0.1
+    assert FindingIn.model_validate({**BASE, "confidence": None}).confidence == 0.1
+    assert FindingIn.model_validate({**BASE, "confidence": "abc"}).confidence == 0.1
+    # clamp в [0,1]
+    assert FindingIn.model_validate({**BASE, "confidence": 1.5}).confidence == 1.0
+    assert FindingIn.model_validate({**BASE, "confidence": -0.2}).confidence == 0.0
+
+
+def test_severity_side_defaults():
+    assert FindingIn.model_validate({**BASE, "severity": "urgent"}).severity == "medium"
+    assert FindingIn.model_validate({**BASE, "severity": ["high"]}).severity == "medium"
+    assert FindingIn.model_validate({**BASE, "side": "MIDDLE"}).side == "RIGHT"
+    assert FindingIn.model_validate({**BASE, "side": "LEFT"}).side == "LEFT"
+
+
+def test_line_coercion():
+    assert FindingIn.model_validate({**BASE, "line": "42"}).line == 42
+    assert FindingIn.model_validate({**BASE, "line": "abc"}).line is None
+    assert FindingIn.model_validate({**BASE, "line": None}).line is None
+
+
+def test_suggestion_and_codequote_nonstring_to_none():
+    assert FindingIn.model_validate({**BASE, "suggestion": 42}).suggestion is None
+    assert FindingIn.model_validate({**BASE, "suggestion": "do x"}).suggestion == "do x"
+    assert FindingIn.model_validate({**BASE, "code_quote": 7}).code_quote is None
+
+
+def test_fix_dropped_when_incomplete():
+    ok = FindingIn.model_validate({**BASE, "fix": {"start_line": 1, "end_line": 2, "replacement": "z"}})
+    assert ok.fix == FixIn(start_line=1, end_line=2, replacement="z")
+    # нестроковый replacement → вся fix отбрасывается
+    assert FindingIn.model_validate({**BASE, "fix": {"start_line": 1, "end_line": 2, "replacement": 9}}).fix is None
+    # мусорный start_line → вся fix отбрасывается
+    assert FindingIn.model_validate({**BASE, "fix": {"start_line": "x", "end_line": 2, "replacement": "z"}}).fix is None
+    assert FindingIn.model_validate({**BASE, "fix": None}).fix is None
+
+
+def test_file_required():
+    with pytest.raises(Exception):
+        FindingIn.model_validate({"severity": "high", "message": "no file"})
+
+
+def test_category_default():
+    assert FindingIn.model_validate(BASE).category == "correctness"
+    assert FindingIn.model_validate({**BASE, "category": "security"}).category == "security"
+
+
+def test_verdict_in():
+    v = VerdictIn.model_validate({"id": "f3", "is_real": False})
+    assert v.id == "f3" and v.is_real is False
+    with pytest.raises(Exception):
+        VerdictIn.model_validate({"id": "f3"})   # is_real required
+```
+
+- [ ] **Step 2: Запустить тест — убедиться, что падает**
+
+Run: `.venv/bin/pytest tests/mcp/test_schemas.py -q`
+Expected: FAIL — `ModuleNotFoundError: No module named 'reviewer.mcp.schemas'`.
+
+- [ ] **Step 3: Реализовать `reviewer/mcp/schemas.py`**
+
+```python
+"""Pydantic-схемы LLM-facing вывода ревью — единый источник (PRI-156).
+
+``FindingIn``/``VerdictIn`` — канон схемы findings/verdicts: из них FastMCP
+выводит схему тулов ``submit_findings``/``submit_verdicts`` (энфорс на тул-границе),
+из них же строится внутренний ``Finding`` (``Finding.from_in``). Валидаторы —
+дословный порт ``_finding_from_dict`` (мягкая коэрция, сохраняет PRI-144):
+кривые значения коэрцируются с дефолтами, обязателен только ``file``.
+"""
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict, field_validator
+
+_VALID_SEVERITIES = frozenset({"low", "medium", "high", "critical"})
+
+
+def _coerce_int(value) -> int | None:
+    """int-коэрция LLM-значения: int("42") → 42, None/мусор → None."""
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
+class FixIn(BaseModel):
+    """Applyable-правка: точная замена диапазона строк НОВОЙ версии (RIGHT)."""
+
+    model_config = ConfigDict(extra="ignore")
+
+    start_line: int | None = None
+    end_line: int | None = None
+    replacement: str | None = None
+
+
+class FindingIn(BaseModel):
+    """LLM-facing находка. Мягкая коэрция = порт ``_finding_from_dict``."""
+
+    model_config = ConfigDict(extra="ignore")
+
+    file: str
+    category: str = "correctness"
+    severity: str = "medium"
+    side: str = "RIGHT"
+    line: int | None = None
+    code_quote: str | None = None
+    message: str = ""
+    suggestion: str | None = None
+    confidence: float = 0.1
+    fix: FixIn | None = None
+
+    @field_validator("category", mode="before")
+    @classmethod
+    def _category(cls, v):
+        return str(v) if v else "correctness"
+
+    @field_validator("severity", mode="before")
+    @classmethod
+    def _severity(cls, v):
+        return v if isinstance(v, str) and v in _VALID_SEVERITIES else "medium"
+
+    @field_validator("side", mode="before")
+    @classmethod
+    def _side(cls, v):
+        return v if v in ("RIGHT", "LEFT") else "RIGHT"
+
+    @field_validator("line", mode="before")
+    @classmethod
+    def _line(cls, v):
+        return _coerce_int(v)
+
+    @field_validator("code_quote", mode="before")
+    @classmethod
+    def _code_quote(cls, v):
+        return v if isinstance(v, str) else None
+
+    @field_validator("message", mode="before")
+    @classmethod
+    def _message(cls, v):
+        return str(v) if v else ""
+
+    @field_validator("suggestion", mode="before")
+    @classmethod
+    def _suggestion(cls, v):
+        return v if isinstance(v, str) else None
+
+    @field_validator("confidence", mode="before")
+    @classmethod
+    def _confidence(cls, v):
+        try:
+            c = float(v)
+        except (TypeError, ValueError):
+            c = 0.1   # не оценено = спекулятивно (ниже честного потолка 0.4) → отсекается гейтом
+        return max(0.0, min(1.0, c))
+
+    @field_validator("fix", mode="before")
+    @classmethod
+    def _fix(cls, v):
+        # Кривая/неполная fix отбрасывается целиком (как в _finding_from_dict).
+        if not isinstance(v, dict):
+            return None
+        start = _coerce_int(v.get("start_line"))
+        end = _coerce_int(v.get("end_line"))
+        replacement = v.get("replacement")
+        if start is None or end is None or not isinstance(replacement, str):
+            return None
+        return {"start_line": start, "end_line": end, "replacement": replacement}
+
+
+class VerdictIn(BaseModel):
+    """Вердикт verify по находке с server-assigned id."""
+
+    model_config = ConfigDict(extra="ignore")
+
+    id: str
+    is_real: bool
+```
+
+- [ ] **Step 4: Запустить тест — убедиться, что проходит + ruff**
+
+Run: `.venv/bin/pytest tests/mcp/test_schemas.py -q && .venv/bin/ruff check reviewer/mcp/schemas.py tests/mcp/test_schemas.py`
+Expected: PASS, ruff clean.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add reviewer/mcp/schemas.py tests/mcp/test_schemas.py
+git commit -m "feat(mcp): Pydantic-схемы FindingIn/VerdictIn — канон LLM-facing вывода (PRI-156)"
+```
+
+---
+
+### Task 2: `Finding.from_in` — конструктор из FindingIn (`reviewer/vcs/base.py`)
+
+Внутренний `Finding` строится из валидированного `FindingIn` (+`centrality=0.0`). Дакт-тайпинг (без runtime-импорта `FindingIn`, чтобы не плодить обратную зависимость vcs→mcp).
+
+**Files:**
+- Modify: `reviewer/vcs/base.py:41-61` (dataclass `Finding`)
+- Test: `tests/vcs/test_finding_from_in.py`
+
+**Interfaces:**
+- Consumes: `FindingIn` (Task 1) — читается по атрибутам.
+- Produces: `Finding.from_in(fi) -> Finding`.
+
+- [ ] **Step 1: Написать падающий тест**
+
+Create `tests/vcs/test_finding_from_in.py`:
+
+```python
+"""Finding.from_in: построение внутреннего Finding из валидированного FindingIn."""
+from reviewer.mcp.schemas import FindingIn
+from reviewer.vcs.base import Finding
+
+
+def test_from_in_maps_fields_and_fix():
+    fi = FindingIn.model_validate({
+        "file": "a.py", "severity": "high", "line": 2, "code_quote": "x = 1",
+        "message": "bug", "suggestion": "fix it", "confidence": 0.9,
+        "fix": {"start_line": 2, "end_line": 2, "replacement": "x = 2"},
+    })
+    f = Finding.from_in(fi)
+    assert isinstance(f, Finding)
+    assert (f.file, f.line, f.side, f.severity) == ("a.py", 2, "RIGHT", "high")
+    assert f.message == "bug" and f.suggestion == "fix it" and f.confidence == 0.9
+    assert (f.fix_start, f.fix_end, f.replacement) == (2, 2, "x = 2")
+    assert f.code_quote == "x = 1"
+    assert f.centrality == 0.0
+
+
+def test_from_in_without_fix():
+    fi = FindingIn.model_validate({"file": "b.py", "message": "m"})
+    f = Finding.from_in(fi)
+    assert (f.fix_start, f.fix_end, f.replacement) == (None, None, None)
+    assert f.category == "correctness" and f.confidence == 0.1
+```
+
+- [ ] **Step 2: Запустить — убедиться, что падает**
+
+Run: `.venv/bin/pytest tests/vcs/test_finding_from_in.py -q`
+Expected: FAIL — `AttributeError: type object 'Finding' has no attribute 'from_in'`.
+
+- [ ] **Step 3: Добавить `from_in` в `Finding`**
+
+В `reviewer/vcs/base.py` добавить вверху файла (после существующих импортов, строка 3 — `from typing import Literal, Protocol`):
+
+```python
+from typing import TYPE_CHECKING, Literal, Protocol
+
+if TYPE_CHECKING:
+    from reviewer.mcp.schemas import FindingIn
+```
+
+В классе `Finding` (после метода `fingerprint`, строка 61) добавить classmethod:
+
+```python
+    @classmethod
+    def from_in(cls, fi: "FindingIn") -> "Finding":
+        """Построить внутренний Finding из валидированного FindingIn (PRI-156).
+
+        Дакт-тайпинг по атрибутам: без runtime-импорта FindingIn (vcs не зависит
+        от mcp). centrality стартует с 0.0 (проставляется графом в publish_review).
+        """
+        fix = fi.fix
+        return cls(
+            category=fi.category,
+            severity=fi.severity,
+            file=fi.file,
+            line=fi.line,
+            side=fi.side,
+            message=fi.message,
+            suggestion=fi.suggestion,
+            confidence=fi.confidence,
+            fix_start=fix.start_line if fix else None,
+            fix_end=fix.end_line if fix else None,
+            replacement=fix.replacement if fix else None,
+            code_quote=fi.code_quote,
+        )
+```
+
+- [ ] **Step 4: Запустить — убедиться, что проходит + ruff**
+
+Run: `.venv/bin/pytest tests/vcs/test_finding_from_in.py -q && .venv/bin/ruff check reviewer/vcs/base.py`
+Expected: PASS, ruff clean.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add reviewer/vcs/base.py tests/vcs/test_finding_from_in.py
+git commit -m "feat(vcs): Finding.from_in — конструктор из валидированного FindingIn (PRI-156)"
+```
+
+---
+
+### Task 3: Сессионное накопление + submit-методы (`reviewer/mcp/service.py`)
+
+Расширить `_Session` (candidates/verdicts/_seq) и добавить методы `submit_findings`/`get_candidate_findings`/`submit_verdicts`.
+
+**Files:**
+- Modify: `reviewer/mcp/service.py:110-117` (`_Session`), импорт схем; добавить методы.
+- Test: `tests/mcp/test_submit_tools.py`
+
+**Interfaces:**
+- Consumes: `FindingIn`, `VerdictIn` (Task 1), `Finding.from_in` (Task 2).
+- Produces (методы `MCPReviewService`):
+  - `submit_findings(repo: str, pr: int, findings: list[dict]) -> dict` → `{"accepted": int, "ids": list[str]}`. id вида `"f{n}"`.
+  - `get_candidate_findings(repo: str, pr: int) -> str` → JSON-строка `{"candidates": [{id,file,line,category,severity,message,code_quote}]}`.
+  - `submit_verdicts(repo: str, pr: int, verdicts: list[dict]) -> dict` → `{"recorded": int, "unknown_ids": list[str]}`.
+- `_Session` получает поля `candidates: dict[str, Finding]`, `verdicts: dict[str, bool]`, `_seq: int`.
+
+- [ ] **Step 1: Написать падающий тест**
+
+Create `tests/mcp/test_submit_tools.py`:
+
+```python
+"""submit_findings/get_candidate_findings/submit_verdicts — сессионное накопление."""
+from __future__ import annotations
+
+import json
+from unittest.mock import patch
+
+from tests.mcp.test_publish import (
+    RAW, _make_mcp_service_with_publish, _fake_chunk,
+)
+
+
+@patch("reviewer.services.review_service.chunk_python", side_effect=_fake_chunk)
+@patch("reviewer.services.review_service.build_overlay")
+def test_submit_findings_accumulates_with_ids(_ov, _ch):
+    svc, _, _ = _make_mcp_service_with_publish()
+    svc.prepare_review("o/r", 7)
+    r1 = svc.submit_findings("o/r", 7, [RAW])
+    r2 = svc.submit_findings("o/r", 7, [dict(RAW, message="bug B")])
+    assert r1 == {"accepted": 1, "ids": ["f1"]}
+    assert r2 == {"accepted": 1, "ids": ["f2"]}
+    sess = svc._sessions[("o/r", 7)]
+    assert set(sess.candidates) == {"f1", "f2"}
+    assert sess.candidates["f1"].message == "bug here"
+
+
+@patch("reviewer.services.review_service.chunk_python", side_effect=_fake_chunk)
+@patch("reviewer.services.review_service.build_overlay")
+def test_get_candidate_findings_returns_ids(_ov, _ch):
+    svc, _, _ = _make_mcp_service_with_publish()
+    svc.prepare_review("o/r", 7)
+    svc.submit_findings("o/r", 7, [RAW])
+    payload = json.loads(svc.get_candidate_findings("o/r", 7))
+    assert payload["candidates"][0]["id"] == "f1"
+    assert payload["candidates"][0]["file"] == "a.py"
+    assert payload["candidates"][0]["code_quote"] == "x = 1"
+
+
+@patch("reviewer.services.review_service.chunk_python", side_effect=_fake_chunk)
+@patch("reviewer.services.review_service.build_overlay")
+def test_submit_verdicts_records_and_flags_unknown(_ov, _ch):
+    svc, _, _ = _make_mcp_service_with_publish()
+    svc.prepare_review("o/r", 7)
+    svc.submit_findings("o/r", 7, [RAW])              # → f1
+    r = svc.submit_verdicts("o/r", 7, [{"id": "f1", "is_real": False},
+                                       {"id": "f9", "is_real": True}])
+    assert r == {"recorded": 1, "unknown_ids": ["f9"]}
+    assert svc._sessions[("o/r", 7)].verdicts == {"f1": False}
+```
+
+- [ ] **Step 2: Запустить — убедиться, что падает**
+
+Run: `.venv/bin/pytest tests/mcp/test_submit_tools.py -q`
+Expected: FAIL — `AttributeError: 'MCPReviewService' object has no attribute 'submit_findings'`.
+
+- [ ] **Step 3a: Добавить импорт схем и расширить `_Session`**
+
+В `reviewer/mcp/service.py` к импортам (после строки 33 `from reviewer.vcs.base import …`) добавить:
+
+```python
+from reviewer.mcp.schemas import FindingIn, VerdictIn
+```
+
+Заменить `dataclass`-импорт (строка 8) на:
+
+```python
+from dataclasses import dataclass, field
+```
+
+Заменить класс `_Session` (строки 110-117) на:
+
+```python
+@dataclass
+class _Session:
+    prepared: PreparedReview
+    # Храним ctx, а не готовые tools: make_tools(ctx) пересоздаётся на каждый
+    # _invoke_tool-вызов, чтобы seen-дедуп (set внутри make_tools) сбрасывался
+    # пер-вызов. Повторный одинаковый вызов отдаёт реальный результат из
+    # ctx.cache (пер-сессия), а не заглушку «повтор: результат уже показан выше».
+    ctx: ToolContext
+    # PRI-156: schema-enforced находки/вердикты копятся в сессии между submit_*
+    # и publish_review. id вида "f{n}" присваивает submit_findings. Состояние
+    # in-memory (регидрированная из стора сессия стартует пустой — допустимо:
+    # перезапуск процесса посреди ревью теряет прогресс, как и раньше).
+    candidates: dict[str, Finding] = field(default_factory=dict)
+    verdicts: dict[str, bool] = field(default_factory=dict)
+    _seq: int = 0
+```
+
+- [ ] **Step 3b: Добавить submit-методы**
+
+В `MCPReviewService` (например, сразу перед `def publish_review`, строка ~512) добавить:
+
+```python
+    def submit_findings(self, repo: str, pr: int, findings: list[dict]) -> dict:
+        """Принять находки субагента в сессию (PRI-156): валидация по FindingIn,
+        присвоение server-assigned id, накопление в _Session.candidates.
+
+        Энфорс схемы — на тул-границе FastMCP (тип list[FindingIn]); здесь
+        повторная model_validate коэрцирует/валидирует dict при прямом вызове
+        (тесты). Невалидный элемент (нет file) → ValidationError → ретрай тула.
+        """
+        from reviewer.services.repo_id import normalize_repo
+        repo = normalize_repo(repo)
+        s = self._session(repo, pr)
+        ids: list[str] = []
+        for d in findings:
+            fi = FindingIn.model_validate(d)
+            s._seq += 1
+            fid = f"f{s._seq}"
+            s.candidates[fid] = Finding.from_in(fi)
+            ids.append(fid)
+        return {"accepted": len(ids), "ids": ids}
+
+    def get_candidate_findings(self, repo: str, pr: int) -> str:
+        """Вернуть накопленных кандидатов с id для verify (JSON-строка)."""
+        import json
+        from reviewer.services.repo_id import normalize_repo
+        repo = normalize_repo(repo)
+        s = self._session(repo, pr)
+        items = [
+            {"id": fid, "file": f.file, "line": f.line, "category": f.category,
+             "severity": f.severity, "message": f.message, "code_quote": f.code_quote}
+            for fid, f in s.candidates.items()
+        ]
+        return json.dumps({"candidates": items}, ensure_ascii=False, indent=2)
+
+    def submit_verdicts(self, repo: str, pr: int, verdicts: list[dict]) -> dict:
+        """Принять вердикты verify в сессию (PRI-156). id вне candidates →
+        игнор + warning. Отсутствие вердикта по находке = keep (см. publish_review)."""
+        from reviewer.services.repo_id import normalize_repo
+        repo = normalize_repo(repo)
+        s = self._session(repo, pr)
+        recorded, unknown = 0, []
+        for d in verdicts:
+            v = VerdictIn.model_validate(d)
+            if v.id not in s.candidates:
+                unknown.append(v.id)
+                log.warning("submit_verdicts: неизвестный id %s (%s#%s)", v.id, repo, pr)
+                continue
+            s.verdicts[v.id] = v.is_real
+            recorded += 1
+        return {"recorded": recorded, "unknown_ids": unknown}
+```
+
+- [ ] **Step 4: Запустить — убедиться, что проходит + ruff**
+
+Run: `.venv/bin/pytest tests/mcp/test_submit_tools.py -q && .venv/bin/ruff check reviewer/mcp/service.py`
+Expected: PASS, ruff clean.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add reviewer/mcp/service.py tests/mcp/test_submit_tools.py
+git commit -m "feat(mcp): submit_findings/submit_verdicts/get_candidate_findings — сессионное накопление (PRI-156)"
+```
+
+---
+
+### Task 4: `publish_review` читает из сессии (`reviewer/mcp/service.py`)
+
+Убрать параметр `findings`; читать candidates+verdicts из сессии; отсев только по явному `is_real=false`; `verify_rejected` = число `False`. Удалить `_finding_from_dict`. Мигрировать тесты `test_publish.py`, `test_session_persist.py`, `test_service.py`.
+
+**Files:**
+- Modify: `reviewer/mcp/service.py` — `publish_review` (512-662), `_record_history` (664-733), удалить `_finding_from_dict` (50-107) и его использование.
+- Modify: `tests/mcp/test_publish.py`, `tests/mcp/test_session_persist.py`, `tests/mcp/test_service.py`.
+
+**Interfaces:**
+- Consumes: `_Session.candidates`/`verdicts` (Task 3).
+- Produces: `publish_review(repo, pr, summary, dry_run=False, task_key=None) -> dict`. Отчёт включает `verify_rejected`; `invalid` остаётся ключом со значением 0 (back-compat).
+
+- [ ] **Step 1: Мигрировать `test_publish.py` под новый поток (тесты сначала)**
+
+В `tests/mcp/test_publish.py` добавить хелпер (после фабрики `_make_mcp_service_with_publish`, строка ~170):
+
+```python
+def _submit_then_publish(svc, repo, pr, findings, *, summary="s", dry_run=False,
+                         verdicts=None, task_key=None):
+    """PRI-156: вместо publish_review(findings=...) — submit + publish из сессии."""
+    if findings:
+        svc.submit_findings(repo, pr, findings)
+    if verdicts:
+        svc.submit_verdicts(repo, pr, verdicts)
+    return svc.publish_review(repo, pr, summary=summary, dry_run=dry_run, task_key=task_key)
+```
+
+Заменить во всех тестах файла вызовы вида
+`svc.publish_review("o/r", 7, summary=S, findings=F[, dry_run=D])`
+на
+`_submit_then_publish(svc, "o/r", 7, F, summary=S[, dry_run=D])`.
+
+Затронутые места (строки на момент написания плана): 185, 197, 217-218, 228, 246, 265, 281, 301, 319, 330, 343-344, 366-368, 390, 410.
+
+Удалить тест `test_publish_coerces_malformed_llm_findings` (строки 286-306): кейс «без file → invalid» теперь невозможен — FindingIn отвергает на тул-границе, до publish такие не доходят. Коэрция confidence/severity покрыта `tests/mcp/test_schemas.py`. Вместо него добавить тест счётчика `invalid=0`:
+
+```python
+@patch("reviewer.services.review_service.chunk_python", side_effect=_fake_chunk)
+@patch("reviewer.services.review_service.build_overlay")
+def test_publish_invalid_always_zero_with_enforced_schema(_ov, _ch) -> None:
+    """Все candidates валидны (validated на submit) → invalid всегда 0."""
+    svc, _, _ = _make_mcp_service_with_publish()
+    svc.prepare_review("o/r", 7)
+    report = _submit_then_publish(svc, "o/r", 7, [RAW], dry_run=True)
+    assert report["invalid"] == 0
+```
+
+Аналогично заменить тест `test_publish_coerces_unhashable_severity_and_nonstringsuggestion` (строки 396-419): теперь коэрция на submit. Оставить проверку публикации (severity список → medium проходит гейт), но через `_submit_then_publish`:
+
+```python
+@patch("reviewer.services.review_service.chunk_python", side_effect=_fake_chunk)
+@patch("reviewer.services.review_service.build_overlay")
+def test_publish_coerced_findings_publish(_ov, _ch) -> None:
+    svc, _, _ = _make_mcp_service_with_publish()
+    svc.prepare_review("o/r", 7)
+    pack = [dict(RAW, severity=["high"], message="unhashable severity"),
+            dict(RAW, suggestion=42, message="non-string suggestion")]
+    report = _submit_then_publish(svc, "o/r", 7, pack, dry_run=True)
+    assert report["dropped_by_gate"] == 0
+    assert len(report["inline"]) == 2
+    inline_bodies = [c["body"] for c in report["inline"]]
+    assert not any("42" in b and "suggestion" in b.lower() for b in inline_bodies)
+```
+
+Добавить новые тесты verify-фолбэка:
+
+```python
+@patch("reviewer.services.review_service.chunk_python", side_effect=_fake_chunk)
+@patch("reviewer.services.review_service.build_overlay")
+def test_publish_drops_findings_with_is_real_false(_ov, _ch) -> None:
+    """Явный is_real=false → находка отсеяна; verify_rejected=1."""
+    svc, _, _ = _make_mcp_service_with_publish()
+    svc.prepare_review("o/r", 7)
+    report = _submit_then_publish(svc, "o/r", 7, [RAW], dry_run=True,
+                                  verdicts=[{"id": "f1", "is_real": False}])
+    assert report["verify_rejected"] == 1
+    assert report["inline"] == []
+
+
+@patch("reviewer.services.review_service.chunk_python", side_effect=_fake_chunk)
+@patch("reviewer.services.review_service.build_overlay")
+def test_publish_keeps_finding_without_verdict(_ov, _ch) -> None:
+    """Нет вердикта (verify умер/частичный) → находка остаётся (recall-safe)."""
+    svc, _, _ = _make_mcp_service_with_publish()
+    svc.prepare_review("o/r", 7)
+    report = _submit_then_publish(svc, "o/r", 7, [RAW], dry_run=True)  # без verdicts
+    assert report["verify_rejected"] == 0
+    assert report["inline"][0]["line"] == 2
+```
+
+- [ ] **Step 2: Запустить — убедиться, что падает**
+
+Run: `.venv/bin/pytest tests/mcp/test_publish.py -q`
+Expected: FAIL — `submit_findings`/новой сигнатуры ещё нет в publish; вызовы `publish_review(..., findings=...)` уже убраны, новые тесты падают на `verify_rejected`/`invalid` или на старой сигнатуре `publish_review` (TypeError: unexpected keyword не возникнет, т.к. findings убран из вызовов; упадут assert по verify_rejected — ключа ещё нет).
+
+- [ ] **Step 3a: Переписать `publish_review`**
+
+В `reviewer/mcp/service.py` заменить сигнатуру и блок 1 (коэрция входа). Новая сигнатура и докстринг:
+
+```python
+    def publish_review(
+        self,
+        repo: str,
+        pr: int,
+        summary: str,
+        dry_run: bool = False,
+        task_key: str | None = None,
+    ) -> dict:
+        """Детерминированный хвост ревью: verify-фильтр → grounding → gate →
+        dedup → assemble → публикация → история → очистка overlay/сессии.
+
+        PRI-156: находки и вердикты читаются ИЗ СЕССИИ (submit_findings/
+        submit_verdicts), параметр findings убран. Отсев verify — только по
+        явному is_real=false; отсутствие вердикта = keep (recall-safe).
+        Сессия (repo, pr) должна быть подготовлена prepare_review. Overlay и
+        сессия очищаются ВСЕГДА (даже при сбое VCS-публикации) — см. _cleanup.
+
+        При указании task_key и успешной публикации (не dry_run) линкует
+        PR↔задача↔код в граф задач (рёбра IMPLEMENTED_BY + TOUCHES).
+
+        Returns:
+            Отчёт со счётчиками (posted/invalid/verify_rejected/dropped_by_gate/
+            deduped/already_posted/moved_to_summary/capped) и inline.
+        """
+        from reviewer.services.repo_id import normalize_repo
+        repo = normalize_repo(repo)
+        s = self._session(repo, pr)
+        p = s.prepared
+
+        # 1) Verify-фильтр из сессии: keep, кроме явного is_real=false (recall-safe).
+        # Затем грунтовка строки по дословной цитате (анти-галлюцинация).
+        _commentable_cache: dict[str, dict[str, set[int]]] = {
+            path: commentable_lines(patch)
+            for path, patch in p.patches.items()
+            if patch is not None
+        }
+        survived = [f for fid, f in s.candidates.items() if s.verdicts.get(fid) is not False]
+        verify_rejected = len(s.candidates) - len(survived)
+        parsed: list[Finding] = []
+        for f in survived:
+            f.line = ground_line(p.sources.get(f.file), f.code_quote, f.line)
+            if f.line is not None and f.side == "RIGHT" and f.file in _commentable_cache:
+                f.line = snap_to_commentable(
+                    f.line, f.side, f.code_quote, _commentable_cache[f.file], p.sources.get(f.file, ""),
+                    max_distance=p.policy.grounding_max_distance,
+                )
+            parsed.append(f)
+```
+
+Остальные блоки 2–5 (gate/dedup/centrality/existing-fps/assemble/publish/link) — без изменений (с `parsed`). В блоке 6 (история+cleanup) пробросить `verify_rejected`. Заменить строки 638-644:
+
+```python
+        # 6) История (fail-soft) и очистка overlay/сессии (ВСЕГДА).
+        dropped_by_gate = len(parsed) - len(kept)
+        run_id = self._record_history(
+            repo, pr, p, list(s.candidates.values()), deduped, asm,
+            dropped_by_gate=dropped_by_gate, verify_rejected=verify_rejected,
+            dry_run=dry_run, posted=posted, error=error,
+        )
+        self._cleanup(repo, pr)
+```
+
+В возвращаемом отчёте (строки 646-662) заменить `"invalid": invalid,` на `"invalid": 0,` и добавить `"verify_rejected": verify_rejected,`:
+
+```python
+        return {
+            "posted": posted,
+            "dry_run": dry_run,
+            "error": error,
+            "run_id": run_id,
+            "summary": full_summary,
+            "inline": [
+                {"path": c.path, "line": c.line, "side": c.side, "body": c.body}
+                for c in asm.inline_comments
+            ],
+            "invalid": 0,                       # PRI-156: вход валиден по схеме (submit)
+            "verify_rejected": verify_rejected,
+            "dropped_by_gate": dropped_by_gate,
+            "deduped": len(kept) - len(deduped),
+            "already_posted": asm.skipped_existing,
+            "moved_to_summary": asm.moved_to_summary,
+            "capped": asm.capped,
+        }
+```
+
+- [ ] **Step 3b: Обновить `_record_history` (analyzed = candidates, verify_rejected проброшен)**
+
+Заменить сигнатуру `_record_history` (664-677): параметр `parsed` → `analyzed`, добавить `verify_rejected`:
+
+```python
+    def _record_history(
+        self,
+        repo: str,
+        pr: int,
+        p: PreparedReview,
+        analyzed: list[Finding],
+        deduped: list[Finding],
+        asm: AssembledReview,
+        *,
+        dropped_by_gate: int,
+        verify_rejected: int,
+        dry_run: bool,
+        posted: bool,
+        error: str,
+    ) -> int | None:
+```
+
+В теле заменить строку 695 и блок verify_rejected (713-715):
+
+```python
+            findings_analyzed = len({f.fingerprint() for f in analyzed})
+```
+```python
+                "findings_analyzed": findings_analyzed,
+                "findings_kept": len(deduped),
+                # PRI-156: verify_rejected = число is_real=false (verify живёт в
+                # сессии submit_verdicts); gate-отсев отдельно в отчёте publish.
+                "verify_rejected": verify_rejected,
+```
+
+Удалить ставшую неиспользуемой переменную `dropped_by_gate` из тела `_record_history`, если она там фигурирует только в комментарии (она приходит параметром — оставить параметр, он не используется внутри? Проверить: в новом теле `dropped_by_gate` не используется. Убрать его из сигнатуры `_record_history` ради чистоты — он считается в publish_review и идёт только в отчёт). Итог: у `_record_history` параметра `dropped_by_gate` нет; вызов из publish_review передаёт только `verify_rejected`. Скорректировать вызов в Step 3a соответственно:
+
+```python
+        run_id = self._record_history(
+            repo, pr, p, list(s.candidates.values()), deduped, asm,
+            verify_rejected=verify_rejected,
+            dry_run=dry_run, posted=posted, error=error,
+        )
+```
+
+- [ ] **Step 3c: Удалить `_finding_from_dict` и `_coerce_int`/`_VALID_SEVERITIES` из service.py**
+
+Удалить функцию `_finding_from_dict` (строки 50-107). `_VALID_SEVERITIES` (39) и `_coerce_int` (42-47) больше не используются в service.py (живут в schemas.py) — удалить их тоже. Проверить отсутствие других ссылок:
+
+Run: `grep -n "_finding_from_dict\|_coerce_int\|_VALID_SEVERITIES" reviewer/mcp/service.py`
+Expected: пусто.
+
+- [ ] **Step 3d: Мигрировать `test_service.py` и `test_session_persist.py`**
+
+В `tests/mcp/test_service.py`: убрать `_finding_from_dict` из импорта (строка 14 → `from reviewer.mcp.service import MCPReviewService`); удалить тест `test_finding_confidence_coercion_and_clamp` (683-697) — покрыт `tests/mcp/test_schemas.py`.
+
+В `tests/mcp/test_session_persist.py`: заменить три вызова `svc.publish_review("o/r", 7, summary="s", findings=[RAW], dry_run=True)` (строки 128, 151, 167) на пару:
+```python
+        svc.submit_findings("o/r", 7, [RAW])
+        report = svc.publish_review("o/r", 7, summary="s", dry_run=True)
+```
+(для строки 128, где результат используется как `report`; для 151/167 — по месту, сохранив присваивание если есть). Проверить наличие `RAW` в файле; если импортируется из test_publish — оставить.
+
+- [ ] **Step 4: Запустить весь mcp-набор — убедиться, что проходит + ruff**
+
+Run: `.venv/bin/pytest tests/mcp/ -q && .venv/bin/ruff check reviewer/mcp/service.py tests/mcp/`
+Expected: PASS (кроме test_server*.py — их сигнатуры чиним в Task 5; если упадут именно они — это ожидаемо, продолжаем). Точечно: `.venv/bin/pytest tests/mcp/test_publish.py tests/mcp/test_service.py tests/mcp/test_session_persist.py tests/mcp/test_submit_tools.py -q` → PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add reviewer/mcp/service.py tests/mcp/test_publish.py tests/mcp/test_service.py tests/mcp/test_session_persist.py
+git commit -m "feat(mcp): publish_review читает findings/verdicts из сессии, убран free-text вход (PRI-156)"
+```
+
+---
+
+### Task 5: Регистрация MCP-тулов + смена сигнатуры publish_review (`reviewer/entrypoints/mcp_server.py`)
+
+Добавить 3 тула (типизированы Pydantic для энфорса FastMCP); поправить обёртку `publish_review` (без findings). Мигрировать `test_server.py`/`test_server_tools.py`.
+
+**Files:**
+- Modify: `reviewer/entrypoints/mcp_server.py` (docstring «22 тула» → 25; обёртка publish_review; +3 обёртки).
+- Modify: `tests/mcp/test_server.py`, `tests/mcp/test_server_tools.py`.
+
+**Interfaces:**
+- Consumes: `service.submit_findings/get_candidate_findings/submit_verdicts/publish_review` (Tasks 3-4), `FindingIn`/`VerdictIn` (Task 1).
+- Produces: MCP-тулы `submit_findings`, `submit_verdicts`, `get_candidate_findings`; обновлённый `publish_review`.
+
+- [ ] **Step 1: Обновить тесты регистрации/форвардинга (сначала тесты)**
+
+В `tests/mcp/test_server.py`:
+- строка 91 docstring «ровно 22» → «ровно 25»;
+- в множество ожидаемых имён (около строк 96-120) добавить `"submit_findings"`, `"submit_verdicts"`, `"get_candidate_findings"`;
+- тест `test_publish_review_dry_run_callable_via_mcp` (147-): вызвать через MCP сначала submit, потом publish без findings:
+```python
+    asyncio.run(server.call_tool("prepare_review", {"repo": "o/r", "pr": 7}))
+    asyncio.run(server.call_tool(
+        "submit_findings",
+        {"repo": "o/r", "pr": 7, "findings": [RAW]},
+    ))
+    result = asyncio.run(server.call_tool(
+        "publish_review",
+        {"repo": "o/r", "pr": 7, "summary": "s", "dry_run": True},
+    ))
+```
+(где `RAW` — тот же словарь, что в test_publish; импортировать при необходимости.)
+
+В `tests/mcp/test_server_tools.py` тест `test_publish_review_tool_forwards_task_key` (24-37): убрать findings из args и из ожидаемого вызова:
+```python
+    asyncio.run(server.call_tool(
+        "publish_review",
+        {"repo": "o/r", "pr": 7, "summary": "s", "task_key": "ID-1"},
+    ))
+    svc.publish_review.assert_called_once_with("o/r", 7, "s", False, "ID-1")
+```
+
+- [ ] **Step 2: Запустить — убедиться, что падает**
+
+Run: `.venv/bin/pytest tests/mcp/test_server.py tests/mcp/test_server_tools.py -q`
+Expected: FAIL — тулов нет / число тулов 22 / publish форвардит лишний `[]`.
+
+- [ ] **Step 3a: Обновить обёртку `publish_review` в `mcp_server.py`**
+
+Заменить существующую обёртку publish_review (строки 185-200 — сейчас `findings: list[dict]`, передаёт `findings` 4-м позиционным аргументом) на сигнатуру без findings:
+
+```python
+    @mcp.tool()
+    def publish_review(
+        repo: str, pr: int, summary: str,
+        dry_run: bool = False, task_key: str | None = None,
+    ) -> dict:
+        """Опубликовать ревью: verify-фильтр/gate/dedup/assemble из сессии (PRI-156)."""
+        return service.publish_review(repo, pr, summary, dry_run, task_key)
+```
+
+- [ ] **Step 3b: Добавить 3 обёртки (рядом с publish_review)**
+
+```python
+    @mcp.tool()
+    def submit_findings(repo: str, pr: int, findings: list[FindingIn]) -> dict:
+        """Сдать находки в сессию (schema-enforced). FastMCP валидирует по FindingIn."""
+        return service.submit_findings(repo, pr, [f.model_dump() for f in findings])
+
+    @mcp.tool()
+    def submit_verdicts(repo: str, pr: int, verdicts: list[VerdictIn]) -> dict:
+        """Сдать вердикты verify в сессию (schema-enforced)."""
+        return service.submit_verdicts(repo, pr, [v.model_dump() for v in verdicts])
+
+    @mcp.tool()
+    def get_candidate_findings(repo: str, pr: int) -> str:
+        """Прочитать накопленных кандидатов с id (для verify)."""
+        return service.get_candidate_findings(repo, pr)
+```
+
+Добавить импорт в начало `mcp_server.py`:
+
+```python
+from reviewer.mcp.schemas import FindingIn, VerdictIn
+```
+
+Обновить docstring `create_server` (строка 18): «с 22 тулами» → «с 25 тулами».
+
+- [ ] **Step 4: Запустить — убедиться, что проходит + ruff + полный прогон**
+
+Run: `.venv/bin/pytest tests/mcp/ -q && .venv/bin/ruff check reviewer/entrypoints/mcp_server.py tests/mcp/`
+Expected: PASS, ruff clean.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add reviewer/entrypoints/mcp_server.py tests/mcp/test_server.py tests/mcp/test_server_tools.py
+git commit -m "feat(mcp): тулы submit_findings/submit_verdicts/get_candidate_findings + publish без findings (PRI-156)"
+```
+
+---
+
+### Task 6: Контракт промптов и скилла под submit-тулы (`plugin/skills/`)
+
+Перевести findings-schema/dimension-tail/verify/analyze/SKILL на submit-тулы; обновить guard-тесты.
+
+**Files:**
+- Modify: `plugin/skills/_common/findings-schema.md`, `plugin/skills/_common/dimension-output-tail.md`, `plugin/skills/_common/tool-usage.md`, `plugin/skills/review-pr/references/verify-prompt.md`, `plugin/skills/review-pr/references/analyze-prompt.md`, `plugin/skills/review-pr/SKILL.md`.
+- Modify: `tests/skills/test_common_blocks.py`.
+
+**Interfaces:** документы; контракт сверяется guard-тестами `tests/skills/`.
+
+- [ ] **Step 1: Обновить guard-тесты (сначала тест)**
+
+В `tests/skills/test_common_blocks.py`:
+
+Добавить тест соответствия схемы Pydantic-канону `FindingIn`:
+
+```python
+def test_findings_schema_matches_finding_in_model():
+    # PRI-156: findings-schema.md — проекция канона FindingIn.
+    from reviewer.mcp.schemas import FindingIn
+
+    schema = _read("findings-schema.md")
+    for name in FindingIn.model_fields:
+        token = "fix" if name == "fix" else name
+        assert token in schema, f"поле FindingIn.{name} отсутствует в findings-schema.md"
+```
+
+В `test_tool_usage_has_both_tool_families` добавить проверку submit-тулов:
+
+```python
+    # PRI-156: submit-тулы schema-enforced вывода
+    assert "submit_findings" in text and "submit_verdicts" in text
+```
+
+- [ ] **Step 2: Запустить — убедиться, что падает**
+
+Run: `.venv/bin/pytest tests/skills/test_common_blocks.py -q`
+Expected: FAIL — `submit_findings` ещё нет в tool-usage.md; FindingIn-guard может пройти (поля совпадают) или упасть, если token не найден.
+
+- [ ] **Step 3a: `findings-schema.md` — submit вместо free-text**
+
+Заменить строки 1-3:
+
+```markdown
+Findings output schema (shared). The calling skill sets `category`.
+
+Submit findings by calling `submit_findings(repo, pr, findings=[…])` — one call,
+each item matching this per-finding schema (the server validates against it and
+assigns a stable id). Do NOT return findings as prose/JSON text.
+```
+
+(Блок полей `{…}` и «Field semantics» — без изменений.)
+
+- [ ] **Step 3b: `dimension-output-tail.md` — submit**
+
+Заменить весь файл на:
+
+```markdown
+Submit the findings by calling `submit_findings(repo, pr, findings=[…])` (one call).
+Each item matches the shared findings schema; the server validates and assigns ids.
+
+If a finding cannot be tied to a specific line, use the closest changed line and
+explain the scope in `message`.
+
+If there are no meaningful findings, call `submit_findings` with an empty list and say so.
+
+Write `message` and `suggestion` in the output language given by the orchestrator
+(standalone: the user's language).
+```
+
+- [ ] **Step 3c: `tool-usage.md` — добавить submit-тулы**
+
+В разделе «PR-session tools» (после строки 19 `get_impact`) добавить:
+
+```markdown
+- `submit_findings` — submit findings (schema-enforced; server assigns ids);
+- `get_candidate_findings` — read accumulated candidate findings (verify only);
+- `submit_verdicts` — submit verify verdicts by candidate id (verify only).
+```
+
+- [ ] **Step 3d: `verify-prompt.md` — get_candidate_findings + submit_verdicts**
+
+Заменить строку 42:
+
+```markdown
+Read the candidate findings via `get_candidate_findings(repo, pr)` (each has a stable
+`id`). For each, submit your decision via `submit_verdicts(repo, pr, verdicts=[{"id": "<id>", "is_real": true|false}])`.
+Submit a verdict only for findings you decide to kill or explicitly keep; a finding
+with no verdict is kept (recall-safe). Do NOT return verdicts as text.
+```
+
+- [ ] **Step 3e: `analyze-prompt.md` — submit**
+
+Заменить строку 60 (хвост после findings-schema include):
+
+```markdown
+Set "category" to one of: correctness|security|performance|maintainability|style.
+Submit via `submit_findings(repo, pr, findings=[…])` — do not return JSON text.
+```
+
+- [ ] **Step 3f: `review-pr/SKILL.md` — submit-поток + убрать «KEEP all on malformed»**
+
+- Строка 75: `Each subagent returns a JSON object {"findings": [...]}` → `Each subagent submits findings via submit_findings(repo, pr, findings=[...]) (schema-enforced; the server assigns ids).`
+- Строки 85-86, 90-91, 94: «returns the same findings JSON schema …» → «submits findings via submit_findings with category … ».
+- Шаг 5 Verify (96-102) заменить на:
+```markdown
+5. **Verify.** Dispatch one subagent with `references/verify-prompt.md` and the
+   repo/pr identifiers. It reads candidates via `get_candidate_findings(repo, pr)`
+   and submits verdicts via `submit_verdicts(repo, pr, verdicts=[{id, is_real}])`.
+   A finding with `is_real=false` is dropped at publish; a finding with no verdict
+   is kept (recall-safe — no orchestrator action needed if verify fails).
+```
+- Шаг 6 Publish (109): `Call publish_review(repo, pr, summary, findings, dry_run, task_key)` → `Call publish_review(repo, pr, summary, dry_run, task_key)` (findings приходят из сессии). Счётчики отчёта (112-113): добавить `verify_rejected` в перечисление.
+
+- [ ] **Step 4: Запустить guard + полный прогон skills**
+
+Run: `.venv/bin/pytest tests/skills/ -q`
+Expected: PASS (включая `test_assembled_prompts.py` — include-сборка цела).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add plugin/skills tests/skills/test_common_blocks.py
+git commit -m "feat(skills): контракт промптов review-pr на submit_findings/submit_verdicts (PRI-156)"
+```
+
+---
+
+### Финальная проверка (после всех задач)
+
+- [ ] **Полный прогон + линт**
+
+Run: `.venv/bin/pytest -q && .venv/bin/ruff check .`
+Expected: все unit-тесты PASS; ruff без новых ошибок (на изменённых файлах). Note: ruff может быть не идеально чист на репо в целом — ориентир на изменённые файлы (см. практику проекта).
+
+- [ ] **Проверить, что free-text findings нигде не остался**
+
+Run: `grep -rn "findings=\[" tests/ ; grep -rn "_finding_from_dict" reviewer/ tests/`
+Expected: пусто (или только хелпер `_submit_then_publish`).
+
+---
+
+## Известные ограничения (вне скоупа, YAGNI)
+
+- **Персистентность candidates/verdicts.** Накопленные находки/вердикты — in-memory в `_Session`; `SessionStore` сериализует только `prepared`. Перезапуск процесса reviewer-mcp между `submit_*` и `publish_review` теряет их (регидрированная сессия стартует с пустыми candidates → пустое ревью). Это тот же профиль риска, что и прерывание ревью сегодня. Персистентность candidates можно добавить позже (расширение `session_serde`), но в PRI-156 не входит.
+- **Прямой Anthropic `response_format`** недоступен (архитектура на LLM-субагентах). Энфорс — только на тул-границе FastMCP.
+
+## Self-Review (выполнено при написании)
+
+- **Spec coverage:** механизм submit-тулов → Tasks 3,5; server-assigned id + session boundary → Tasks 3,4; Pydantic-канон → Task 1; Finding.from_in → Task 2; мягкая коэрция = порт _finding_from_dict → Task 1 (валидаторы) + Task 4 (удаление старой функции); фолбэк «нет verdict = keep» → Task 4; промпты/SKILL/guard → Task 6. Все секции спеки покрыты.
+- **Type consistency:** `submit_findings(repo,pr,findings)->{accepted,ids}`, `submit_verdicts(...)->{recorded,unknown_ids}`, `get_candidate_findings(repo,pr)->str`, `publish_review(repo,pr,summary,dry_run,task_key)`, `Finding.from_in(fi)`, `FindingIn`/`VerdictIn`/`FixIn` — имена согласованы между задачами.
+- **Placeholder scan:** код приведён полностью в каждом шаге; миграции тестов перечислены по строкам.

--- a/docs/superpowers/specs/2026-06-22-pri-156-structured-outputs-design.md
+++ b/docs/superpowers/specs/2026-06-22-pri-156-structured-outputs-design.md
@@ -1,0 +1,177 @@
+# PRI-156 — Structured Outputs (schema-enforced JSON) для findings/verdicts
+
+**Задача:** ID-156 / PRI-156 («Движок (reviewer CLI/MCP)»). Оценка M.
+**Дата:** 2026-06-22. **Ветка базы:** `dev` (индекс досинхронизирован до HEAD `1cceefc`).
+
+## Проблема
+
+Субагенты ревью (analyze/dimension/verify) возвращают **free-text JSON**, который парсится
+LLM-оркестратором. При malformed-выводе срабатывают хрупкие фолбэки: verify при кривом ответе
+делает «KEEP all findings» (потеря фильтрации), а серверная коэрция `_finding_from_dict` чинит
+кривые словари дефолтами постфактум. Это даёт парс-ошибки и расфокус калибровки.
+
+**Цель:** перевести вывод analyze/dimension/verify на schema-enforced через **вызов MCP-тула**;
+схему findings и verdicts определить **один раз**; валидацию вынести на тул-границу.
+
+**Критерии приёмки (из задачи):**
+- доля malformed-выводов → ~0;
+- поля findings валидны по схеме;
+- verify не теряет находки из-за парс-ошибок.
+
+## Ключевое архитектурное ограничение
+
+Субагенты — это **Claude Code LLM-субагенты**, которых диспатчит LLM-оркестратор через скилл
+`review-pr/SKILL.md`. Это **не** прямые вызовы Anthropic API из Python, поэтому Python-сервер
+**не может** выставить `response_format`/`tools` для энфорса схемы. Единственная граница, которую
+Python реально контролирует, — это **вызов MCP-тула**. Отсюда механизм энфорса: субагент **вызывает**
+MCP-тул, FastMCP/Pydantic валидирует аргументы по схеме, malformed → ошибка тула → субагент ретраит.
+
+## Принятые решения (развилки brainstorming)
+
+1. **Механизм энфорса:** новые MCP-тулы `submit_findings` / `submit_verdicts`. Субагент вызывает
+   их вместо возврата free-text. Энфорс на тул-границе (FastMCP/Pydantic).
+2. **Граница данных:** полностью через сессию. `submit_findings` присваивает каждой находке
+   **server-assigned id**; verify читает кандидатов тулом и ссылается по id (не по хрупкому индексу
+   массива); `publish_review` читает всё из сессии — **параметр `findings` убирается**.
+3. **Источник схемы:** Pydantic-модели `FindingIn`/`VerdictIn` — **канонический** единый источник.
+   FastMCP выводит из них тул-схему; внутренний dataclass `Finding` строится из валидированного
+   `FindingIn`; `findings-schema.md` — тонкий человеческий док, который guard-тест сверяет с моделью.
+4. **Строгость:** мягкая коэрция **внутри** `FindingIn`-валидаторов — поведение `_finding_from_dict`
+   дословно (сохраняет PRI-144). Только `file` обязателен; остальное коэрцируется с дефолтами.
+5. **Фолбэк verify:** отсутствие verdict = keep (структурный дефолт). Единственный путь отсева —
+   явный `is_real=false`. Инструкция «KEEP all on malformed» из SKILL.md удаляется как избыточная.
+
+## Связанный контекст (фундамент, оба смержены)
+
+- **PRI-142** — `_common/findings-schema.md` уже существует (общий контракт). PRI-156 его **энфорсит**,
+  не переопределяет.
+- **PRI-144** — калибровка `confidence` (шкала 0.8–1.0 / 0.5–0.7 / ≤0.4) + коэрция (`confidence`
+  fallback 0.1, clamp [0,1]). Семантику **сохранить** в валидаторах `FindingIn`.
+
+## Архитектура
+
+### Новые файлы / тулы
+
+- **`reviewer/mcp/schemas.py`** (новый) — Pydantic-канон: `FixIn`, `FindingIn`, `VerdictIn`.
+- **`reviewer/entrypoints/mcp_server.py`** — 3 новые `@mcp.tool()`-обёртки (типизированы Pydantic
+  для энфорса): `submit_findings`, `submit_verdicts`, `get_candidate_findings`. Сигнатура
+  `publish_review` меняется (без `findings`).
+- **`reviewer/mcp/service.py`** — методы `submit_findings`/`submit_verdicts`/`get_candidate_findings`;
+  расширение `_Session`; переработка `publish_review`; удаление `_finding_from_dict`.
+- **`reviewer/vcs/base.py`** — `Finding.from_in(FindingIn) -> Finding`.
+
+### Схема (`reviewer/mcp/schemas.py`)
+
+```python
+class FixIn(BaseModel):
+    start_line: int | None = None     # coerce; мусор → None (вся fix отбрасывается выше)
+    end_line: int | None = None
+    replacement: str | None = None    # не-строка → None
+
+class FindingIn(BaseModel):
+    file: str                          # required → ValidationError, если нет
+    category: str = "correctness"      # задаётся вызывающим скиллом
+    severity: str = "medium"           # validator: вне {low,medium,high,critical} → "medium"
+    side: str = "RIGHT"               # validator: вне {RIGHT,LEFT} → "RIGHT"
+    line: int | None = None            # coerce; мусор → None
+    code_quote: str | None = None      # не-строка → None
+    message: str = ""
+    suggestion: str | None = None      # не-строка → None
+    confidence: float = 0.1            # validator: мусор → 0.1, clamp [0,1]
+    fix: FixIn | None = None           # если start/end не коэрцятся или replacement не строка → None
+
+class VerdictIn(BaseModel):
+    id: str
+    is_real: bool
+```
+
+Поведение валидаторов = дословный порт `_finding_from_dict` (service.py:49-106). `Finding.from_in(fi)`
+строит dataclass `Finding` (+`centrality=0.0`); `fingerprint()` не меняется. Server-assigned id
+кандидата живёт **в сессии**, не в `Finding`.
+
+### Состояние сессии (`_Session`, service.py:111)
+
+```python
+candidates: dict[str, Finding]   # id → Finding (копится submit_findings)
+verdicts:   dict[str, bool]      # id → is_real (копится submit_verdicts)
+_seq:       int                  # счётчик для id вида "f{n}"
+```
+
+### Поведение тулов (методы `MCPReviewService`)
+
+- **`submit_findings(repo, pr, findings: list[FindingIn]) -> dict`** — FastMCP уже провалидировал;
+  для каждого `fi` строит `Finding.from_in(fi)`, присваивает id (`f{++_seq}`), кладёт в
+  `candidates`. Возврат `{"accepted": N, "ids": [...]}`.
+- **`get_candidate_findings(repo, pr) -> str`** — нумерованный/идентифицированный срез кандидатов
+  для verify: `[{id, file, line, category, severity, message, code_quote}, …]`.
+- **`submit_verdicts(repo, pr, verdicts: list[VerdictIn]) -> dict`** — пишет `verdicts[id]=is_real`;
+  id вне `candidates` → игнор + `log.warning`. Возврат `{"recorded": N, "unknown_ids": [...]}`.
+- **`publish_review(repo, pr, summary, dry_run=False, task_key=None) -> dict`** — читает
+  `candidates`+`verdicts` из сессии. Отсев: `verdicts.get(id) is False` → drop; иначе keep. Далее без
+  изменений: ground → snap → gate → dedup → centrality → assemble → publish → история → cleanup.
+  `verify_rejected` = число `is_real=false`. `cleanup` чистит `candidates`/`verdicts` вместе с сессией.
+
+### Поток данных
+
+```
+analyze/dimension субагент:
+  → submit_findings(repo, pr, findings=[FindingIn, …])
+        malformed → ошибка тула → РЕТРАЙ ; ok → candidates[id] = Finding.from_in(fi)
+  → возвращает короткий статус-текст (не JSON)
+
+verify субагент:
+  → get_candidate_findings(repo, pr) → [{id, …}, …]
+  → submit_verdicts(repo, pr, verdicts=[{id, is_real}, …])
+
+оркестратор:
+  → publish_review(repo, pr, summary, dry_run, task_key)   # без findings
+        verdict is_real=false → drop; нет verdict / true → keep → … → publish
+```
+
+## Изменения промптов / скилла
+
+- **`_common/findings-schema.md`** — интро «Return ONLY a JSON object» → «Submit findings via
+  `submit_findings` with this per-finding schema»; поля без изменений (guard-тест сверяет с `FindingIn`).
+- **`_common/dimension-output-tail.md`** — «верни JSON» → «вызови `submit_findings`».
+- **`_common/tool-usage.md`** — добавить `submit_findings`/`submit_verdicts`/`get_candidate_findings`
+  в список тулов.
+- **`review-pr/references/verify-prompt.md`** — «Return ONLY {verdicts…}» → «прочитай
+  `get_candidate_findings`, вынеси вердикты через `submit_verdicts(id, is_real)`».
+- **`review-pr/references/analyze-prompt.md`** (+ dimension-промпты performance/maintainability/
+  requirements/blast-radius через их output-контракт) — submit вместо возврата JSON.
+- **`review-pr/SKILL.md`** шаги 3–6: субагенты submit'ят; verify читает кандидатов тулом; publish_review
+  без `findings`; строка «If the verifier fails or returns malformed output, KEEP all findings» —
+  **удаляется** (структурный дефолт).
+
+## Обработка ошибок / фолбэк
+
+- malformed-аргументы тула → FastMCP/Pydantic reject → ретрай субагента (энфорс; malformed → ~0).
+- analyze-субагент умер без `submit_findings` → его юнит без находок → файл в «не проанализировано»
+  (текущее поведение оркестратора сохраняется).
+- verify умер / частичный → отсутствующие вердикты = keep (recall-safe, структурно).
+- `submit_*` на неподготовленную сессию → ошибка тула «session not prepared» (как у прочих
+  session-bound тулов).
+- Пустые `candidates` → пустое ревью (валидно).
+
+## Тестирование
+
+- **`tests/mcp/`**: паритет коэрции `FindingIn` со старым `_finding_from_dict` (table-driven по тем
+  же кейсам); `submit_findings` — аккумуляция + присвоение id; `get_candidate_findings` — формат;
+  `submit_verdicts` — запись + unknown-id игнор; `publish_review` читает из сессии; verdict-absence =
+  keep; частичный verify; счётчик `verify_rejected`.
+- **`tests/skills/`**: guard — findings-schema.md ↔ `FindingIn` (вместо ↔ `Finding`); сборка промптов
+  с submit-тулами; контракт verify-prompt.
+- Обновить существующие тесты `publish_review` под новую сигнатуру (без `findings`).
+
+## Совместимость
+
+`publish_review` и новые submit-тулы вызывает **только** плагин `review-pr` этого репозитория —
+внешних потребителей нет, смена сигнатуры безопасна. Проект на русском: комментарии/докстринги/CLI.
+Guard-тесты `tests/skills/` держать зелёными.
+
+## Вне скоупа (YAGNI)
+
+- Прямые Anthropic API-вызовы с `response_format` (архитектура на LLM-субагентах этого не позволяет).
+- Изменение шкалы калибровки `confidence` (это PRI-144, уже смержено).
+- Переопределение полей схемы findings (это PRI-142; здесь только энфорс существующих полей).
+- Хранение server-assigned id в самом `Finding` (id ephemeral, живёт в сессии).

--- a/plugin/skills/_common/dimension-output-tail.md
+++ b/plugin/skills/_common/dimension-output-tail.md
@@ -1,9 +1,10 @@
-Standalone runs may additionally render the findings as a readable list after the JSON.
+Submit the findings by calling `submit_findings(repo, pr, findings=[…])` (one call).
+Each item matches the shared findings schema; the server validates and assigns ids.
 
 If a finding cannot be tied to a specific line, use the closest changed line and
 explain the scope in `message`.
 
-If there are no meaningful findings, return `{"findings": []}` and say so.
+If there are no meaningful findings, call `submit_findings` with an empty list and say so.
 
 Write `message` and `suggestion` in the output language given by the orchestrator
 (standalone: the user's language).

--- a/plugin/skills/_common/findings-schema.md
+++ b/plugin/skills/_common/findings-schema.md
@@ -1,9 +1,11 @@
 Findings output schema (shared). The calling skill sets `category`.
 
-Return ONLY a JSON object (no prose around it):
+Submit findings by calling `submit_findings(repo, pr, findings=[…])` — one call,
+each item matching this per-finding schema (the server validates against it and
+assigns a stable id). Do NOT return findings as prose/JSON text.
 
 ```json
-{"findings": [{
+[{
   "category": "<set by the calling skill>",
   "severity": "low|medium|high|critical",
   "file": "<path of the reviewed file>",
@@ -14,7 +16,7 @@ Return ONLY a JSON object (no prose around it):
   "suggestion": "<short advice or null>",
   "fix": {"start_line": N, "end_line": M, "replacement": "<new code>"} | null,
   "confidence": 0.0
-}]}
+}]
 ```
 
 Field semantics:

--- a/plugin/skills/_common/tool-usage.md
+++ b/plugin/skills/_common/tool-usage.md
@@ -16,7 +16,10 @@ Tool discipline (shared):
 - `get_definition` — a symbol's definition;
 - `read_file` — exact source context;
 - `get_changed_file_diff` — other changed files of this PR;
-- `get_impact` — callers of a changed signature that live outside the diff.
+- `get_impact` — callers of a changed signature that live outside the diff;
+- `submit_findings` — submit findings (schema-enforced; server assigns ids);
+- `get_candidate_findings` — read accumulated candidate findings (verify only);
+- `submit_verdicts` — submit verify verdicts by candidate id (verify only).
 
 ## Session-less tools (`ask` / `solve-task`, no PR session)
 

--- a/plugin/skills/review-pr/SKILL.md
+++ b/plugin/skills/review-pr/SKILL.md
@@ -72,7 +72,7 @@ blocks.
      (`search_code`, `get_related_symbols`, `read_file`, `get_definition`,
      `find_callers`, `get_changed_file_diff`);
    - the target output language.
-   Each subagent returns a JSON object `{"findings": [...]}` (schema in the prompt).
+   Each subagent submits findings via `submit_findings(repo, pr, findings=[...])` (schema-enforced; the server assigns ids).
 
 4. **Dimensions (parallel with step 3).** Dispatch whole-diff subagents:
    - performance: follow the methodology of `../performance-review/SKILL.md`
@@ -82,35 +82,33 @@ blocks.
      `references/requirements-prompt.md`, the diffs of all units (path + patch), the `TaskBrief`,
      plus the related/similar task context gathered in step 2 (linked tasks, their PRs, touched code,
      similar tasks) as an optional "Related context" block, the repo/pr identifiers (so it can call
-     the reviewer MCP tools), and the target output language. It returns the same findings JSON
-     schema with category `requirements`.
+     the reviewer MCP tools), and the target output language. It submits findings via
+     `submit_findings` with category `requirements`.
    - blast-radius: dispatch one subagent with `references/blast-radius-prompt.md`, the diffs of
      all units (path + patch), each unit's `commentable_right`/`commentable_left` (the line numbers
      where inline comments are allowed), the PR `title`/`body`, the repo/pr identifiers (so it can
      call the reviewer MCP tools, including `get_impact`), and the target output language. It
-     returns the same findings JSON schema with category `correctness`.
+     submits findings via `submit_findings` with category `correctness`.
    Give the performance/maintainability subagents: the diffs of all units (path + patch), the
    repo/pr identifiers so they can call the reviewer MCP tools, and the target output language.
-   They must return the same findings JSON schema (category `performance` / `maintainability`).
+   They must submit findings via `submit_findings` (category `performance` / `maintainability`).
 
-5. **Verify.** Collect all findings into one numbered list. Dispatch one subagent
-   with `references/verify-prompt.md`, the findings list, the diffs, and the
-   repo/pr identifiers so the subagent can call the reviewer MCP tools
-   (`read_file`, `search_code`, `find_callers`, `get_definition`, `get_impact`). It returns
-   `{"verdicts": [{"index": N, "is_real": true|false}]}`. Drop findings with
-   `is_real=false`. If the verifier fails or returns malformed output, KEEP all
-   findings (recall-safe).
+5. **Verify.** Dispatch one subagent with `references/verify-prompt.md` and the
+   repo/pr identifiers. It reads candidates via `get_candidate_findings(repo, pr)`
+   and submits verdicts via `submit_verdicts(repo, pr, verdicts=[{id, is_real}])`.
+   A finding with `is_real=false` is dropped at publish; a finding with no verdict
+   is kept (recall-safe — no orchestrator action needed if verify fails).
 
 6. **Publish.** Compose a short review summary (2-5 sentences, in
    `policy.output_language`): what the PR does, overall assessment, key risks.
    If a task was read, state whether the PR meets the task's requirements; if the task context was
    requested but unavailable (no key, board MCP not connected, task not found), say so briefly.
    Mention files that were not analyzed: failed subagents and `skipped_paths`
-   from the prepare payload. Call `publish_review(repo, pr, summary, findings, dry_run, task_key)`
+   from the prepare payload. Call `publish_review(repo, pr, summary, dry_run, task_key)`
    where `task_key` is the canonical `TaskBrief.key` if a task was read (else omit / null). When
    published, this links the PR to the task in the graph for future reviews. Report to the user:
    posted/dry-run, inline count, and the report counters
-   (dropped_by_gate/deduped/invalid/already_posted/moved_to_summary/capped), run_id.
+   (dropped_by_gate/deduped/invalid/already_posted/moved_to_summary/capped/verify_rejected), run_id.
 
 ## Failure handling
 

--- a/plugin/skills/review-pr/references/analyze-prompt.md
+++ b/plugin/skills/review-pr/references/analyze-prompt.md
@@ -58,3 +58,4 @@ these are stylistic preferences with no behavioural impact.
 
 <!-- include: _common/findings-schema.md -->
 Set "category" to one of: correctness|security|performance|maintainability|style.
+Submit via `submit_findings(repo, pr, findings=[…])` — do not return JSON text.

--- a/plugin/skills/review-pr/references/verify-prompt.md
+++ b/plugin/skills/review-pr/references/verify-prompt.md
@@ -39,4 +39,7 @@ Finding: "new required parameter `timeout` breaks existing callers".
 Found via find_callers: 5 places call `connect(host, port)` without timeout.
 Verdict: is_real=true — all 5 call sites will raise TypeError on deploy.
 
-Return ONLY: {"verdicts": [{"index": N, "is_real": true|false}]}
+Read the candidate findings via `get_candidate_findings(repo, pr)` (each has a stable
+`id`). For each, submit your decision via `submit_verdicts(repo, pr, verdicts=[{"id": "<id>", "is_real": true|false}])`.
+Submit a verdict only for findings you decide to kill or explicitly keep; a finding
+with no verdict is kept (recall-safe). Do NOT return verdicts as text.

--- a/reviewer/entrypoints/mcp_server.py
+++ b/reviewer/entrypoints/mcp_server.py
@@ -9,13 +9,14 @@ import sys
 
 from mcp.server.fastmcp import FastMCP
 
+from reviewer.mcp.schemas import FindingIn, VerdictIn
 from reviewer.mcp.service import MCPReviewService
 
 log = logging.getLogger(__name__)
 
 
 def create_server(service: MCPReviewService) -> FastMCP:
-    """Создать и вернуть сконфигурированный FastMCP-сервер с 22 тулами.
+    """Создать и вернуть сконфигурированный FastMCP-сервер с 25 тулами.
 
     Все тулы — обычные def (sync), а не async: сервис не потокобезопасен
     и рассчитан на последовательное исполнение sync-тулов FastMCP в event loop.
@@ -184,20 +185,31 @@ def create_server(service: MCPReviewService) -> FastMCP:
         repo: str,
         pr: int,
         summary: str,
-        findings: list[dict],
         dry_run: bool = False,
         task_key: str | None = None,
     ) -> dict:
-        """Deterministic publish tail: policy gate, line grounding, dedup,
-        inline/summary split, suggestion invariants, fingerprint idempotency,
-        comment cap, GitHub review post, history record, overlay cleanup.
+        """Опубликовать ревью: verify-фильтр/gate/dedup/assemble из сессии (PRI-156).
+
+        Находки берутся из сессии (накоплены через submit_findings/submit_verdicts).
         When task_key is set and the review is really published, the PR is linked
         to that task in the task graph (IMPLEMENTED_BY + TOUCHES changed code).
-        Each finding: {category, severity(low|medium|high|critical), file, line,
-        side(RIGHT|LEFT), code_quote, message, suggestion,
-        fix:{start_line,end_line,replacement}|null, confidence:0..1}.
         With dry_run=true nothing is posted; the full report is returned."""
-        return service.publish_review(repo, pr, summary, findings, dry_run, task_key)
+        return service.publish_review(repo, pr, summary, dry_run, task_key)
+
+    @mcp.tool()
+    def submit_findings(repo: str, pr: int, findings: list[FindingIn]) -> dict:
+        """Сдать находки в сессию (schema-enforced). FastMCP валидирует по FindingIn."""
+        return service.submit_findings(repo, pr, [f.model_dump() for f in findings])
+
+    @mcp.tool()
+    def submit_verdicts(repo: str, pr: int, verdicts: list[VerdictIn]) -> dict:
+        """Сдать вердикты verify в сессию (schema-enforced)."""
+        return service.submit_verdicts(repo, pr, [v.model_dump() for v in verdicts])
+
+    @mcp.tool()
+    def get_candidate_findings(repo: str, pr: int) -> str:
+        """Прочитать накопленных кандидатов с id (для verify)."""
+        return service.get_candidate_findings(repo, pr)
 
     return mcp
 

--- a/reviewer/mcp/schemas.py
+++ b/reviewer/mcp/schemas.py
@@ -8,7 +8,7 @@
 """
 from __future__ import annotations
 
-from pydantic import BaseModel, ConfigDict, field_validator
+from pydantic import BaseModel, ConfigDict, Field, field_validator
 
 _VALID_SEVERITIES = frozenset({"low", "medium", "high", "critical"})
 
@@ -36,7 +36,7 @@ class FindingIn(BaseModel):
 
     model_config = ConfigDict(extra="ignore")
 
-    file: str
+    file: str = Field(min_length=1)
     category: str = "correctness"
     severity: str = "medium"
     side: str = "RIGHT"

--- a/reviewer/mcp/schemas.py
+++ b/reviewer/mcp/schemas.py
@@ -1,0 +1,114 @@
+"""Pydantic-схемы LLM-facing вывода ревью — единый источник (PRI-156).
+
+``FindingIn``/``VerdictIn`` — канон схемы findings/verdicts: из них FastMCP
+выводит схему тулов ``submit_findings``/``submit_verdicts`` (энфорс на тул-границе),
+из них же строится внутренний ``Finding`` (``Finding.from_in``). Валидаторы —
+дословный порт ``_finding_from_dict`` (мягкая коэрция, сохраняет PRI-144):
+кривые значения коэрцируются с дефолтами, обязателен только ``file``.
+"""
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict, field_validator
+
+_VALID_SEVERITIES = frozenset({"low", "medium", "high", "critical"})
+
+
+def _coerce_int(value) -> int | None:
+    """int-коэрция LLM-значения: int("42") → 42, None/мусор → None."""
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
+class FixIn(BaseModel):
+    """Applyable-правка: точная замена диапазона строк НОВОЙ версии (RIGHT)."""
+
+    model_config = ConfigDict(extra="ignore")
+
+    start_line: int | None = None
+    end_line: int | None = None
+    replacement: str | None = None
+
+
+class FindingIn(BaseModel):
+    """LLM-facing находка. Мягкая коэрция = порт ``_finding_from_dict``."""
+
+    model_config = ConfigDict(extra="ignore")
+
+    file: str
+    category: str = "correctness"
+    severity: str = "medium"
+    side: str = "RIGHT"
+    line: int | None = None
+    code_quote: str | None = None
+    message: str = ""
+    suggestion: str | None = None
+    confidence: float = 0.1
+    fix: FixIn | None = None
+
+    @field_validator("category", mode="before")
+    @classmethod
+    def _category(cls, v):
+        return str(v) if v else "correctness"
+
+    @field_validator("severity", mode="before")
+    @classmethod
+    def _severity(cls, v):
+        return v if isinstance(v, str) and v in _VALID_SEVERITIES else "medium"
+
+    @field_validator("side", mode="before")
+    @classmethod
+    def _side(cls, v):
+        return v if v in ("RIGHT", "LEFT") else "RIGHT"
+
+    @field_validator("line", mode="before")
+    @classmethod
+    def _line(cls, v):
+        return _coerce_int(v)
+
+    @field_validator("code_quote", mode="before")
+    @classmethod
+    def _code_quote(cls, v):
+        return v if isinstance(v, str) else None
+
+    @field_validator("message", mode="before")
+    @classmethod
+    def _message(cls, v):
+        return str(v) if v else ""
+
+    @field_validator("suggestion", mode="before")
+    @classmethod
+    def _suggestion(cls, v):
+        return v if isinstance(v, str) else None
+
+    @field_validator("confidence", mode="before")
+    @classmethod
+    def _confidence(cls, v):
+        try:
+            c = float(v)
+        except (TypeError, ValueError):
+            c = 0.1   # не оценено = спекулятивно (ниже честного потолка 0.4) → отсекается гейтом
+        return max(0.0, min(1.0, c))
+
+    @field_validator("fix", mode="before")
+    @classmethod
+    def _fix(cls, v):
+        # Кривая/неполная fix отбрасывается целиком (как в _finding_from_dict).
+        if not isinstance(v, dict):
+            return None
+        start = _coerce_int(v.get("start_line"))
+        end = _coerce_int(v.get("end_line"))
+        replacement = v.get("replacement")
+        if start is None or end is None or not isinstance(replacement, str):
+            return None
+        return {"start_line": start, "end_line": end, "replacement": replacement}
+
+
+class VerdictIn(BaseModel):
+    """Вердикт verify по находке с server-assigned id."""
+
+    model_config = ConfigDict(extra="ignore")
+
+    id: str
+    is_real: bool

--- a/reviewer/mcp/service.py
+++ b/reviewer/mcp/service.py
@@ -668,8 +668,8 @@ class MCPReviewService:
             now = datetime.now(timezone.utc)
             status = "error" if (error and not dry_run) else "ok"
             comments_inline = len(asm.inline_comments)
-            # PRI-156: analyzed — все candidates (до verify-фильтра), по уникальным
-            # fingerprint (грунтовка выполнена в publish_review до передачи сюда).
+            # PRI-156: analyzed — все candidates (до verify-фильтра); грунтовка строк
+            # выполнена только для survived, не для отвергнутых candidates.
             findings_analyzed = len({f.fingerprint() for f in analyzed})
             run = {
                 "repo": repo,

--- a/reviewer/mcp/service.py
+++ b/reviewer/mcp/service.py
@@ -5,7 +5,7 @@
 """
 import logging
 from collections.abc import Callable
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from datetime import datetime, timezone
 
 from reviewer.agent.assemble import (
@@ -30,6 +30,7 @@ from reviewer.services.review_service import (
 from reviewer.tasks.graph import PRRef
 from reviewer.tools.code_tools import ToolContext, make_tools
 from reviewer.tools.graph_format import format_neighbors
+from reviewer.mcp.schemas import FindingIn, VerdictIn
 from reviewer.vcs.base import ChangedFile, Finding, VCSProvider
 from reviewer.vcs.diff import commentable_lines
 
@@ -115,6 +116,13 @@ class _Session:
     # пер-вызов. Повторный одинаковый вызов отдаёт реальный результат из
     # ctx.cache (пер-сессия), а не заглушку «повтор: результат уже показан выше».
     ctx: ToolContext
+    # PRI-156: schema-enforced находки/вердикты копятся в сессии между submit_*
+    # и publish_review. id вида "f{n}" присваивает submit_findings. Состояние
+    # in-memory (регидрированная из стора сессия стартует пустой — допустимо:
+    # перезапуск процесса посреди ревью теряет прогресс, как и раньше).
+    candidates: dict[str, Finding] = field(default_factory=dict)
+    verdicts: dict[str, bool] = field(default_factory=dict)
+    _seq: int = 0
 
 
 class MCPReviewService:
@@ -511,6 +519,56 @@ class MCPReviewService:
                 except Exception:
                     log.warning("get_pr_diff: не удалось закрыть VCS", exc_info=True)
         return _format_pr_diff(files) or "(PR без изменённых файлов)"
+
+    def submit_findings(self, repo: str, pr: int, findings: list[dict]) -> dict:
+        """Принять находки субагента в сессию (PRI-156): валидация по FindingIn,
+        присвоение server-assigned id, накопление в _Session.candidates.
+
+        Энфорс схемы — на тул-границе FastMCP (тип list[FindingIn]); здесь
+        повторная model_validate коэрцирует/валидирует dict при прямом вызове
+        (тесты). Невалидный элемент (нет file) → ValidationError → ретрай тула.
+        """
+        from reviewer.services.repo_id import normalize_repo
+        repo = normalize_repo(repo)
+        s = self._session(repo, pr)
+        ids: list[str] = []
+        for d in findings:
+            fi = FindingIn.model_validate(d)
+            s._seq += 1
+            fid = f"f{s._seq}"
+            s.candidates[fid] = Finding.from_in(fi)
+            ids.append(fid)
+        return {"accepted": len(ids), "ids": ids}
+
+    def get_candidate_findings(self, repo: str, pr: int) -> str:
+        """Вернуть накопленных кандидатов с id для verify (JSON-строка)."""
+        import json
+        from reviewer.services.repo_id import normalize_repo
+        repo = normalize_repo(repo)
+        s = self._session(repo, pr)
+        items = [
+            {"id": fid, "file": f.file, "line": f.line, "category": f.category,
+             "severity": f.severity, "message": f.message, "code_quote": f.code_quote}
+            for fid, f in s.candidates.items()
+        ]
+        return json.dumps({"candidates": items}, ensure_ascii=False, indent=2)
+
+    def submit_verdicts(self, repo: str, pr: int, verdicts: list[dict]) -> dict:
+        """Принять вердикты verify в сессию (PRI-156). id вне candidates →
+        игнор + warning. Отсутствие вердикта по находке = keep (см. publish_review)."""
+        from reviewer.services.repo_id import normalize_repo
+        repo = normalize_repo(repo)
+        s = self._session(repo, pr)
+        recorded, unknown = 0, []
+        for d in verdicts:
+            v = VerdictIn.model_validate(d)
+            if v.id not in s.candidates:
+                unknown.append(v.id)
+                log.warning("submit_verdicts: неизвестный id %s (%s#%s)", v.id, repo, pr)
+                continue
+            s.verdicts[v.id] = v.is_real
+            recorded += 1
+        return {"recorded": recorded, "unknown_ids": unknown}
 
     def publish_review(
         self,

--- a/reviewer/mcp/service.py
+++ b/reviewer/mcp/service.py
@@ -37,76 +37,6 @@ from reviewer.vcs.diff import commentable_lines
 log = logging.getLogger(__name__)
 
 
-_VALID_SEVERITIES = frozenset({"low", "medium", "high", "critical"})
-
-
-def _coerce_int(value) -> int | None:
-    """int-коэрция LLM-значения: int("42") → 42, None/мусор → None."""
-    try:
-        return int(value)
-    except (TypeError, ValueError):
-        return None
-
-
-def _finding_from_dict(d) -> Finding | None:
-    """Собрать Finding из словаря в схеме analyze-промпта.
-
-    Вход приходит от модели — кривые словари штатны, коэрция самодостаточная
-    (НЕ зависит от _FindingModel в analyzer). Схема: ``category, severity, file,
-    line, code_quote, message, suggestion, fix{start_line,end_line,replacement},
-    confidence`` (+опц. ``side``). ``code_quote`` хранится в Finding для fuzzy snap в publish_review.
-
-    Гарантии коэрции:
-
-    - не-dict или dict без ``file`` → None (вызывающий считает invalid);
-    - ``line``: int-коэрция, мусор → None;
-    - ``confidence``: float-коэрция, None/мусор → 0.1; значение клампится в [0.0, 1.0];
-    - ``severity`` вне {low,medium,high,critical} → "medium";
-    - ``side`` вне {RIGHT,LEFT} → "RIGHT";
-    - ``suggestion``: не-строка → None (не попадает в тело комментария как repr);
-    - ``fix``: int-коэрция start/end; при мусоре (или нестроковом replacement)
-      fix отбрасывается целиком.
-    """
-    if not isinstance(d, dict) or not d.get("file"):
-        return None
-    severity = d.get("severity")
-    if not isinstance(severity, str) or severity not in _VALID_SEVERITIES:
-        severity = "medium"
-    side = d.get("side")
-    if side not in ("RIGHT", "LEFT"):
-        side = "RIGHT"
-    try:
-        confidence = float(d.get("confidence"))
-    except (TypeError, ValueError):
-        confidence = 0.1   # не оценено = спекулятивно (ниже честного потолка 0.4) → отсекается гейтом
-    confidence = max(0.0, min(1.0, confidence))   # clamp в [0,1]
-    fix = d.get("fix")
-    fix_start = fix_end = replacement = None
-    if isinstance(fix, dict):
-        fix_start = _coerce_int(fix.get("start_line"))
-        fix_end = _coerce_int(fix.get("end_line"))
-        replacement = fix.get("replacement")
-        if fix_start is None or fix_end is None or not isinstance(replacement, str):
-            fix_start = fix_end = replacement = None
-    suggestion = d.get("suggestion")
-    if not isinstance(suggestion, str):
-        suggestion = None
-    _cq = d.get("code_quote")
-    return Finding(
-        category=str(d.get("category") or "correctness"),
-        severity=severity,
-        file=str(d["file"]),
-        line=_coerce_int(d.get("line")),
-        side=side,
-        message=str(d.get("message") or ""),
-        suggestion=suggestion,
-        confidence=confidence,
-        fix_start=fix_start,
-        fix_end=fix_end,
-        replacement=replacement,
-        code_quote=_cq if isinstance(_cq, str) else None,
-    )
-
 
 @dataclass
 class _Session:
@@ -575,53 +505,41 @@ class MCPReviewService:
         repo: str,
         pr: int,
         summary: str,
-        findings: list[dict],
         dry_run: bool = False,
         task_key: str | None = None,
     ) -> dict:
-        """Детерминированный хвост ревью: gate → grounding → dedup → assemble →
-        публикация → история → очистка overlay/сессии.
+        """Детерминированный хвост ревью: verify-фильтр → grounding → gate →
+        dedup → assemble → публикация → история → очистка overlay/сессии.
 
-        ``findings`` — словари в схеме analyze-промпта (вход от LLM). Кривые
-        словари не валят publish: запись без ``file`` пропускается (счётчик
-        ``invalid`` в отчёте), остальные поля коэрцируются с дефолтами — см.
-        :func:`_finding_from_dict`. Сессия (repo, pr) должна быть подготовлена
-        ``prepare_review``. Overlay и сессия очищаются ВСЕГДА (даже при сбое
-        VCS-публикации) — см. ``_cleanup``.
+        PRI-156: находки и вердикты читаются ИЗ СЕССИИ (submit_findings/
+        submit_verdicts), параметр findings убран. Отсев verify — только по
+        явному is_real=false; отсутствие вердикта = keep (recall-safe).
+        Сессия (repo, pr) должна быть подготовлена prepare_review. Overlay и
+        сессия очищаются ВСЕГДА (даже при сбое VCS-публикации) — см. _cleanup.
 
-        При указании ``task_key`` и успешной публикации (не dry_run) автоматически
-        линкует PR↔задача↔код в граф задач через ``task_service.link_review``
-        (рёбра IMPLEMENTED_BY + TOUCHES затронутых символов).
-
-        Args:
-            summary: сводка от модели; к ней добавляется markdown-отчёт assemble.
-            dry_run: не публиковать в VCS, только собрать отчёт.
-            task_key: канонический ключ задачи (например «ID-1») для авто-линковки.
+        При указании task_key и успешной публикации (не dry_run) линкует
+        PR↔задача↔код в граф задач (рёбра IMPLEMENTED_BY + TOUCHES).
 
         Returns:
-            Отчёт со счётчиками (posted/invalid/dropped_by_gate/deduped/
-            already_posted/moved_to_summary/capped) и inline.
+            Отчёт со счётчиками (posted/invalid/verify_rejected/dropped_by_gate/
+            deduped/already_posted/moved_to_summary/capped) и inline.
         """
         from reviewer.services.repo_id import normalize_repo
         repo = normalize_repo(repo)
         s = self._session(repo, pr)
         p = s.prepared
 
-        # 1) Коэрция LLM-входа (кривой dict без file → скип) и грунтовка строки
-        # по дословной цитате (анти-галлюцинация).
+        # 1) Verify-фильтр из сессии: keep, кроме явного is_real=false (recall-safe).
+        # Затем грунтовка строки по дословной цитате (анти-галлюцинация).
         _commentable_cache: dict[str, dict[str, set[int]]] = {
             path: commentable_lines(patch)
             for path, patch in p.patches.items()
             if patch is not None
         }
+        survived = [f for fid, f in s.candidates.items() if s.verdicts.get(fid) is not False]
+        verify_rejected = len(s.candidates) - len(survived)
         parsed: list[Finding] = []
-        invalid = 0
-        for d in findings:
-            f = _finding_from_dict(d)
-            if f is None:
-                invalid += 1
-                log.warning("publish_review: пропущена некорректная находка: %r", d)
-                continue
+        for f in survived:
             f.line = ground_line(p.sources.get(f.file), f.code_quote, f.line)
             if f.line is not None and f.side == "RIGHT" and f.file in _commentable_cache:
                 f.line = snap_to_commentable(
@@ -696,8 +614,9 @@ class MCPReviewService:
         # 6) История (fail-soft) и очистка overlay/сессии (ВСЕГДА).
         dropped_by_gate = len(parsed) - len(kept)
         run_id = self._record_history(
-            repo, pr, p, parsed, deduped, asm,
-            dropped_by_gate=dropped_by_gate, dry_run=dry_run, posted=posted, error=error,
+            repo, pr, p, list(s.candidates.values()), deduped, asm,
+            verify_rejected=verify_rejected,
+            dry_run=dry_run, posted=posted, error=error,
         )
         self._cleanup(repo, pr)
 
@@ -711,7 +630,8 @@ class MCPReviewService:
                 {"path": c.path, "line": c.line, "side": c.side, "body": c.body}
                 for c in asm.inline_comments
             ],
-            "invalid": invalid,
+            "invalid": 0,                       # PRI-156: вход валиден по схеме (submit)
+            "verify_rejected": verify_rejected,
             "dropped_by_gate": dropped_by_gate,
             "deduped": len(kept) - len(deduped),
             "already_posted": asm.skipped_existing,
@@ -724,11 +644,11 @@ class MCPReviewService:
         repo: str,
         pr: int,
         p: PreparedReview,
-        parsed: list[Finding],
+        analyzed: list[Finding],
         deduped: list[Finding],
         asm: AssembledReview,
         *,
-        dropped_by_gate: int,
+        verify_rejected: int,
         dry_run: bool,
         posted: bool,
         error: str,
@@ -748,9 +668,9 @@ class MCPReviewService:
             now = datetime.now(timezone.utc)
             status = "error" if (error and not dry_run) else "ok"
             comments_inline = len(asm.inline_comments)
-            # Паритет со старым пайплайном: analyzed — по уникальным fingerprint
-            # (parsed уже грунтован, но ещё без _sane_line из assemble — допустимо).
-            findings_analyzed = len({f.fingerprint() for f in parsed})
+            # PRI-156: analyzed — все candidates (до verify-фильтра), по уникальным
+            # fingerprint (грунтовка выполнена в publish_review до передачи сюда).
+            findings_analyzed = len({f.fingerprint() for f in analyzed})
             run = {
                 "repo": repo,
                 "pr_number": pr,
@@ -768,9 +688,9 @@ class MCPReviewService:
                 "files_failed": 0,
                 "findings_analyzed": findings_analyzed,
                 "findings_kept": len(deduped),
-                # verify_rejected = отсев политикой-gate (в новом пути verify
-                # живёт в скилле, до publish доходят уже отфильтрованные находки).
-                "verify_rejected": dropped_by_gate,
+                # PRI-156: verify_rejected = число is_real=false (verify живёт в
+                # сессии submit_verdicts); gate-отсев отдельно в отчёте publish.
+                "verify_rejected": verify_rejected,
                 "comments_inline": comments_inline,
                 # Считаем только реально опубликованные не-inline строки
                 # (findings_rows включает skipped_existing с published=False).

--- a/reviewer/vcs/base.py
+++ b/reviewer/vcs/base.py
@@ -1,6 +1,9 @@
 import re
 from dataclasses import dataclass
-from typing import Literal, Protocol
+from typing import TYPE_CHECKING, Literal, Protocol
+
+if TYPE_CHECKING:
+    from reviewer.mcp.schemas import FindingIn
 
 def normalize_message(message: str) -> str:
     """Нормализовать текст находки для dedup/fingerprint: устранить незначимые
@@ -59,6 +62,29 @@ class Finding:
         import hashlib
         key = f"{self.file}|{self.line}|{self.side}|{self.category}|{normalize_message(self.message)}"
         return hashlib.sha256(key.encode()).hexdigest()[:16]
+
+    @classmethod
+    def from_in(cls, fi: "FindingIn") -> "Finding":
+        """Построить внутренний Finding из валидированного FindingIn (PRI-156).
+
+        Дакт-тайпинг по атрибутам: без runtime-импорта FindingIn (vcs не зависит
+        от mcp). centrality стартует с 0.0 (проставляется графом в publish_review).
+        """
+        fix = fi.fix
+        return cls(
+            category=fi.category,
+            severity=fi.severity,
+            file=fi.file,
+            line=fi.line,
+            side=fi.side,
+            message=fi.message,
+            suggestion=fi.suggestion,
+            confidence=fi.confidence,
+            fix_start=fix.start_line if fix else None,
+            fix_end=fix.end_line if fix else None,
+            replacement=fix.replacement if fix else None,
+            code_quote=fi.code_quote,
+        )
 
 class VCSProvider(Protocol):
     def get_pull_request(self, number: int) -> PullRequest: ...

--- a/tests/mcp/test_publish.py
+++ b/tests/mcp/test_publish.py
@@ -170,6 +170,16 @@ def _make_mcp_service_with_publish(
     return svc, vcs, history
 
 
+def _submit_then_publish(svc, repo, pr, findings, *, summary="s", dry_run=False,
+                         verdicts=None, task_key=None):
+    """PRI-156: вместо publish_review(findings=...) — submit + publish из сессии."""
+    if findings:
+        svc.submit_findings(repo, pr, findings)
+    if verdicts:
+        svc.submit_verdicts(repo, pr, verdicts)
+    return svc.publish_review(repo, pr, summary=summary, dry_run=dry_run, task_key=task_key)
+
+
 # ---------------------------------------------------------------------------
 # Тесты
 #
@@ -182,7 +192,7 @@ def _make_mcp_service_with_publish(
 def test_publish_posts_inline_and_records_history(_ov, _ch) -> None:
     svc, vcs, history = _make_mcp_service_with_publish()
     svc.prepare_review("o/r", 7)
-    report = svc.publish_review("o/r", 7, summary="Overall fine", findings=[RAW])
+    report = _submit_then_publish(svc, "o/r", 7, [RAW], summary="Overall fine")
     assert report["posted"] is True
     assert vcs.published[0]["comments"][0]["path"] == "a.py"
     assert history.runs[0]["pr_number"] == 7
@@ -194,7 +204,7 @@ def test_publish_posts_inline_and_records_history(_ov, _ch) -> None:
 def test_publish_dry_run_does_not_post_but_reports(_ov, _ch) -> None:
     svc, vcs, history = _make_mcp_service_with_publish()
     svc.prepare_review("o/r", 7)
-    report = svc.publish_review("o/r", 7, summary="s", findings=[RAW], dry_run=True)
+    report = _submit_then_publish(svc, "o/r", 7, [RAW], dry_run=True)
     assert report["posted"] is False and vcs.published == []
     assert report["inline"][0]["line"] == 2
     assert report["capped"] == 0
@@ -214,8 +224,7 @@ def test_publish_gates_low_severity_and_grounds_line(_ov, _ch) -> None:
     svc.prepare_review("o/r", 7)
     low = dict(RAW, severity="low")                       # ниже threshold=medium
     wrong_line = dict(RAW, line=99)                       # грунтовка по code_quote → 2
-    report = svc.publish_review("o/r", 7, summary="s",
-                                findings=[low, wrong_line], dry_run=True)
+    report = _submit_then_publish(svc, "o/r", 7, [low, wrong_line], dry_run=True)
     assert report["dropped_by_gate"] == 1
     assert report["inline"][0]["line"] == 2
 
@@ -225,7 +234,7 @@ def test_publish_gates_low_severity_and_grounds_line(_ov, _ch) -> None:
 def test_publish_cleans_overlay_even_on_vcs_error(_ov, _ch) -> None:
     svc, vcs, history = _make_mcp_service_with_publish(vcs_fails=True)
     svc.prepare_review("o/r", 7)
-    report = svc.publish_review("o/r", 7, summary="s", findings=[RAW])
+    report = _submit_then_publish(svc, "o/r", 7, [RAW])
     assert report["posted"] is False and report["error"]
     # prepare сам чистит overlay один раз (self-healing) + cleanup после publish
     assert svc.components.store.deleted_refs.count("pr:7") == 2
@@ -243,7 +252,7 @@ def test_publish_factory_vcs_not_closed(_ov, _ch) -> None:
     """Внешний (factory) VCS сервис НЕ закрывает — жизненным циклом владеет фабрика."""
     svc, vcs, _ = _make_mcp_service_with_publish()
     svc.prepare_review("o/r", 7)
-    svc.publish_review("o/r", 7, summary="s", findings=[RAW], dry_run=True)
+    _submit_then_publish(svc, "o/r", 7, [RAW], dry_run=True)
     assert vcs.close_calls == 0
 
 
@@ -262,7 +271,7 @@ def test_publish_closes_internal_vcs() -> None:
         "reviewer.services.review_service.chunk_python", side_effect=_fake_chunk,
     ), patch("reviewer.services.review_service.build_overlay"):
         svc.prepare_review("o/r", 7)
-        svc.publish_review("o/r", 7, summary="s", findings=[RAW], dry_run=True)
+        _submit_then_publish(svc, "o/r", 7, [RAW], dry_run=True)
     assert vcs.close_calls == 1
     assert ("o/r", 7) not in svc._sessions
 
@@ -278,32 +287,19 @@ def test_publish_history_failsoft(_ov, _ch) -> None:
 
     history.record_run = boom
     svc.prepare_review("o/r", 7)
-    report = svc.publish_review("o/r", 7, summary="s", findings=[RAW])
+    report = _submit_then_publish(svc, "o/r", 7, [RAW])
     assert report["posted"] is True
     assert report["run_id"] is None
 
 
 @patch("reviewer.services.review_service.chunk_python", side_effect=_fake_chunk)
 @patch("reviewer.services.review_service.build_overlay")
-def test_publish_coerces_malformed_llm_findings(_ov, _ch) -> None:
-    """Кривые dict'ы от LLM не валят publish: без file — скип (invalid),
-    line="42" — int-коэрция (+грунтовка), confidence=None → 0.1 (ниже порога → отсекается),
-    severity="urgent" → "medium". Валидные публикуются."""
-    svc, vcs, _ = _make_mcp_service_with_publish()
+def test_publish_invalid_always_zero_with_enforced_schema(_ov, _ch) -> None:
+    """Все candidates валидны (validated на submit) → invalid всегда 0."""
+    svc, _, _ = _make_mcp_service_with_publish()
     svc.prepare_review("o/r", 7)
-    pack = [
-        {"category": "correctness", "severity": "high",
-         "message": "no file", "confidence": 0.9},          # без file → invalid
-        dict(RAW, line="42", message="bug A"),               # int-коэрция строки
-        dict(RAW, confidence=None, message="bug B"),         # None → 0.1 (ниже порога 0.5 → dropped)
-        dict(RAW, severity="urgent", message="bug C"),       # вне enum → medium
-    ]
-    report = svc.publish_review("o/r", 7, summary="s", findings=pack)
-    assert report["posted"] is True
-    assert report["invalid"] == 1
-    assert report["dropped_by_gate"] == 1                    # bug B (confidence=0.1) отсекается
-    assert len(report["inline"]) == 2
-    assert all(c["line"] == 2 for c in report["inline"])     # все загрунтованы по цитате
+    report = _submit_then_publish(svc, "o/r", 7, [RAW], dry_run=True)
+    assert report["invalid"] == 0
 
 
 @patch("reviewer.services.review_service.chunk_python", side_effect=_fake_chunk)
@@ -316,7 +312,7 @@ def test_publish_skips_already_posted_fingerprints(_ov, _ch) -> None:
     ).fingerprint()
     svc, vcs, _ = _make_mcp_service_with_publish(existing_fps={fp})
     svc.prepare_review("o/r", 7)
-    report = svc.publish_review("o/r", 7, summary="s", findings=[RAW], dry_run=True)
+    report = _submit_then_publish(svc, "o/r", 7, [RAW], dry_run=True)
     assert report["already_posted"] == 1
     assert report["inline"] == []
 
@@ -327,7 +323,7 @@ def test_publish_empty_findings_posts_summary(_ov, _ch) -> None:
     """Пустой список находок: ревью публикуется со сводкой «Замечаний не найдено»."""
     svc, vcs, _ = _make_mcp_service_with_publish()
     svc.prepare_review("o/r", 7)
-    report = svc.publish_review("o/r", 7, summary="s", findings=[])
+    report = _submit_then_publish(svc, "o/r", 7, [], summary="s")
     assert report["posted"] is True
     assert report["inline"] == []
     assert "Замечаний не найдено" in report["summary"]
@@ -340,8 +336,7 @@ def test_publish_dedups_near_identical_findings(_ov, _ch) -> None:
     """Две одинаковые находки схлопываются в одну: deduped=1, один inline."""
     svc, vcs, history = _make_mcp_service_with_publish()
     svc.prepare_review("o/r", 7)
-    report = svc.publish_review("o/r", 7, summary="s",
-                                findings=[RAW, dict(RAW)], dry_run=True)
+    report = _submit_then_publish(svc, "o/r", 7, [RAW, dict(RAW)], dry_run=True)
     assert report["deduped"] == 1
     assert len(report["inline"]) == 1
     # findings_analyzed — по уникальным fingerprint (точный дубль не раздувает счётчик)
@@ -363,8 +358,8 @@ def test_publish_skipped_existing_not_counted_in_comments_summary(_ov, _ch) -> N
     summary_raw = dict(RAW, line=None, code_quote=None, message="summary finding")
     svc, vcs, history = _make_mcp_service_with_publish(existing_fps={fp})
     svc.prepare_review("o/r", 7)
-    report = svc.publish_review(
-        "o/r", 7, summary="s", findings=[RAW, summary_raw], dry_run=True,
+    report = _submit_then_publish(
+        svc, "o/r", 7, [RAW, summary_raw], dry_run=True,
     )
     # RAW пропущена (already_posted), summary_raw уходит в summary
     assert report["already_posted"] == 1
@@ -387,7 +382,7 @@ def test_publish_annotates_centrality_from_graph(_ov, _ch) -> None:
     ]
     svc.components.graph.in_degree.return_value = {"a.py#foo": 4}
     svc.prepare_review("o/r", 7)
-    svc.publish_review("o/r", 7, summary="s", findings=[RAW], dry_run=True)
+    _submit_then_publish(svc, "o/r", 7, [RAW], dry_run=True)
     # Центральность была запрошена ровно для пойманного символа.
     svc.components.graph.in_degree.assert_called_once()
     assert svc.components.graph.in_degree.call_args.args[1] == ["a.py#foo"]
@@ -395,25 +390,37 @@ def test_publish_annotates_centrality_from_graph(_ov, _ch) -> None:
 
 @patch("reviewer.services.review_service.chunk_python", side_effect=_fake_chunk)
 @patch("reviewer.services.review_service.build_overlay")
-def test_publish_coerces_unhashable_severity_and_nonstringsuggestion(_ov, _ch) -> None:
-    """Unhashable severity (список) → "medium"; не-строковый suggestion → None.
-
-    Проверяет фикс: frozenset-membership на списке давал TypeError,
-    repr suggestion в теле комментария устранён коэрцией в str | None.
-    """
+def test_publish_coerced_findings_publish(_ov, _ch) -> None:
+    """Коэрция severity/suggestion на submit → medium проходит гейт, suggestion=None не в теле."""
     svc, vcs, _ = _make_mcp_service_with_publish()
     svc.prepare_review("o/r", 7)
-    pack = [
-        dict(RAW, severity=["high"], message="unhashable severity"),    # список → medium
-        dict(RAW, suggestion=42, message="non-string suggestion"),       # int → None
-    ]
-    report = svc.publish_review("o/r", 7, summary="s", findings=pack, dry_run=True)
-    # Оба прошли гейт (medium >= threshold=medium) и опубликовались
-    assert report["invalid"] == 0
+    pack = [dict(RAW, severity=["high"], message="unhashable severity"),
+            dict(RAW, suggestion=42, message="non-string suggestion")]
+    report = _submit_then_publish(svc, "o/r", 7, pack, dry_run=True)
     assert report["dropped_by_gate"] == 0
     assert len(report["inline"]) == 2
-    # suggestion=42 должен превратиться в None (не "42" или repr)
     inline_bodies = [c["body"] for c in report["inline"]]
-    assert not any("42" in b and "suggestion" in b.lower() for b in inline_bodies), (
-        "suggestion=42 не должен попадать в тело комментария как repr/str"
-    )
+    assert not any("42" in b and "suggestion" in b.lower() for b in inline_bodies)
+
+
+@patch("reviewer.services.review_service.chunk_python", side_effect=_fake_chunk)
+@patch("reviewer.services.review_service.build_overlay")
+def test_publish_drops_findings_with_is_real_false(_ov, _ch) -> None:
+    """Явный is_real=false → находка отсеяна; verify_rejected=1."""
+    svc, _, _ = _make_mcp_service_with_publish()
+    svc.prepare_review("o/r", 7)
+    report = _submit_then_publish(svc, "o/r", 7, [RAW], dry_run=True,
+                                  verdicts=[{"id": "f1", "is_real": False}])
+    assert report["verify_rejected"] == 1
+    assert report["inline"] == []
+
+
+@patch("reviewer.services.review_service.chunk_python", side_effect=_fake_chunk)
+@patch("reviewer.services.review_service.build_overlay")
+def test_publish_keeps_finding_without_verdict(_ov, _ch) -> None:
+    """Нет вердикта (verify умер/частичный) → находка остаётся (recall-safe)."""
+    svc, _, _ = _make_mcp_service_with_publish()
+    svc.prepare_review("o/r", 7)
+    report = _submit_then_publish(svc, "o/r", 7, [RAW], dry_run=True)  # без verdicts
+    assert report["verify_rejected"] == 0
+    assert report["inline"][0]["line"] == 2

--- a/tests/mcp/test_schemas.py
+++ b/tests/mcp/test_schemas.py
@@ -1,0 +1,67 @@
+"""Тесты FindingIn/VerdictIn — мягкая коэрция (порт _finding_from_dict, PRI-144)."""
+from __future__ import annotations
+
+import pytest
+
+from reviewer.mcp.schemas import FindingIn, FixIn, VerdictIn
+
+BASE = {"file": "a.py", "severity": "high", "message": "m", "line": 1, "code_quote": "x = 1"}
+
+
+def test_confidence_coercion_and_clamp():
+    # валидные проходят как есть
+    assert FindingIn.model_validate({**BASE, "confidence": 0.9}).confidence == 0.9
+    assert FindingIn.model_validate({**BASE, "confidence": 0.5}).confidence == 0.5
+    # не оценено / None / мусор → 0.1
+    assert FindingIn.model_validate(BASE).confidence == 0.1
+    assert FindingIn.model_validate({**BASE, "confidence": None}).confidence == 0.1
+    assert FindingIn.model_validate({**BASE, "confidence": "abc"}).confidence == 0.1
+    # clamp в [0,1]
+    assert FindingIn.model_validate({**BASE, "confidence": 1.5}).confidence == 1.0
+    assert FindingIn.model_validate({**BASE, "confidence": -0.2}).confidence == 0.0
+
+
+def test_severity_side_defaults():
+    assert FindingIn.model_validate({**BASE, "severity": "urgent"}).severity == "medium"
+    assert FindingIn.model_validate({**BASE, "severity": ["high"]}).severity == "medium"
+    assert FindingIn.model_validate({**BASE, "side": "MIDDLE"}).side == "RIGHT"
+    assert FindingIn.model_validate({**BASE, "side": "LEFT"}).side == "LEFT"
+
+
+def test_line_coercion():
+    assert FindingIn.model_validate({**BASE, "line": "42"}).line == 42
+    assert FindingIn.model_validate({**BASE, "line": "abc"}).line is None
+    assert FindingIn.model_validate({**BASE, "line": None}).line is None
+
+
+def test_suggestion_and_codequote_nonstring_to_none():
+    assert FindingIn.model_validate({**BASE, "suggestion": 42}).suggestion is None
+    assert FindingIn.model_validate({**BASE, "suggestion": "do x"}).suggestion == "do x"
+    assert FindingIn.model_validate({**BASE, "code_quote": 7}).code_quote is None
+
+
+def test_fix_dropped_when_incomplete():
+    ok = FindingIn.model_validate({**BASE, "fix": {"start_line": 1, "end_line": 2, "replacement": "z"}})
+    assert ok.fix == FixIn(start_line=1, end_line=2, replacement="z")
+    # нестроковый replacement → вся fix отбрасывается
+    assert FindingIn.model_validate({**BASE, "fix": {"start_line": 1, "end_line": 2, "replacement": 9}}).fix is None
+    # мусорный start_line → вся fix отбрасывается
+    assert FindingIn.model_validate({**BASE, "fix": {"start_line": "x", "end_line": 2, "replacement": "z"}}).fix is None
+    assert FindingIn.model_validate({**BASE, "fix": None}).fix is None
+
+
+def test_file_required():
+    with pytest.raises(Exception):
+        FindingIn.model_validate({"severity": "high", "message": "no file"})
+
+
+def test_category_default():
+    assert FindingIn.model_validate(BASE).category == "correctness"
+    assert FindingIn.model_validate({**BASE, "category": "security"}).category == "security"
+
+
+def test_verdict_in():
+    v = VerdictIn.model_validate({"id": "f3", "is_real": False})
+    assert v.id == "f3" and v.is_real is False
+    with pytest.raises(Exception):
+        VerdictIn.model_validate({"id": "f3"})   # is_real required

--- a/tests/mcp/test_schemas.py
+++ b/tests/mcp/test_schemas.py
@@ -55,6 +55,13 @@ def test_file_required():
         FindingIn.model_validate({"severity": "high", "message": "no file"})
 
 
+def test_file_rejects_empty_string():
+    with pytest.raises(Exception):
+        FindingIn.model_validate({**BASE, "file": ""})
+    # пробел-непустой проходит (паритет со старым _finding_from_dict: falsy-проверка)
+    assert FindingIn.model_validate({**BASE, "file": " "}).file == " "
+
+
 def test_category_default():
     assert FindingIn.model_validate(BASE).category == "correctness"
     assert FindingIn.model_validate({**BASE, "category": "security"}).category == "security"

--- a/tests/mcp/test_server.py
+++ b/tests/mcp/test_server.py
@@ -88,7 +88,7 @@ def _make_mcp_service(number: int = 7) -> MCPReviewService:
 # ---------------------------------------------------------------------------
 
 def test_server_registers_all_tools() -> None:
-    """create_server регистрирует ровно 22 ожидаемых MCP-тулов."""
+    """create_server регистрирует ровно 25 ожидаемых MCP-тулов."""
     from reviewer.entrypoints.mcp_server import create_server
 
     server = create_server(_make_mcp_service())
@@ -112,6 +112,9 @@ def test_server_registers_all_tools() -> None:
         "get_task",
         "get_board_config",
         "publish_review",
+        "submit_findings",
+        "submit_verdicts",
+        "get_candidate_findings",
         "search_codebase",
         "related_symbols",
         "callers",
@@ -145,21 +148,24 @@ def test_prepare_review_callable_via_mcp(_ov, _ch) -> None:
 @patch("reviewer.services.review_service.chunk_python", side_effect=_fake_chunk)
 @patch("reviewer.services.review_service.build_overlay")
 def test_publish_review_dry_run_callable_via_mcp(_ov, _ch) -> None:
-    """Smoke: publish_review через MCP-слой — pydantic-валидация findings
-    (list[dict]) и сериализация dict-отчёта в TextContent."""
+    """Smoke: submit_findings + publish_review через MCP-слой (PRI-156).
+
+    Находки сдаются через submit_findings (schema-enforced FindingIn),
+    publish_review вызывается без findings и возвращает dict-отчёт.
+    """
+    from tests.mcp.test_publish import RAW
+
     from reviewer.entrypoints.mcp_server import create_server
 
     server = create_server(_make_mcp_service())
     asyncio.run(server.call_tool("prepare_review", {"repo": "o/r", "pr": 7}))
-    finding = {
-        "category": "correctness", "severity": "high", "file": "a.py",
-        "line": 1, "code_quote": None, "message": "bug", "suggestion": None,
-        "fix": None, "confidence": 0.9,
-    }
+    asyncio.run(server.call_tool(
+        "submit_findings",
+        {"repo": "o/r", "pr": 7, "findings": [RAW]},
+    ))
     result = asyncio.run(server.call_tool(
         "publish_review",
-        {"repo": "o/r", "pr": 7, "summary": "s",
-         "findings": [finding], "dry_run": True},
+        {"repo": "o/r", "pr": 7, "summary": "s", "dry_run": True},
     ))
 
     assert result, "ожидали непустой результат"

--- a/tests/mcp/test_server_tools.py
+++ b/tests/mcp/test_server_tools.py
@@ -31,10 +31,9 @@ def test_publish_review_tool_forwards_task_key():
     # Гоним реальную обёртку тула через FastMCP.call_tool, а не мок напрямую.
     asyncio.run(server.call_tool(
         "publish_review",
-        {"repo": "o/r", "pr": 7, "summary": "s", "findings": [],
-         "dry_run": False, "task_key": "ID-1"},
+        {"repo": "o/r", "pr": 7, "summary": "s", "task_key": "ID-1"},
     ))
-    svc.publish_review.assert_called_once_with("o/r", 7, "s", [], False, "ID-1")
+    svc.publish_review.assert_called_once_with("o/r", 7, "s", False, "ID-1")
 
 
 def test_get_board_config_tool_registered():

--- a/tests/mcp/test_service.py
+++ b/tests/mcp/test_service.py
@@ -11,7 +11,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from reviewer.config.settings import Settings
-from reviewer.mcp.service import MCPReviewService, _finding_from_dict
+from reviewer.mcp.service import MCPReviewService
 from reviewer.vcs.base import (
     ChangedFile,
     PullRequest,
@@ -425,7 +425,7 @@ def test_publish_review_links_task_when_task_key(
     svc = MCPReviewService(settings, components, vcs_factory=lambda o, r: vcs)
     svc.prepare_review("o/r", 7)
 
-    svc.publish_review("o/r", 7, "summary", [], dry_run=False, task_key="ID-1")
+    svc.publish_review("o/r", 7, "summary", dry_run=False, task_key="ID-1")
 
     components.task_service.link_review.assert_called_once()
     args = components.task_service.link_review.call_args.args
@@ -448,7 +448,7 @@ def test_publish_review_no_link_on_dry_run(
     vcs.list_existing_fingerprints.return_value = set()
     svc = MCPReviewService(settings, components, vcs_factory=lambda o, r: vcs)
     svc.prepare_review("o/r", 7)
-    svc.publish_review("o/r", 7, "summary", [], dry_run=True, task_key="ID-1")
+    svc.publish_review("o/r", 7, "summary", dry_run=True, task_key="ID-1")
     components.task_service.link_review.assert_not_called()
 
 
@@ -464,7 +464,7 @@ def test_publish_review_no_link_without_task_key(
     vcs.list_existing_fingerprints.return_value = set()
     svc = MCPReviewService(settings, components, vcs_factory=lambda o, r: vcs)
     svc.prepare_review("o/r", 7)
-    svc.publish_review("o/r", 7, "summary", [], dry_run=False)
+    svc.publish_review("o/r", 7, "summary", dry_run=False)
     components.task_service.link_review.assert_not_called()
 
 
@@ -678,20 +678,3 @@ def test_get_pr_diff_empty_files_note():
     svc = MCPReviewService(_settings(), _components(), vcs_factory=lambda o, r: vcs)
     assert svc.get_pr_diff("o/r", 7) == "(PR без изменённых файлов)"
 
-
-# ---------------------------------------------------------------------------
-# Тесты Task 1 (PRI-144): коэрция confidence — fallback 0.1 + clamp [0,1]
-# ---------------------------------------------------------------------------
-
-def test_finding_confidence_coercion_and_clamp():
-    base = {"file": "a.py", "severity": "high", "message": "m", "line": 1, "code_quote": "x = 1"}
-    # валидные значения проходят как есть
-    assert _finding_from_dict({**base, "confidence": 0.9}).confidence == 0.9
-    assert _finding_from_dict({**base, "confidence": 0.5}).confidence == 0.5
-    # не оценено / None / мусор → 0.1 (ниже честного потолка спекулятивной зоны 0.4)
-    assert _finding_from_dict(base).confidence == 0.1
-    assert _finding_from_dict({**base, "confidence": None}).confidence == 0.1
-    assert _finding_from_dict({**base, "confidence": "abc"}).confidence == 0.1
-    # clamp в [0,1]
-    assert _finding_from_dict({**base, "confidence": 1.5}).confidence == 1.0
-    assert _finding_from_dict({**base, "confidence": -0.2}).confidence == 0.0

--- a/tests/mcp/test_session_persist.py
+++ b/tests/mcp/test_session_persist.py
@@ -125,7 +125,8 @@ def test_publish_after_restart_rehydrates_session(_ov, _ch) -> None:
         svc.prepare_review("o/r", 7)
         assert ("o/r", 7) in store.rows               # сессия персистнута
         svc._sessions.clear()                          # эмуляция рестарта процесса
-        report = svc.publish_review("o/r", 7, summary="s", findings=[RAW], dry_run=True)
+        svc.submit_findings("o/r", 7, [RAW])
+        report = svc.publish_review("o/r", 7, summary="s", dry_run=True)
     assert report["inline"][0]["line"] == 2            # регидрация дала рабочую сессию
     assert ("o/r", 7) not in store.rows                # cleanup удалил персист
 
@@ -148,7 +149,7 @@ def test_publish_miss_raises_with_recovery_hint() -> None:
     store = _FakeSessionStore()                          # пусто: prepare не вызывался
     svc = _make_service(store)
     with pytest.raises(ValueError, match="prepare_review"):
-        svc.publish_review("o/r", 7, summary="s", findings=[RAW], dry_run=True)
+        svc.publish_review("o/r", 7, summary="s", dry_run=True)
 
 
 @patch("reviewer.services.review_service.chunk_python", side_effect=_fake_chunk)
@@ -164,4 +165,4 @@ def test_persist_disabled_no_rehydration(_ov, _ch) -> None:
         assert svc._session_store is None          # гейт: персист выключен → store не создан
         svc._sessions.clear()                              # эмуляция рестарта
         with pytest.raises(ValueError, match="prepare_review"):
-            svc.publish_review("o/r", 7, summary="s", findings=[RAW], dry_run=True)
+            svc.publish_review("o/r", 7, summary="s", dry_run=True)

--- a/tests/mcp/test_submit_tools.py
+++ b/tests/mcp/test_submit_tools.py
@@ -1,0 +1,47 @@
+"""submit_findings/get_candidate_findings/submit_verdicts — сессионное накопление."""
+from __future__ import annotations
+
+import json
+from unittest.mock import patch
+
+from tests.mcp.test_publish import (
+    RAW, _make_mcp_service_with_publish, _fake_chunk,
+)
+
+
+@patch("reviewer.services.review_service.chunk_python", side_effect=_fake_chunk)
+@patch("reviewer.services.review_service.build_overlay")
+def test_submit_findings_accumulates_with_ids(_ov, _ch):
+    svc, _, _ = _make_mcp_service_with_publish()
+    svc.prepare_review("o/r", 7)
+    r1 = svc.submit_findings("o/r", 7, [RAW])
+    r2 = svc.submit_findings("o/r", 7, [dict(RAW, message="bug B")])
+    assert r1 == {"accepted": 1, "ids": ["f1"]}
+    assert r2 == {"accepted": 1, "ids": ["f2"]}
+    sess = svc._sessions[("o/r", 7)]
+    assert set(sess.candidates) == {"f1", "f2"}
+    assert sess.candidates["f1"].message == "bug here"
+
+
+@patch("reviewer.services.review_service.chunk_python", side_effect=_fake_chunk)
+@patch("reviewer.services.review_service.build_overlay")
+def test_get_candidate_findings_returns_ids(_ov, _ch):
+    svc, _, _ = _make_mcp_service_with_publish()
+    svc.prepare_review("o/r", 7)
+    svc.submit_findings("o/r", 7, [RAW])
+    payload = json.loads(svc.get_candidate_findings("o/r", 7))
+    assert payload["candidates"][0]["id"] == "f1"
+    assert payload["candidates"][0]["file"] == "a.py"
+    assert payload["candidates"][0]["code_quote"] == "x = 1"
+
+
+@patch("reviewer.services.review_service.chunk_python", side_effect=_fake_chunk)
+@patch("reviewer.services.review_service.build_overlay")
+def test_submit_verdicts_records_and_flags_unknown(_ov, _ch):
+    svc, _, _ = _make_mcp_service_with_publish()
+    svc.prepare_review("o/r", 7)
+    svc.submit_findings("o/r", 7, [RAW])              # → f1
+    r = svc.submit_verdicts("o/r", 7, [{"id": "f1", "is_real": False},
+                                       {"id": "f9", "is_real": True}])
+    assert r == {"recorded": 1, "unknown_ids": ["f9"]}
+    assert svc._sessions[("o/r", 7)].verdicts == {"f1": False}

--- a/tests/skills/test_assembled_prompts.py
+++ b/tests/skills/test_assembled_prompts.py
@@ -52,7 +52,9 @@ def test_blast_radius_assembled_has_tooling_and_confidence_tail():
 
 def test_verify_keeps_verdicts_schema_and_tools():
     v = assemble("review-pr/references/verify-prompt.md")
-    assert '{"verdicts":' in v.replace(" ", "")    # своя схема не тронута
+    # PRI-156: verify теперь вызывает submit_verdicts, а не возвращает JSON-текст
+    assert "submit_verdicts" in v                   # submit-контракт на месте
+    assert "get_candidate_findings" in v            # чтение кандидатов тулом
     assert "find_callers" in v                      # tool-usage подставлен
 
 

--- a/tests/skills/test_common_blocks.py
+++ b/tests/skills/test_common_blocks.py
@@ -70,6 +70,18 @@ def test_tool_usage_has_both_tool_families():
     assert "search_code" in text and "get_changed_file_diff" in text and "get_impact" in text
     # session-less
     assert "search_codebase" in text and "related_symbols" in text and "definition" in text
+    # PRI-156: submit-тулы schema-enforced вывода
+    assert "submit_findings" in text and "submit_verdicts" in text
+
+
+def test_findings_schema_matches_finding_in_model():
+    # PRI-156: findings-schema.md — проекция канона FindingIn.
+    from reviewer.mcp.schemas import FindingIn
+
+    schema = _read("findings-schema.md")
+    for name in FindingIn.model_fields:
+        token = "fix" if name == "fix" else name
+        assert token in schema, f"поле FindingIn.{name} отсутствует в findings-schema.md"
 
 
 def test_branch_selection_has_review_branches_logic():

--- a/tests/vcs/test_finding_from_in.py
+++ b/tests/vcs/test_finding_from_in.py
@@ -1,0 +1,25 @@
+"""Finding.from_in: построение внутреннего Finding из валидированного FindingIn."""
+from reviewer.mcp.schemas import FindingIn
+from reviewer.vcs.base import Finding
+
+
+def test_from_in_maps_fields_and_fix():
+    fi = FindingIn.model_validate({
+        "file": "a.py", "severity": "high", "line": 2, "code_quote": "x = 1",
+        "message": "bug", "suggestion": "fix it", "confidence": 0.9,
+        "fix": {"start_line": 2, "end_line": 2, "replacement": "x = 2"},
+    })
+    f = Finding.from_in(fi)
+    assert isinstance(f, Finding)
+    assert (f.file, f.line, f.side, f.severity) == ("a.py", 2, "RIGHT", "high")
+    assert f.message == "bug" and f.suggestion == "fix it" and f.confidence == 0.9
+    assert (f.fix_start, f.fix_end, f.replacement) == (2, 2, "x = 2")
+    assert f.code_quote == "x = 1"
+    assert f.centrality == 0.0
+
+
+def test_from_in_without_fix():
+    fi = FindingIn.model_validate({"file": "b.py", "message": "m"})
+    f = Finding.from_in(fi)
+    assert (f.fix_start, f.fix_end, f.replacement) == (None, None, None)
+    assert f.category == "correctness" and f.confidence == 0.1


### PR DESCRIPTION
## PRI-156 — Structured Outputs (schema-enforced JSON) для findings/verdicts

Перевод вывода субагентов ревью (analyze/dimension/verify) с **free-text JSON** на
**schema-enforced через вызов MCP-тула**. Энфорс на тул-границе FastMCP/Pydantic:
malformed-аргумент → ошибка тула → ретрай субагента.

### Что меняется
- **`reviewer/mcp/schemas.py`** (новый) — Pydantic-канон `FixIn`/`FindingIn`/`VerdictIn`.
  Валидаторы — дословный порт `_finding_from_dict` (сохранена калибровка `confidence` из PRI-144:
  fallback 0.1, clamp [0,1]). `file` обязателен и непуст (`min_length=1`).
- **`Finding.from_in(FindingIn)`** в `reviewer/vcs/base.py` — конструктор внутреннего dataclass
  (дакт-тайпинг, без runtime-зависимости vcs→mcp).
- **Сессионное накопление** в `MCPReviewService`: `submit_findings` (server-assigned id `f{n}`),
  `get_candidate_findings`, `submit_verdicts`. `publish_review` читает findings/verdicts из сессии —
  **параметр `findings` убран**.
- **Фолбэк verify теперь структурный**: отсутствие verdict = keep; единственный путь отсева —
  явный `is_real=false`. Инструкция «KEEP all on malformed» из SKILL.md удалена как избыточная.
- **3 новые MCP-тула** (`mcp_server.py`, типизированы Pydantic) + контракт промптов/скилла
  `review-pr` переведён на submit-тулы; guard-тесты `tests/skills/` обновлены и держат
  findings-schema ↔ `FindingIn` в синхроне.

### Критерии приёмки
- доля malformed-выводов → ~0 (энфорс на тул-границе);
- поля findings валидны по схеме (Pydantic-канон);
- verify не теряет находки из-за парс-ошибок (структурный keep).

### Тесты
- Полный unit-набор: **605 passed**, 44 deselected (integration), 0 падений.
- ruff: clean (line-length 100, py311).
- `tests/skills/` guard-тесты зелёные.

### Процесс
Реализовано через subagent-driven-development: спека → план → 6 TDD-задач (каждая с task-review
spec+quality) → финальное whole-branch ревью (Opus): **Ready to merge — YES**, ноль Critical/Important.
Спека: `docs/superpowers/specs/2026-06-22-pri-156-structured-outputs-design.md`.
