### PR TITLE
feat: GraphRAG community summaries (PRI-159) + PR walkthrough (PRI-119)

### DIFF
--- a/docs/superpowers/plans/2026-06-23-pr52-followups.md
+++ b/docs/superpowers/plans/2026-06-23-pr52-followups.md
@@ -1,0 +1,312 @@
+# PR #52 Follow-ups Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Дошлифовать три фолоу-апа PR #52: walkthrough читает summaries по целевой ветке PR; `member_node_ids` персистится (server-side re-derive); `get_summaries` отдаёт `updated_at`.
+
+**Architecture:** Три независимые правки в трёх слоях (skill / service / store). Публичные сигнатуры MCP-тулов не меняются. #2 переиспользует чистые функции `cluster_key()`/`compute_source_hash()` из `reviewer/graph/summaries.py`; member-список пишется только при совпадении пере-вычисленного `source_hash` с переданным (иначе `[]` + note, fail-soft).
+
+**Tech Stack:** Python 3.11, pytest, psycopg/pgvector (Postgres ParadeDB :5433), FastMCP.
+
+## Global Constraints
+
+- Язык проекта — **русский**: докстринги/комментарии/сообщения на русском.
+- Коммиты — **Conventional Commits на русском, без self-attribution** (никаких `Co-Authored-By`/упоминаний Claude).
+- Ruff: line-length 100, target py311.
+- Ветка работы: `feat/graphrag-summaries-walkthrough` (дослать в открытый PR #52 → dev).
+- **Не трогать:** `build_clusters`, `upsert_summary`, единичный `get_summary`, схему БД (`subsystem_summaries` уже имеет колонки `member_node_ids` и `updated_at`), публичные сигнатуры MCP-тулов.
+- Integration-тесты требуют поднятый Postgres :5433 (`docker compose up -d`).
+
+---
+
+### Task 1: `get_summaries` отдаёт `updated_at` (store)
+
+**Files:**
+- Modify: `reviewer/index/summary_store.py` (метод `get_summaries`)
+- Test: `tests/index/test_summary_store.py` (модифицировать существующий `test_upsert_then_get_roundtrip`)
+
+**Interfaces:**
+- Consumes: ничего нового.
+- Produces: `SummaryStore.get_summaries(repo, branch) -> list[dict]`, где каждый dict теперь `{"cluster_key", "title", "summary", "updated_at"}` (`updated_at` — ISO-строка). `service.get_subsystem_summaries` пробрасывает результат as-is, правок не требует.
+
+- [ ] **Step 1: Обновить существующий тест под новое поле (он сейчас падает на точном равенстве)**
+
+В `tests/index/test_summary_store.py`, в `test_upsert_then_get_roundtrip`, заменить блок проверки `get_summaries`:
+
+```python
+    rows = store.get_summaries("t/t", "dev")
+    assert len(rows) == 1
+    row = rows[0]
+    assert row["cluster_key"] == "reviewer/index"
+    assert row["title"] == "Индекс"
+    assert row["summary"] == "Хранилище чанков и ретрив."
+    assert "T" in row["updated_at"]        # ISO-таймстамп (зеркало единичного get_summary)
+```
+
+(остальное тело теста — `upsert_summary`, `get_source_hashes`, `get_summary` — без изменений)
+
+- [ ] **Step 2: Прогнать тест — убедиться, что падает**
+
+Run: `.venv/bin/pytest -m integration tests/index/test_summary_store.py::test_upsert_then_get_roundtrip -v`
+Expected: FAIL — `KeyError: 'updated_at'` (текущий `get_summaries` не отдаёт поле).
+
+- [ ] **Step 3: Добавить `updated_at` в `get_summaries`**
+
+В `reviewer/index/summary_store.py` заменить метод `get_summaries` на:
+
+```python
+    def get_summaries(self, repo: str, branch: str) -> list[dict]:
+        try:
+            with self._connect() as conn:
+                rows = conn.execute(
+                    "SELECT cluster_key, title, summary, updated_at FROM subsystem_summaries "
+                    "WHERE repo=%s AND branch=%s ORDER BY cluster_key",
+                    (repo, branch)).fetchall()
+        except psycopg.errors.UndefinedTable:
+            return []
+        return [{"cluster_key": k, "title": t, "summary": s, "updated_at": u.isoformat()}
+                for k, t, s, u in rows]
+```
+
+- [ ] **Step 4: Прогнать тест — убедиться, что проходит**
+
+Run: `.venv/bin/pytest -m integration tests/index/test_summary_store.py -v`
+Expected: PASS (все тесты файла, включая `test_upsert_is_idempotent_update` — он читает `["summary"]`, доп. поле его не ломает).
+
+- [ ] **Step 5: Линт + коммит**
+
+```bash
+.venv/bin/ruff check reviewer/index/summary_store.py tests/index/test_summary_store.py
+git add reviewer/index/summary_store.py tests/index/test_summary_store.py
+git commit -m "feat(index): get_summaries отдаёт updated_at (PR #52 follow-up)"
+```
+
+---
+
+### Task 2: `member_node_ids` через server-side re-derive (service)
+
+**Files:**
+- Modify: `reviewer/mcp/service.py` (метод `index_subsystem_summary`)
+- Test: `tests/mcp/test_subsystem_summaries.py` (модифицировать `test_index_and_get_subsystem_summaries_roundtrip_via_store`; добавить тест mismatch)
+
+**Interfaces:**
+- Consumes: `ChunkStore.list_base_members(repo, branch) -> list[tuple[path, symbol_fqn, content_hash, start_line]]`; чистые `cluster_key(path, depth) -> str` и `compute_source_hash(list[tuple[node_id, content_hash]]) -> str` из `reviewer.graph.summaries`; `Settings.summary_cluster_depth: int` (=2); `SummaryStore.upsert_summary(repo, branch, cluster_key, title, summary, member_node_ids, source_hash)`.
+- Produces: `index_subsystem_summary(repo, branch, cluster_key, title, summary, source_hash) -> dict` теперь возвращает `{"cluster_key", "stored": True, "members": <int>}` (+`"note"` при рассинхроне). **Сигнатура тула не меняется** — `member_node_ids` сервер выводит сам.
+
+- [ ] **Step 1: Обновить существующий roundtrip-тест под server-side re-derive (happy-path)**
+
+В `tests/mcp/test_subsystem_summaries.py` заменить `test_index_and_get_subsystem_summaries_roundtrip_via_store` на:
+
+```python
+def test_index_and_get_subsystem_summaries_roundtrip_via_store():
+    from reviewer.graph.summaries import compute_source_hash
+    c = MagicMock()
+    # base-состав кластера reviewer/index (depth=2) — сервер выведет member_node_ids из него
+    c.store.list_base_members.return_value = [
+        ("reviewer/index/a.py", "A", "h1", 1),
+        ("reviewer/index/b.py", "B", "h2", 2),
+    ]
+    sh = compute_source_hash([("reviewer/index/a.py#A", "h1"),
+                              ("reviewer/index/b.py#B", "h2")])
+    c.summary_store.get_summaries.return_value = [
+        {"cluster_key": "reviewer/index", "title": "Индекс", "summary": "...",
+         "updated_at": "2026-06-23T00:00:00+00:00"}]
+    svc = _svc(c)
+
+    out = svc.index_subsystem_summary("o/n", "dev", "reviewer/index", "Индекс", "...", sh)
+    assert out == {"cluster_key": "reviewer/index", "stored": True, "members": 2}
+    # upsert получил выведенный (отсортированный) member_node_ids, а не []
+    args = c.summary_store.upsert_summary.call_args.args
+    assert args[5] == ["reviewer/index/a.py#A", "reviewer/index/b.py#B"]
+
+    got = svc.get_subsystem_summaries("o/n", "dev")
+    assert got["summaries"][0]["cluster_key"] == "reviewer/index"
+```
+
+- [ ] **Step 2: Добавить тест рассинхрона (stale source_hash → [] + note)**
+
+В тот же файл добавить:
+
+```python
+def test_index_subsystem_summary_stale_hash_empties_members():
+    c = MagicMock()
+    c.store.list_base_members.return_value = [("reviewer/index/a.py", "A", "h1", 1)]
+    svc = _svc(c)
+    # передан неактуальный source_hash → пере-вычисленный не совпадёт
+    out = svc.index_subsystem_summary("o/n", "dev", "reviewer/index", "Индекс", "...", "STALE")
+    assert out["stored"] is True
+    assert out["members"] == 0
+    assert "note" in out
+    assert c.summary_store.upsert_summary.call_args.args[5] == []   # member_node_ids пуст
+```
+
+- [ ] **Step 3: Прогнать тесты — убедиться, что падают**
+
+Run: `.venv/bin/pytest tests/mcp/test_subsystem_summaries.py -v`
+Expected: FAIL — старая реализация зашивает `[]` и возвращает `{"cluster_key","stored":True}` без `members`; `list_base_members` не вызывается (happy-path ждёт `members: 2`).
+
+- [ ] **Step 4: Реализовать server-side re-derive в `index_subsystem_summary`**
+
+В `reviewer/mcp/service.py` заменить метод `index_subsystem_summary` на (импорт под алиасом — параметр `cluster_key` затеняет одноимённую функцию):
+
+```python
+    def index_subsystem_summary(self, repo: str, branch: str, cluster_key: str,
+                                title: str, summary: str, source_hash: str) -> dict:
+        """Персистнуть один summary подсистемы (idempotent upsert).
+
+        member_node_ids выводятся сервером (re-derive по cluster_key над base-составом)
+        и пишутся только при совпадении пере-вычисленного source_hash с переданным —
+        иначе [] + note (состав базы изменился между list и index; самозалечивается
+        следующим проходом summarize-subsystems)."""
+        from reviewer.graph.summaries import cluster_key as cluster_key_of, compute_source_hash
+        rb = self._resolve_repo_branch(repo, branch)
+        if isinstance(rb, str):
+            return {"stored": False, "note": rb}
+        repo, resolved = rb
+        depth = self.settings.summary_cluster_depth
+        raw = self.components.store.list_base_members(repo, resolved)
+        members = [(f"{p}#{s}", h) for p, s, h, _ in raw
+                   if cluster_key_of(p, depth) == cluster_key]
+        consistent = compute_source_hash(members) == source_hash
+        member_node_ids = sorted(nid for nid, _ in members) if consistent else []
+        self.components.summary_store.upsert_summary(
+            repo, resolved, cluster_key, title, summary, member_node_ids, source_hash)
+        out = {"cluster_key": cluster_key, "stored": True, "members": len(member_node_ids)}
+        if not consistent:
+            out["note"] = "состав кластера изменился с момента list — member_node_ids не сохранены"
+        return out
+```
+
+- [ ] **Step 5: Прогнать тесты — убедиться, что проходят**
+
+Run: `.venv/bin/pytest tests/mcp/test_subsystem_summaries.py -v`
+Expected: PASS (все 5 тестов файла: 3 про list_subsystem_clusters без изменений + 2 обновлённых/новых).
+
+- [ ] **Step 6: Линт + коммит**
+
+```bash
+.venv/bin/ruff check reviewer/mcp/service.py tests/mcp/test_subsystem_summaries.py
+git add reviewer/mcp/service.py tests/mcp/test_subsystem_summaries.py
+git commit -m "feat(mcp): index_subsystem_summary выводит member_node_ids server-side (PR #52 follow-up)"
+```
+
+---
+
+### Task 3: pr-walkthrough читает summaries по `pr.base_ref` (skill)
+
+**Files:**
+- Modify: `plugin/skills/pr-walkthrough/SKILL.md` (убрать include branch-selection; шаг 5)
+- Test: `tests/skills/test_pr_walkthrough_skill.py` (добавить guard-тест)
+
+**Interfaces:**
+- Consumes: `prepare_review` уже возвращает `pr.base_ref` в payload (`_prepared_payload`).
+- Produces: только промпт-скилл (markdown). Машинных сигнатур не задаёт.
+
+- [ ] **Step 1: Добавить guard-тест на использование base_ref**
+
+В `tests/skills/test_pr_walkthrough_skill.py` добавить:
+
+```python
+def test_step5_summaries_use_pr_base_ref():
+    text = SKILL.read_text(encoding="utf-8")
+    # summaries индексируются по целевой ветке PR, не по локальной git-ветке
+    assert "base_ref" in text
+    # include branch-selection убран — неверная абстракция для PR-скоупного скилла
+    assert "branch-selection" not in text
+```
+
+- [ ] **Step 2: Прогнать тест — убедиться, что падает**
+
+Run: `.venv/bin/pytest tests/skills/test_pr_walkthrough_skill.py::test_step5_summaries_use_pr_base_ref -v`
+Expected: FAIL — сейчас `base_ref` в тексте нет, а `branch-selection` есть.
+
+- [ ] **Step 3: Убрать include branch-selection**
+
+В `plugin/skills/pr-walkthrough/SKILL.md` удалить include-блок между шагом 1 и шагом 2. Заменить:
+
+```
+   and stop.
+
+<!-- include: _common/branch-selection.md -->
+
+2. **Reading order (centrality).**
+```
+
+на:
+
+```
+   and stop.
+
+2. **Reading order (centrality).**
+```
+
+- [ ] **Step 4: Переписать шаг 5 на `pr.base_ref`**
+
+В том же файле заменить шаг 5:
+
+```
+5. **Subsystem prior (optional).** `get_subsystem_summaries(repo, branch)` → name the touched
+   subsystem(s) in one line. Empty / unavailable → skip (fail-open).
+```
+
+на:
+
+```
+5. **Subsystem prior (optional).** `get_subsystem_summaries(repo, pr.base_ref)` → name the touched
+   subsystem(s) in one line. Pass the PR's target branch `pr.base_ref` (from the `prepare_review`
+   response), NOT the local git branch — subsystem summaries are indexed per target branch
+   (`base:<branch>`). Empty / unavailable → skip (fail-open).
+```
+
+- [ ] **Step 5: Прогнать guard-тесты скилла — убедиться, что проходят**
+
+Run: `.venv/bin/pytest tests/skills/test_pr_walkthrough_skill.py -v`
+Expected: PASS — новый тест зелёный; `test_skill_includes_resolve_to_existing_common_files` остаётся зелёным (остаются 2 include: `tool-usage.md`, `anti-hallucination.md`).
+
+- [ ] **Step 6: Коммит**
+
+```bash
+git add plugin/skills/pr-walkthrough/SKILL.md tests/skills/test_pr_walkthrough_skill.py
+git commit -m "fix(skills): pr-walkthrough читает summaries по pr.base_ref (PR #52 follow-up)"
+```
+
+---
+
+### Task 4: Финальная верификация всей ветки
+
+**Files:** нет (только прогон).
+
+- [ ] **Step 1: Полный unit-прогон**
+
+Run: `.venv/bin/pytest -q`
+Expected: PASS (включая все guard-тесты `tests/skills/` — удаление include из одного скилла не должно ломать кросс-скилльные guard'ы).
+
+- [ ] **Step 2: Integration-прогон затронутых SQL-путей**
+
+Run: `.venv/bin/pytest -m integration tests/index/test_summary_store.py -v`
+Expected: PASS (Postgres :5433 поднят).
+
+- [ ] **Step 3: Линт по всему диффу**
+
+Run: `.venv/bin/ruff check reviewer/ tests/ plugin/`
+Expected: чисто по затронутым файлам (репо-wide грязь, не относящаяся к диффу, — не блокер).
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- #1 (walkthrough base_ref) → Task 3. ✓
+- #2 (member_node_ids server re-derive + consistency guard) → Task 2. ✓
+- #3 (get_summaries updated_at) → Task 1. ✓
+- Прогон unit+integration → Task 4. ✓
+- Границы (не трогать build_clusters/upsert_summary/get_summary/схему/сигнатуры тулов) → соблюдены во всех тасках. ✓
+
+**Placeholder scan:** плейсхолдеров нет — весь код приведён дословно.
+
+**Type consistency:**
+- `list_base_members` → 4-tuple `(path, symbol_fqn, content_hash, start_line)`, распаковка `for p, s, h, _ in raw`. ✓
+- `compute_source_hash(list[tuple[str, str]])` — вход `members` (node_id, content_hash); сортировка внутренняя, поэтому совпадает с `list_subsystem_clusters`. ✓
+- `upsert_summary(...)` — `member_node_ids` 6-й позиционный аргумент (`call_args.args[5]`). ✓
+- Алиас `cluster_key as cluster_key_of` снимает коллизию с параметром `cluster_key: str`. ✓
+- Возврат `index_subsystem_summary` — `{"cluster_key","stored","members"(,"note")}`; тесты ассертят ровно это. ✓

--- a/docs/superpowers/plans/2026-06-23-pri-119-pr-walkthrough.md
+++ b/docs/superpowers/plans/2026-06-23-pri-119-pr-walkthrough.md
@@ -1,0 +1,298 @@
+# PRI-119 — PR walkthrough (гид по чтению) — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Дать ревьюеру-человеку markdown-гид по PR (откуда начать читать, что меняет файл, на что влияет) — отдельно от находок-багов.
+
+**Architecture:** Новый LLM-скилл `/reviewer_pr-walkthrough` поверх существующей PR-сессии: `prepare_review` → `get_impact`/`get_changed_file_diff`/`find_callers` → markdown в терминал. Опциональный приор — `get_subsystem_summaries` (PRI-159). Опциональный постинг в PR — тонкий метод `post_pr_walkthrough` (переиспользует `GitHubProvider.publish_review` с пустыми inline-комментариями).
+
+**Tech Stack:** Python 3.11–3.13, FastMCP, httpx (GitHubProvider), pytest. Реализуется **после** PRI-159. Спек: `docs/superpowers/specs/2026-06-23-pri-119-pr-walkthrough-design.md`.
+
+## Global Constraints
+
+- Язык проекта — **русский**: докстринги, комментарии, гид и вывод скилла. Тело SKILL.md — на английском (токены), но скилл инструктирует отвечать по-русски.
+- Коммиты — **Conventional Commits на русском, без self-attribution**.
+- Ветка работы: `feat/graphrag-summaries-walkthrough` (та же программа, что PRI-159).
+- PR-сессионные тулы уже существуют: `prepare_review`, `get_impact`, `get_changed_file_diff`, `find_callers`, `get_related_symbols`, `read_file`.
+- `GitHubProvider.publish_review(number, head_sha, summary, comments)` — постинг review (см. `reviewer/vcs/github.py:163`).
+- Постинг в PR — outward-facing: только по явной просьбе пользователя + подтверждение.
+- Unit-тесты не трогают сеть (фейки). Линт: `.venv/bin/ruff check .`.
+
+---
+
+### Task 1: Метод постинга `post_pr_walkthrough` + MCP-тул
+
+**Files:**
+- Modify: `reviewer/mcp/service.py` (метод + константа-маркер)
+- Modify: `reviewer/entrypoints/mcp_server.py` (`@mcp.tool()`-обёртка)
+- Test: `tests/mcp/test_pr_walkthrough.py`
+
+**Interfaces:**
+- Consumes: PR-сессия (`self._session(repo, pr).prepared.vcs` + `.prepared.prq.head_sha`), `GitHubProvider.publish_review`.
+- Produces:
+  - `WALKTHROUGH_MARKER = "<!-- ai-walkthrough -->"` (module-level в `service.py`).
+  - `MCPReviewService.post_pr_walkthrough(repo, pr, markdown) -> dict` → `{"posted": True, "pr": pr}` или `{"posted": False, "reason": ...}`.
+
+- [ ] **Step 1: Написать падающий unit-тест**
+
+```python
+# tests/mcp/test_pr_walkthrough.py
+"""Unit-тест постинга walkthrough-гида (PRI-119). Сессия и VCS — фейки."""
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+from reviewer.config.settings import Settings
+from reviewer.mcp.service import MCPReviewService
+
+
+def _settings() -> Settings:
+    s = Settings()
+    s.voyage_api_key = "test"
+    s.github_token = "test"
+    s.default_repo = ""
+    return s
+
+
+def test_post_pr_walkthrough_posts_body_with_marker_and_no_comments():
+    svc = MCPReviewService(_settings(), MagicMock())
+    vcs = MagicMock()
+    prepared = SimpleNamespace(vcs=vcs, prq=SimpleNamespace(head_sha="head456"))
+    svc._session = lambda repo, pr: SimpleNamespace(prepared=prepared)   # изолируем сессию
+
+    out = svc.post_pr_walkthrough("o/n", 7, "## Начни отсюда\n- a.py")
+
+    assert out == {"posted": True, "pr": 7}
+    vcs.publish_review.assert_called_once()
+    number, head_sha, body, comments = vcs.publish_review.call_args.args
+    assert number == 7 and head_sha == "head456"
+    assert body.startswith("<!-- ai-walkthrough -->")
+    assert "Начни отсюда" in body
+    assert comments == []      # гид — без inline-находок
+
+
+def test_post_pr_walkthrough_fail_soft_on_network_error():
+    svc = MCPReviewService(_settings(), MagicMock())
+    vcs = MagicMock()
+    vcs.publish_review.side_effect = RuntimeError("boom")
+    prepared = SimpleNamespace(vcs=vcs, prq=SimpleNamespace(head_sha="h"))
+    svc._session = lambda repo, pr: SimpleNamespace(prepared=prepared)
+
+    out = svc.post_pr_walkthrough("o/n", 7, "guide")
+    assert out["posted"] is False
+    assert "RuntimeError" in out["reason"]
+```
+
+- [ ] **Step 2: Прогнать — падает**
+
+Run: `.venv/bin/pytest tests/mcp/test_pr_walkthrough.py -q`
+Expected: FAIL (`AttributeError: ... 'post_pr_walkthrough'`).
+
+- [ ] **Step 3: Реализовать метод в `reviewer/mcp/service.py`**
+
+Module-level (рядом с прочими константами модуля):
+
+```python
+WALKTHROUGH_MARKER = "<!-- ai-walkthrough -->"
+```
+
+Метод (рядом с `publish_review` в `MCPReviewService`):
+
+```python
+    def post_pr_walkthrough(self, repo: str, pr: int, markdown: str) -> dict:
+        """Опубликовать walkthrough-гид в PR как review-комментарий (без inline-находок).
+
+        Маркер ``<!-- ai-walkthrough -->`` в body отделяет гид от ревью-находок
+        (``<!-- ai-review:* -->``). Outward-facing — вызывается только по явной
+        просьбе пользователя. Fail-soft при сетевой ошибке."""
+        from reviewer.services.repo_id import normalize_repo
+        sess = self._session(normalize_repo(repo), pr)
+        prepared = sess.prepared
+        body = f"{WALKTHROUGH_MARKER}\n\n{markdown}"
+        try:
+            prepared.vcs.publish_review(pr, prepared.prq.head_sha, body, [])
+        except Exception as e:
+            log.warning("post_pr_walkthrough: сбой постинга", exc_info=True)
+            return {"posted": False, "reason": f"{type(e).__name__}: {e}"}
+        return {"posted": True, "pr": pr}
+```
+
+- [ ] **Step 4: Прогнать — проходит**
+
+Run: `.venv/bin/pytest tests/mcp/test_pr_walkthrough.py -q`
+Expected: PASS (2 passed).
+
+- [ ] **Step 5: Зарегистрировать тул в `reviewer/entrypoints/mcp_server.py`** (после `get_candidate_findings`)
+
+```python
+    @mcp.tool()
+    def post_pr_walkthrough(repo: str, pr: int, markdown: str) -> dict:
+        """Post a human-facing PR reading guide (walkthrough) as a PR review comment,
+        separate from bug findings (carries a <!-- ai-walkthrough --> marker, empty
+        inline comments). Outward-facing: the /reviewer_pr-walkthrough skill calls this
+        only on explicit user request. Requires an active prepare_review session."""
+        return service.post_pr_walkthrough(repo, pr, markdown)
+```
+
+- [ ] **Step 6: Smoke сервера + линт + коммит**
+
+```bash
+.venv/bin/pytest tests/mcp/test_server.py tests/mcp/test_server_tools.py -q
+.venv/bin/ruff check reviewer/mcp/service.py reviewer/entrypoints/mcp_server.py tests/mcp/test_pr_walkthrough.py
+git add reviewer/mcp/service.py reviewer/entrypoints/mcp_server.py tests/mcp/test_pr_walkthrough.py
+git commit -m "feat(mcp): post_pr_walkthrough — постинг гида ревьюеру-человеку (PRI-119)"
+```
+
+(Если `test_server_tools.py` проверяет точный список имён тулов — добавить туда `post_pr_walkthrough`.)
+
+---
+
+### Task 2: Скилл `/reviewer_pr-walkthrough` + guard-тест
+
+**Files:**
+- Create: `plugin/skills/pr-walkthrough/SKILL.md`
+- Test: `tests/skills/test_pr_walkthrough_skill.py`
+
+**Interfaces:**
+- Consumes тулы: `prepare_review`, `get_impact`, `get_changed_file_diff`, `find_callers`, `get_related_symbols` (есть); `get_subsystem_summaries` (PRI-159, опц.); `post_pr_walkthrough` (Task 1, опц.).
+
+- [ ] **Step 1: Написать падающий guard-тест**
+
+```python
+# tests/skills/test_pr_walkthrough_skill.py
+from pathlib import Path
+import re
+
+SKILL = (Path(__file__).resolve().parents[2]
+         / "plugin" / "skills" / "pr-walkthrough" / "SKILL.md")
+
+
+def test_skill_exists_and_uses_session_tools():
+    text = SKILL.read_text(encoding="utf-8")
+    assert "prepare_review" in text
+    assert "get_impact" in text
+    assert "find_callers" in text
+
+
+def test_skill_includes_resolve_to_existing_common_files():
+    text = SKILL.read_text(encoding="utf-8")
+    includes = re.findall(r"<!-- include: (_common/[\w\-./]+) -->", text)
+    assert includes, "нет include-маркеров _common"
+    base = SKILL.resolve().parents[1]
+    for inc in includes:
+        assert (base / inc).is_file(), f"include не найден: {inc}"
+
+
+def test_skill_posting_is_opt_in_and_russian():
+    text = SKILL.read_text(encoding="utf-8")
+    assert "post_pr_walkthrough" in text
+    low = text.lower()
+    assert "russian" in low or "русск" in low
+    # постинг — только по явной просьбе (outward-facing)
+    assert "explicit" in low or "only on explicit" in low or "явн" in low
+```
+
+- [ ] **Step 2: Прогнать — падает**
+
+Run: `.venv/bin/pytest tests/skills/test_pr_walkthrough_skill.py -q`
+Expected: FAIL (`FileNotFoundError`).
+
+- [ ] **Step 3: Создать `plugin/skills/pr-walkthrough/SKILL.md`**
+
+```markdown
+---
+name: reviewer_pr-walkthrough
+description: Build a human-facing reading guide for a GitHub pull request (where to start, what each file changes, what it impacts) using the reviewer PR session + code graph. Use when the user asks to walk a human reviewer through a PR ("PR walkthrough", "гид по PR", "как читать этот PR", "проведи по PR"). NOT a bug review (see review-pr). Requires the reviewer MCP server + base index.
+---
+
+# PR walkthrough (reading guide for a human reviewer)
+
+Help a human reviewer orient in a PR — not find bugs. Produce a markdown guide: where to start
+(by centrality), what each file changes, and what it impacts ("careful, affects X"). Separate from
+bug findings (`review-pr`).
+
+**Always answer the user in Russian** (the project language). Tool calls, identifiers and `path:line`
+stay verbatim.
+
+## Tools
+
+<!-- include: _common/tool-usage.md -->
+Plus the PR-session tools (reviewer MCP): `prepare_review`, `get_impact`, `get_changed_file_diff`,
+`find_callers`, `get_related_symbols`, `read_file`; optional `get_subsystem_summaries` (PRI-159);
+optional `post_pr_walkthrough` (only on explicit user request).
+
+## Pipeline
+
+1. **Resolve repo & prepare the session.** Resolve `repo` (git remote). Call `prepare_review(repo, pr)`.
+   If it returns `{"status": "skipped"}` (branch not in REVIEW_BRANCHES), tell the user (in Russian)
+   and stop.
+
+<!-- include: _common/branch-selection.md -->
+
+2. **Reading order (centrality).** Call `get_impact(repo, pr)` → changed symbols and their callers.
+   Order "start here" by how much depends on each changed symbol (most central first). Graph down →
+   fall back to ordering by file (fail-open).
+
+3. **What each file changes.** For each changed file, `get_changed_file_diff(repo, pr, path)` → one
+   line describing what it changes.
+
+4. **Impact ("careful, affects X").** For the central changed symbols, `find_callers` /
+   `get_related_symbols` → who depends on them. Every "affects X" must be backed by a real caller.
+
+5. **Subsystem prior (optional).** `get_subsystem_summaries(repo, branch)` → name the touched
+   subsystem(s) in one line. Empty / unavailable → skip (fail-open).
+
+6. **Assemble the guide (Russian markdown):**
+   - **Начни отсюда** — ordered list (most central first).
+   - **По файлам** — one line per changed file.
+   - **Осторожно, влияет на** — impacted symbols + their callers.
+   - (optional) **Подсистемы** — 1–2 lines from summaries.
+
+7. **Output.** Print the guide to the user by default. Post to the PR ONLY on explicit user request:
+   confirm first, then call `post_pr_walkthrough(repo, pr, markdown)` (posts a PR review comment with
+   a `<!-- ai-walkthrough -->` marker, separate from bug findings).
+
+## Grounding (hard rule)
+
+<!-- include: _common/anti-hallucination.md -->
+
+Every "affects X" is backed by a real `find_callers` result. Never invent callers or impact.
+
+## Notes
+
+- This is a reading guide, NOT a bug review — no findings, no inline severity comments.
+- Posting to the PR is outward-facing and never happens without explicit user request + confirmation.
+- Works without PRI-159 summaries and degrades gracefully when the graph is unavailable.
+```
+
+- [ ] **Step 4: Прогнать guard-тесты (и общий skills-набор) — проходят**
+
+Run: `.venv/bin/pytest tests/skills/ -q`
+Expected: PASS (новый тест зелёный; `test_common_blocks`/`test_assembled_prompts` не сломаны).
+
+- [ ] **Step 5: Полный прогон + коммит**
+
+```bash
+.venv/bin/pytest -q
+git add plugin/skills/pr-walkthrough/SKILL.md tests/skills/test_pr_walkthrough_skill.py
+git commit -m "feat(skills): скилл pr-walkthrough — гид по PR для ревьюера-человека (PRI-119)"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- Гид по units PR (порядок чтения по центральности, что меняет файл, карта вызывающих) → Task 2 (шаги 2–4, тулы `get_impact`/`get_changed_file_diff`/`find_callers`).
+- Вывод markdown в терминал, отдельно от находок-багов → Task 2 (шаг 6–7), маркер `<!-- ai-walkthrough -->` (Task 1).
+- Опц. постинг в PR через `mcp/service.py` → Task 1 (`post_pr_walkthrough`), с подтверждением (Task 2 шаг 7).
+- Опц. приор PRI-159 (fail-open) → Task 2 (шаг 5).
+- Fail-open (граф down → порядок по файлам; ветка не отслеживается → skipped) → Task 2 (шаги 1–2).
+- Тесты: unit постинга (фейк VCS), guard скилла → Tasks 1–2.
+
+**Placeholder scan:** нет TBD/TODO; весь код и текст скилла приведены, команды и ожидаемый вывод указаны.
+
+**Type consistency:** `post_pr_walkthrough(repo, pr, markdown)` одинаков в service-методе, MCP-туле, тесте и шаге 7 скилла; `WALKTHROUGH_MARKER` используется в методе и проверяется тестом; `publish_review(number, head_sha, body, comments)` соответствует `GitHubProvider.publish_review`.
+
+**Вне объёма (из спека):** Python-хелпер упорядочивания (строит LLM), автопостинг без подтверждения, связка с PRI-112/PRI-115.

--- a/docs/superpowers/plans/2026-06-23-pri-159-community-summaries.md
+++ b/docs/superpowers/plans/2026-06-23-pri-159-community-summaries.md
@@ -1,0 +1,932 @@
+# PRI-159 — GraphRAG community summaries — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Предрасчитывать краткие summary подсистем кода (кластеры графа по модулям) оффлайн и отдавать их потребителям (`ask`, далее PR-walkthrough) как дешёвый высокоуровневый приор.
+
+**Architecture:** Скилл-оркестрация: чистый Python кластеризует base-индекс по пути (`reviewer/graph/summaries.py`), MCP-тулы отдают кластеры и персистят summary в новую таблицу Postgres (`SummaryStore`), LLM-скилл `/reviewer_summarize-subsystems` пишет тексты, `ask` читает их через `get_subsystem_summaries`. Без LLM на сервере и без эмбеддингов в MVP (fetch-all).
+
+**Tech Stack:** Python 3.11–3.13, psycopg + psycopg_pool + pgvector, Neo4j (GraphStore), FastMCP, pytest. Спек: `docs/superpowers/specs/2026-06-23-pri-159-community-summaries-design.md`.
+
+## Global Constraints
+
+- Язык проекта — **русский**: докстринги, комментарии, тексты summary, вывод скилла. Тело SKILL.md — на английском (токены), но скилл инструктирует отвечать пользователю по-русски.
+- Коммиты — **Conventional Commits на русском, без self-attribution** (никаких `Co-Authored-By`/упоминаний Claude).
+- Ветка работы: `feat/graphrag-summaries-walkthrough`.
+- `node_id = "path#fqn"` — единый ключ RAG↔граф.
+- `ref` base-индекса ветки = `base:<branch>` (через `reviewer.index.refs.base_ref`).
+- Всё скоупится по `(repo, branch)` (мульти-бранч/мульти-репо).
+- Unit-тесты не трогают внешние сервисы (фейки/MagicMock). Тесты с реальным Postgres/Neo4j помечаются `@pytest.mark.integration` и не идут в дефолтном `pytest` (`addopts = -m 'not integration'`).
+- Линт: `.venv/bin/ruff check .` (line-length 100, target py311).
+
+---
+
+### Task 1: Чистая логика кластеризации (`reviewer/graph/summaries.py`)
+
+**Files:**
+- Create: `reviewer/graph/summaries.py`
+- Test: `tests/graph/test_summaries.py`
+
+**Interfaces:**
+- Produces:
+  - `@dataclass Member{node_id: str, path: str, content_hash: str, start_line: int}`
+  - `@dataclass Cluster{key: str, member_node_ids: list[str], files: list[str], top_symbols: list[dict], num_members: int, source_hash: str}`
+  - `cluster_key(path: str, depth: int) -> str`
+  - `compute_source_hash(items: list[tuple[str, str]]) -> str`  (items = `(node_id, content_hash)`)
+  - `build_clusters(members: list[Member], in_degree_fn: Callable[[list[str]], dict[str,int]] | None, *, depth: int = 2, min_size: int = 1, top_n: int = 10) -> list[Cluster]`
+
+- [ ] **Step 1: Написать падающие тесты**
+
+```python
+# tests/graph/test_summaries.py
+from reviewer.graph.summaries import (
+    Member, cluster_key, compute_source_hash, build_clusters,
+)
+
+
+def _m(node_id, path, h="h", line=1):
+    return Member(node_id=node_id, path=path, content_hash=h, start_line=line)
+
+
+def test_cluster_key_takes_first_depth_dir_segments():
+    assert cluster_key("reviewer/index/store.py", 2) == "reviewer/index"
+    assert cluster_key("reviewer/graph/store.py", 2) == "reviewer/graph"
+    assert cluster_key("reviewer/index/sub/x.py", 2) == "reviewer/index"
+
+
+def test_cluster_key_root_file_and_short_dir():
+    assert cluster_key("setup.py", 2) == "<root>"
+    assert cluster_key("reviewer/app.py", 2) == "reviewer"
+
+
+def test_compute_source_hash_is_order_independent_and_changes_with_content():
+    a = compute_source_hash([("x#f", "h1"), ("y#g", "h2")])
+    b = compute_source_hash([("y#g", "h2"), ("x#f", "h1")])
+    assert a == b                       # детерминирован, не зависит от порядка
+    assert a != compute_source_hash([("x#f", "h1"), ("y#g", "CHANGED")])
+
+
+def test_build_clusters_groups_by_module_and_filters_min_size():
+    members = [
+        _m("reviewer/index/a.py#A", "reviewer/index/a.py"),
+        _m("reviewer/index/b.py#B", "reviewer/index/b.py"),
+        _m("reviewer/graph/c.py#C", "reviewer/graph/c.py"),
+    ]
+    clusters = build_clusters(members, None, depth=2, min_size=2)
+    keys = {c.key for c in clusters}
+    assert keys == {"reviewer/index"}     # graph отброшен (1 < min_size=2)
+    idx = next(c for c in clusters if c.key == "reviewer/index")
+    assert idx.num_members == 2
+    assert idx.files == ["reviewer/index/a.py", "reviewer/index/b.py"]
+
+
+def test_build_clusters_ranks_top_symbols_by_in_degree():
+    members = [
+        _m("reviewer/x/a.py#A", "reviewer/x/a.py", line=10),
+        _m("reviewer/x/b.py#B", "reviewer/x/b.py", line=20),
+    ]
+    deg = {"reviewer/x/b.py#B": 5, "reviewer/x/a.py#A": 1}
+    [c] = build_clusters(members, lambda ids: deg, depth=2, top_n=10)
+    assert c.top_symbols[0]["node_id"] == "reviewer/x/b.py#B"   # выше in_degree → первый
+
+
+def test_build_clusters_fail_soft_when_in_degree_raises():
+    members = [_m("reviewer/x/a.py#A", "reviewer/x/a.py")]
+    def boom(ids):
+        raise RuntimeError("neo4j down")
+    [c] = build_clusters(members, boom, depth=2)   # не падает
+    assert c.top_symbols[0]["node_id"] == "reviewer/x/a.py#A"
+```
+
+- [ ] **Step 2: Прогнать тесты — убедиться, что падают**
+
+Run: `.venv/bin/pytest tests/graph/test_summaries.py -q`
+Expected: FAIL (`ModuleNotFoundError: reviewer.graph.summaries`).
+
+- [ ] **Step 3: Реализовать модуль**
+
+```python
+# reviewer/graph/summaries.py
+"""Кластеризация графа кода по модулям/пути и расчёт ключа свежести.
+
+Чистая логика без I/O: членство и центральность приходят аргументами, поэтому
+покрывается unit-тестами без Postgres/Neo4j. Кластер = пакет/директория
+(префикс пути node_id="path#fqn"); summary каждого кластера пишет LLM-скилл.
+"""
+from __future__ import annotations
+
+import hashlib
+from dataclasses import dataclass
+from typing import Callable
+
+
+@dataclass
+class Member:
+    node_id: str          # "path#fqn"
+    path: str
+    content_hash: str
+    start_line: int
+
+
+@dataclass
+class Cluster:
+    key: str
+    member_node_ids: list[str]
+    files: list[str]
+    top_symbols: list[dict]   # [{"node_id", "file", "line"}], отсортированы по центральности
+    num_members: int
+    source_hash: str
+
+
+def cluster_key(path: str, depth: int) -> str:
+    """Ключ кластера = директория пути, обрезанная до первых ``depth`` сегментов.
+
+    "reviewer/index/store.py", depth=2 -> "reviewer/index".
+    Файл в корне -> "<root>"; директория короче depth -> вся директория.
+    """
+    dir_parts = path.split("/")[:-1]      # отбросить имя файла
+    if not dir_parts:
+        return "<root>"
+    return "/".join(dir_parts[:depth])
+
+
+def compute_source_hash(items: list[tuple[str, str]]) -> str:
+    """sha256 от sorted("node_id:content_hash") — детерминированный ключ свежести.
+
+    Меняется только при изменении состава кластера или содержимого его файлов
+    (content_hash — тот же дедуп-инвариант, что у чанков)."""
+    joined = "\n".join(sorted(f"{nid}:{h}" for nid, h in items))
+    return hashlib.sha256(joined.encode("utf-8")).hexdigest()
+
+
+def build_clusters(
+    members: list[Member],
+    in_degree_fn: Callable[[list[str]], dict[str, int]] | None,
+    *,
+    depth: int = 2,
+    min_size: int = 1,
+    top_n: int = 10,
+) -> list[Cluster]:
+    """Сгруппировать членов по cluster_key; top_symbols — по in_degree (fail-soft)."""
+    groups: dict[str, list[Member]] = {}
+    for m in members:
+        groups.setdefault(cluster_key(m.path, depth), []).append(m)
+
+    degrees: dict[str, int] = {}
+    if in_degree_fn is not None:
+        try:
+            degrees = in_degree_fn([m.node_id for m in members]) or {}
+        except Exception:
+            degrees = {}                  # граф недоступен → порядок по (path, line)
+
+    clusters: list[Cluster] = []
+    for key, ms in sorted(groups.items()):
+        if len(ms) < min_size:
+            continue
+        ranked = sorted(
+            ms, key=lambda m: (-degrees.get(m.node_id, 0), m.path, m.start_line))
+        top = [{"node_id": m.node_id, "file": m.path, "line": m.start_line}
+               for m in ranked[:top_n]]
+        clusters.append(Cluster(
+            key=key,
+            member_node_ids=sorted(m.node_id for m in ms),
+            files=sorted({m.path for m in ms}),
+            top_symbols=top,
+            num_members=len(ms),
+            source_hash=compute_source_hash([(m.node_id, m.content_hash) for m in ms]),
+        ))
+    return clusters
+```
+
+- [ ] **Step 4: Прогнать тесты — должны пройти**
+
+Run: `.venv/bin/pytest tests/graph/test_summaries.py -q`
+Expected: PASS (5 passed).
+
+- [ ] **Step 5: Линт + коммит**
+
+```bash
+.venv/bin/ruff check reviewer/graph/summaries.py tests/graph/test_summaries.py
+git add reviewer/graph/summaries.py tests/graph/test_summaries.py
+git commit -m "feat(graph): кластеризация графа по модулям для community summaries (PRI-159)"
+```
+
+---
+
+### Task 2: Таблица `subsystem_summaries` + `SummaryStore` + настройка глубины
+
+**Files:**
+- Modify: `reviewer/index/schema.sql` (добавить DDL в конец)
+- Modify: `reviewer/config/settings.py` (поле `summary_cluster_depth`)
+- Create: `reviewer/index/summary_store.py`
+- Test: `tests/index/test_summary_store.py` (integration)
+
+**Interfaces:**
+- Produces `SummaryStore(dsn, *, min_size=1, max_size=4)` с методами:
+  - `upsert_summary(repo, branch, cluster_key, title, summary, member_node_ids: list[str], source_hash) -> None`
+  - `get_source_hashes(repo, branch) -> dict[str, str]`
+  - `get_summaries(repo, branch) -> list[dict]`  (`{cluster_key, title, summary}`)
+  - `get_summary(repo, branch, cluster_key) -> dict | None`
+  - `close() -> None`
+- Produces `Settings.summary_cluster_depth: int = 2`.
+
+- [ ] **Step 1: Добавить DDL таблицы в `reviewer/index/schema.sql`** (в конец файла)
+
+```sql
+-- Предрасчитанные summary подсистем (PRI-159): кластер графа по модулю → краткий обзор.
+-- Отдельно от chunks — у summary нет lines/symbol и base/overlay-freshness.
+CREATE TABLE IF NOT EXISTS subsystem_summaries (
+    repo            text    NOT NULL DEFAULT '',
+    branch          text    NOT NULL,
+    cluster_key     text    NOT NULL,            -- напр. "reviewer/index"
+    title           text    NOT NULL,            -- одна строка «что это»
+    summary         text    NOT NULL,            -- сжатый абзац (RU)
+    member_node_ids text[]  NOT NULL DEFAULT '{}',
+    source_hash     text    NOT NULL,            -- ключ свежести
+    embedding       vector(1024),                -- nullable; зарезервировано под вектор-поиск
+    updated_at      timestamptz NOT NULL DEFAULT now(),
+    PRIMARY KEY (repo, branch, cluster_key)
+);
+```
+
+- [ ] **Step 2: Добавить поле настройки в `reviewer/config/settings.py`**
+
+Рядом с другими int-полями добавить:
+
+```python
+    summary_cluster_depth: int = 2   # глубина пути для кластера подсистемы (PRI-159)
+```
+
+- [ ] **Step 3: Написать падающий integration-тест `SummaryStore`**
+
+```python
+# tests/index/test_summary_store.py
+import os
+import pytest
+
+from reviewer.index.store import ChunkStore
+from reviewer.index.summary_store import SummaryStore
+
+pytestmark = pytest.mark.integration
+
+DSN = os.getenv("PG_DSN", "postgresql://postgres:postgres@localhost:5433/postgres")
+
+
+@pytest.fixture()
+def store():
+    ChunkStore(DSN).init_schema()        # создаёт subsystem_summaries (schema.sql)
+    s = SummaryStore(DSN)
+    yield s
+    with s._connect() as conn:
+        conn.execute("DELETE FROM subsystem_summaries WHERE repo='t/t'")
+        conn.commit()
+    s.close()
+
+
+def test_upsert_then_get_roundtrip(store):
+    store.upsert_summary("t/t", "dev", "reviewer/index", "Индекс",
+                         "Хранилище чанков и ретрив.", ["reviewer/index/store.py#X"], "h1")
+    assert store.get_source_hashes("t/t", "dev") == {"reviewer/index": "h1"}
+    rows = store.get_summaries("t/t", "dev")
+    assert rows == [{"cluster_key": "reviewer/index", "title": "Индекс",
+                     "summary": "Хранилище чанков и ретрив."}]
+    one = store.get_summary("t/t", "dev", "reviewer/index")
+    assert one["member_node_ids"] == ["reviewer/index/store.py#X"]
+
+
+def test_upsert_is_idempotent_update(store):
+    store.upsert_summary("t/t", "dev", "reviewer/index", "A", "old", [], "h1")
+    store.upsert_summary("t/t", "dev", "reviewer/index", "A", "new", [], "h2")
+    assert store.get_source_hashes("t/t", "dev") == {"reviewer/index": "h2"}
+    assert store.get_summaries("t/t", "dev")[0]["summary"] == "new"
+```
+
+- [ ] **Step 4: Прогнать — убедиться, что падает**
+
+Run: `.venv/bin/pytest tests/index/test_summary_store.py -m integration -q`
+Expected: FAIL (`ModuleNotFoundError: reviewer.index.summary_store`).
+
+- [ ] **Step 5: Реализовать `reviewer/index/summary_store.py`** (зеркало `TaskStore`)
+
+```python
+# reviewer/index/summary_store.py
+"""Хранилище предрасчитанных summary подсистем (таблица subsystem_summaries).
+
+Зеркалит паттерн TaskStore: ленивый пул, register_vector на каждое соединение.
+Таблицу создаёт ChunkStore.init_schema (общий schema.sql)."""
+from __future__ import annotations
+
+import threading
+
+import psycopg.errors
+from pgvector.psycopg import register_vector
+from psycopg_pool import ConnectionPool
+
+
+class SummaryStore:
+    def __init__(self, dsn: str, *, min_size: int = 1, max_size: int = 4) -> None:
+        self.dsn = dsn
+        self._min_size = min_size
+        self._max_size = max_size
+        self._pool: ConnectionPool | None = None
+        self._init_lock = threading.Lock()
+
+    def _ensure_pool(self) -> ConnectionPool:
+        if self._pool is None:
+            with self._init_lock:
+                if self._pool is None:
+                    self._pool = ConnectionPool(
+                        self.dsn, min_size=self._min_size, max_size=self._max_size,
+                        open=False, configure=lambda conn: register_vector(conn))
+                    self._pool.open()
+        return self._pool
+
+    def _connect(self):
+        return self._ensure_pool().connection()
+
+    def close(self) -> None:
+        if self._pool is not None:
+            self._pool.close()
+            self._pool = None
+
+    def upsert_summary(self, repo: str, branch: str, cluster_key: str, title: str,
+                       summary: str, member_node_ids: list[str], source_hash: str) -> None:
+        sql = """
+        INSERT INTO subsystem_summaries
+            (repo, branch, cluster_key, title, summary, member_node_ids, source_hash, updated_at)
+        VALUES (%s,%s,%s,%s,%s,%s,%s, now())
+        ON CONFLICT (repo, branch, cluster_key) DO UPDATE SET
+            title=EXCLUDED.title, summary=EXCLUDED.summary,
+            member_node_ids=EXCLUDED.member_node_ids,
+            source_hash=EXCLUDED.source_hash, updated_at=now()
+        """
+        with self._connect() as conn:
+            conn.execute(sql, (repo, branch, cluster_key, title, summary,
+                               member_node_ids, source_hash))
+            conn.commit()
+
+    def get_source_hashes(self, repo: str, branch: str) -> dict[str, str]:
+        try:
+            with self._connect() as conn:
+                rows = conn.execute(
+                    "SELECT cluster_key, source_hash FROM subsystem_summaries "
+                    "WHERE repo=%s AND branch=%s", (repo, branch)).fetchall()
+        except psycopg.errors.UndefinedTable:
+            return {}
+        return {k: h for k, h in rows}
+
+    def get_summaries(self, repo: str, branch: str) -> list[dict]:
+        try:
+            with self._connect() as conn:
+                rows = conn.execute(
+                    "SELECT cluster_key, title, summary FROM subsystem_summaries "
+                    "WHERE repo=%s AND branch=%s ORDER BY cluster_key",
+                    (repo, branch)).fetchall()
+        except psycopg.errors.UndefinedTable:
+            return []
+        return [{"cluster_key": k, "title": t, "summary": s} for k, t, s in rows]
+
+    def get_summary(self, repo: str, branch: str, cluster_key: str) -> dict | None:
+        try:
+            with self._connect() as conn:
+                row = conn.execute(
+                    "SELECT cluster_key, title, summary, member_node_ids, source_hash, updated_at "
+                    "FROM subsystem_summaries WHERE repo=%s AND branch=%s AND cluster_key=%s",
+                    (repo, branch, cluster_key)).fetchone()
+        except psycopg.errors.UndefinedTable:
+            return None
+        if row is None:
+            return None
+        return {"cluster_key": row[0], "title": row[1], "summary": row[2],
+                "member_node_ids": list(row[3] or []), "source_hash": row[4],
+                "updated_at": row[5].isoformat()}
+```
+
+- [ ] **Step 6: Прогнать integration-тест — должен пройти**
+
+Run: `.venv/bin/pytest tests/index/test_summary_store.py -m integration -q`
+Expected: PASS (нужен поднятый Postgres :5433 — `docker compose up -d`).
+
+- [ ] **Step 7: Линт + коммит**
+
+```bash
+.venv/bin/ruff check reviewer/index/summary_store.py tests/index/test_summary_store.py
+git add reviewer/index/schema.sql reviewer/config/settings.py reviewer/index/summary_store.py tests/index/test_summary_store.py
+git commit -m "feat(index): таблица и SummaryStore для community summaries (PRI-159)"
+```
+
+---
+
+### Task 3: `ChunkStore.list_base_members` — состав base-индекса для кластеризации
+
+**Files:**
+- Modify: `reviewer/index/store.py` (новый метод в `ChunkStore`)
+- Test: `tests/index/test_summary_store.py` (добавить integration-тест)
+
+**Interfaces:**
+- Consumes: `reviewer.index.refs.base_ref`.
+- Produces: `ChunkStore.list_base_members(repo, branch) -> list[tuple[str, str, str, int]]` = `(path, symbol_fqn, content_hash, start_line)` для `ref=base:<branch>`.
+
+- [ ] **Step 1: Добавить падающий integration-тест** (в конец `tests/index/test_summary_store.py`)
+
+```python
+def test_list_base_members_reads_base_ref_rows():
+    from reviewer.index.store import ChunkStore, ChunkRow
+    cs = ChunkStore(DSN)
+    cs.init_schema()
+    cs.upsert([ChunkRow(repo="t/t", ref="base:dev", content_hash="h", path="reviewer/x/a.py",
+                        lang="python", symbol_fqn="A", kind="function",
+                        start_line=3, end_line=9, text="def a(): ...", embedding=[0.0]*1024)])
+    try:
+        members = cs.list_base_members("t/t", "dev")
+        assert ("reviewer/x/a.py", "A", "h", 3) in members
+    finally:
+        cs.delete_ref("t/t", "base:dev")
+        cs.close()
+```
+
+- [ ] **Step 2: Прогнать — убедиться, что падает**
+
+Run: `.venv/bin/pytest tests/index/test_summary_store.py::test_list_base_members_reads_base_ref_rows -m integration -q`
+Expected: FAIL (`AttributeError: 'ChunkStore' object has no attribute 'list_base_members'`).
+
+- [ ] **Step 3: Реализовать метод** (в `reviewer/index/store.py`, рядом с `count_chunks`)
+
+```python
+    def list_base_members(self, repo: str, branch: str) -> list[tuple[str, str, str, int]]:
+        """Состав base-индекса ветки для кластеризации подсистем (PRI-159):
+        (path, symbol_fqn, content_hash, start_line) для ref=base:<branch>."""
+        from reviewer.index.refs import base_ref
+        with self._connect() as conn:
+            rows = conn.execute(
+                "SELECT path, symbol_fqn, content_hash, start_line FROM chunks "
+                "WHERE repo=%s AND ref=%s", (repo, base_ref(branch))).fetchall()
+        return [(p, s, h, sl) for p, s, h, sl in rows]
+```
+
+- [ ] **Step 4: Прогнать — должен пройти**
+
+Run: `.venv/bin/pytest tests/index/test_summary_store.py -m integration -q`
+Expected: PASS.
+
+- [ ] **Step 5: Линт + коммит**
+
+```bash
+.venv/bin/ruff check reviewer/index/store.py
+git add reviewer/index/store.py tests/index/test_summary_store.py
+git commit -m "feat(index): ChunkStore.list_base_members для кластеризации подсистем (PRI-159)"
+```
+
+---
+
+### Task 4: Wiring в `Components` + три MCP-метода + тулы
+
+**Files:**
+- Modify: `reviewer/app.py` (поле `Components.summary_store`, сборка в `build_components`)
+- Modify: `reviewer/mcp/service.py` (методы `list_subsystem_clusters`, `index_subsystem_summary`, `get_subsystem_summaries`)
+- Modify: `reviewer/entrypoints/mcp_server.py` (три `@mcp.tool()`-обёртки)
+- Test: `tests/test_app_wiring.py` (добавить), `tests/mcp/test_subsystem_summaries.py` (создать)
+
+**Interfaces:**
+- Consumes: `build_clusters`/`Member` (Task 1), `SummaryStore` (Task 2), `ChunkStore.list_base_members` (Task 3), `MCPReviewService._resolve_repo_branch` (есть), `GraphStore.in_degree(repo, node_ids, *, branch)` (есть).
+- Produces (service-методы и одноимённые тулы):
+  - `list_subsystem_clusters(repo, branch=None, depth=None, min_size=None) -> dict` → `{"branch", "clusters": [{cluster_key, num_members, files, top_symbols, source_hash, stale}]}` или `{"clusters": [], "note": ...}`.
+  - `index_subsystem_summary(repo, branch, cluster_key, title, summary, source_hash) -> dict` → `{"cluster_key", "stored": True}`.
+  - `get_subsystem_summaries(repo, branch=None, cluster_key=None) -> dict` → `{"summaries": [...]}` (или `{"summary": {...}|None}` при заданном cluster_key).
+
+- [ ] **Step 1: Добавить падающий wiring-тест** (в `tests/test_app_wiring.py`)
+
+```python
+def test_build_components_wires_summary_store(monkeypatch):
+    monkeypatch.setenv("VOYAGE_API_KEY", "v")
+    c = build_components(Settings(), connect=False)
+    assert c.summary_store is not None
+```
+
+- [ ] **Step 2: Прогнать — падает**
+
+Run: `.venv/bin/pytest tests/test_app_wiring.py::test_build_components_wires_summary_store -q`
+Expected: FAIL (`AttributeError: ... 'summary_store'`).
+
+- [ ] **Step 3: Подключить `SummaryStore` в `reviewer/app.py`**
+
+В `@dataclass Components` добавить поле (после `store`):
+
+```python
+    summary_store: "SummaryStore"
+```
+
+Добавить импорт сверху:
+
+```python
+from reviewer.index.summary_store import SummaryStore
+```
+
+В `build_components` создать рядом со `store` и передать в `Components(...)` (последним аргументом, сохранив порядок остальных):
+
+```python
+    summary_store = SummaryStore(
+        settings.pg_dsn,
+        min_size=settings.pg_pool_min_size,
+        max_size=settings.pg_pool_max_size,
+    )
+    ...
+    return Components(settings, store, graph, embedder, reranker, retriever,
+                      task_store, task_graph, task_service, sync_service,
+                      summary_store)
+```
+
+(Поле `summary_store` добавить в конец списка полей `Components` и в конец позиционных аргументов конструктора.)
+
+- [ ] **Step 4: Прогнать wiring-тест — проходит**
+
+Run: `.venv/bin/pytest tests/test_app_wiring.py -q`
+Expected: PASS.
+
+- [ ] **Step 5: Написать падающий unit-тест service-методов** (`tests/mcp/test_subsystem_summaries.py`)
+
+```python
+"""Unit-тесты MCP-методов community summaries (PRI-159). Фейки вместо Postgres/Neo4j."""
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from reviewer.config.settings import Settings
+from reviewer.mcp.service import MCPReviewService
+
+
+def _settings() -> Settings:
+    s = Settings()
+    s.voyage_api_key = "test"
+    s.default_repo = ""
+    return s
+
+
+def _svc(components) -> MCPReviewService:
+    svc = MCPReviewService(_settings(), components)
+    # изолируем резолв repo/ветки от REVIEW_BRANCHES в .env
+    svc._resolve_repo_branch = lambda repo, branch: ("o/n", "dev")
+    return svc
+
+
+def test_list_subsystem_clusters_marks_stale():
+    c = MagicMock()
+    c.store.list_base_members.return_value = [
+        ("reviewer/index/a.py", "A", "h1", 1),
+        ("reviewer/index/b.py", "B", "h2", 2),
+    ]
+    c.graph = None                                  # граф недоступен → fail-soft
+    c.summary_store.get_source_hashes.return_value = {}   # ничего не сохранено → stale=True
+    svc = _svc(c)
+    out = svc.list_subsystem_clusters("o/n", "dev", depth=2, min_size=1)
+    [cl] = out["clusters"]
+    assert cl["cluster_key"] == "reviewer/index"
+    assert cl["num_members"] == 2
+    assert cl["stale"] is True
+
+
+def test_list_subsystem_clusters_fresh_when_hash_matches():
+    c = MagicMock()
+    c.store.list_base_members.return_value = [("reviewer/index/a.py", "A", "h1", 1)]
+    c.graph = None
+    # вычисляем эталонный source_hash так же, как продакшен
+    from reviewer.graph.summaries import compute_source_hash
+    sh = compute_source_hash([("reviewer/index/a.py#A", "h1")])
+    c.summary_store.get_source_hashes.return_value = {"reviewer/index": sh}
+    svc = _svc(c)
+    [cl] = svc.list_subsystem_clusters("o/n", "dev")["clusters"]
+    assert cl["stale"] is False
+
+
+def test_list_subsystem_clusters_empty_index_returns_note():
+    c = MagicMock()
+    c.store.list_base_members.return_value = []
+    svc = _svc(c)
+    out = svc.list_subsystem_clusters("o/n", "dev")
+    assert out["clusters"] == []
+    assert "note" in out
+
+
+def test_index_and_get_subsystem_summaries_roundtrip_via_store():
+    c = MagicMock()
+    c.summary_store.get_summaries.return_value = [
+        {"cluster_key": "reviewer/index", "title": "Индекс", "summary": "..."}]
+    svc = _svc(c)
+    assert svc.index_subsystem_summary("o/n", "dev", "reviewer/index", "Индекс", "...", "h1") == {
+        "cluster_key": "reviewer/index", "stored": True}
+    c.summary_store.upsert_summary.assert_called_once()
+    got = svc.get_subsystem_summaries("o/n", "dev")
+    assert got["summaries"][0]["cluster_key"] == "reviewer/index"
+```
+
+- [ ] **Step 6: Прогнать — падает**
+
+Run: `.venv/bin/pytest tests/mcp/test_subsystem_summaries.py -q`
+Expected: FAIL (`AttributeError: ... 'list_subsystem_clusters'`).
+
+- [ ] **Step 7: Реализовать три метода в `reviewer/mcp/service.py`** (рядом с `search_codebase`)
+
+```python
+    def list_subsystem_clusters(self, repo: str, branch: str | None = None,
+                                depth: int | None = None,
+                                min_size: int | None = None) -> dict:
+        """Кластеризовать base-граф по модулям → кластеры для /summarize-subsystems."""
+        from reviewer.graph.summaries import Member, build_clusters
+        rb = self._resolve_repo_branch(repo, branch)
+        if isinstance(rb, str):
+            return {"clusters": [], "note": rb}
+        repo, resolved = rb
+        raw = self.components.store.list_base_members(repo, resolved)
+        if not raw:
+            return {"clusters": [],
+                    "note": "(base-индекс пуст — выполните /reviewer_sync-codebase)"}
+        members = [Member(node_id=f"{p}#{s}", path=p, content_hash=h, start_line=sl)
+                   for p, s, h, sl in raw]
+        graph = self.components.graph
+        in_degree_fn = (
+            (lambda ids: graph.in_degree(repo, ids, branch=resolved))
+            if graph is not None else None)
+        clusters = build_clusters(
+            members, in_degree_fn,
+            depth=depth or self.settings.summary_cluster_depth,
+            min_size=min_size or 1)
+        stored = self.components.summary_store.get_source_hashes(repo, resolved)
+        return {"branch": resolved, "clusters": [
+            {"cluster_key": c.key, "num_members": c.num_members, "files": c.files,
+             "top_symbols": c.top_symbols, "source_hash": c.source_hash,
+             "stale": stored.get(c.key) != c.source_hash}
+            for c in clusters]}
+
+    def index_subsystem_summary(self, repo: str, branch: str, cluster_key: str,
+                                title: str, summary: str, source_hash: str) -> dict:
+        """Персистнуть один summary подсистемы (idempotent upsert)."""
+        rb = self._resolve_repo_branch(repo, branch)
+        if isinstance(rb, str):
+            return {"stored": False, "note": rb}
+        repo, resolved = rb
+        self.components.summary_store.upsert_summary(
+            repo, resolved, cluster_key, title, summary, [], source_hash)
+        return {"cluster_key": cluster_key, "stored": True}
+
+    def get_subsystem_summaries(self, repo: str, branch: str | None = None,
+                                cluster_key: str | None = None) -> dict:
+        """Дешёвый приор: предрасчитанные summary подсистем (fail-open у потребителя)."""
+        rb = self._resolve_repo_branch(repo, branch)
+        if isinstance(rb, str):
+            return {"summaries": [], "note": rb}
+        repo, resolved = rb
+        store = self.components.summary_store
+        if cluster_key:
+            return {"summary": store.get_summary(repo, resolved, cluster_key)}
+        return {"summaries": store.get_summaries(repo, resolved)}
+```
+
+- [ ] **Step 8: Прогнать unit-тест — проходит**
+
+Run: `.venv/bin/pytest tests/mcp/test_subsystem_summaries.py -q`
+Expected: PASS (4 passed).
+
+- [ ] **Step 9: Зарегистрировать три тула в `reviewer/entrypoints/mcp_server.py`** (после `get_pr_diff`, перед `publish_review`)
+
+```python
+    @mcp.tool()
+    def list_subsystem_clusters(repo: str, branch: str | None = None,
+                                depth: int | None = None,
+                                min_size: int | None = None) -> dict:
+        """Cluster the base code graph into subsystems (by module path) for the
+        /reviewer_summarize-subsystems skill. Returns per cluster: cluster_key,
+        num_members, files, top_symbols (by centrality), source_hash, and stale
+        (true when the stored summary is missing or its source_hash differs).
+        No PR session; branch defaults to the primary tracked branch."""
+        return service.list_subsystem_clusters(repo, branch, depth, min_size)
+
+    @mcp.tool()
+    def index_subsystem_summary(repo: str, branch: str, cluster_key: str,
+                                title: str, summary: str, source_hash: str) -> dict:
+        """Persist one subsystem summary (idempotent upsert keyed by
+        repo+branch+cluster_key). Called by /reviewer_summarize-subsystems after the
+        LLM writes title+summary for a cluster. source_hash ties the summary to the
+        cluster's current content for staleness."""
+        return service.index_subsystem_summary(
+            repo, branch, cluster_key, title, summary, source_hash)
+
+    @mcp.tool()
+    def get_subsystem_summaries(repo: str, branch: str | None = None,
+                                cluster_key: str | None = None) -> dict:
+        """Cheap high-level prior for ask / PR-walkthrough: precomputed subsystem
+        summaries. cluster_key=None → all {cluster_key, title, summary}; a cluster_key
+        → one full summary (or null). Empty when none built (consumer is fail-open).
+        No PR session; branch defaults to primary."""
+        return service.get_subsystem_summaries(repo, branch, cluster_key)
+```
+
+- [ ] **Step 10: Smoke — сервер регистрирует тулы**
+
+Run: `.venv/bin/pytest tests/mcp/test_server.py tests/mcp/test_server_tools.py -q`
+Expected: PASS (существующие тесты сервера не сломаны; при необходимости добавить имена новых тулов в их allowlist).
+
+- [ ] **Step 11: Линт + коммит**
+
+```bash
+.venv/bin/ruff check reviewer/app.py reviewer/mcp/service.py reviewer/entrypoints/mcp_server.py tests/mcp/test_subsystem_summaries.py
+git add reviewer/app.py reviewer/mcp/service.py reviewer/entrypoints/mcp_server.py tests/test_app_wiring.py tests/mcp/test_subsystem_summaries.py
+git commit -m "feat(mcp): тулы list/index/get subsystem summaries + wiring (PRI-159)"
+```
+
+---
+
+### Task 5: Скилл `/reviewer_summarize-subsystems` + guard-тест
+
+**Files:**
+- Create: `plugin/skills/summarize-subsystems/SKILL.md`
+- Test: `tests/skills/test_summarize_subsystems.py`
+
+**Interfaces:**
+- Consumes тулы Task 4 (`list_subsystem_clusters`, `index_subsystem_summary`) + harness `Read`.
+
+- [ ] **Step 1: Написать падающий guard-тест**
+
+```python
+# tests/skills/test_summarize_subsystems.py
+from pathlib import Path
+
+SKILL = (Path(__file__).resolve().parents[2]
+         / "plugin" / "skills" / "summarize-subsystems" / "SKILL.md")
+
+
+def test_skill_exists_and_mentions_tools():
+    text = SKILL.read_text(encoding="utf-8")
+    assert "list_subsystem_clusters" in text
+    assert "index_subsystem_summary" in text
+
+
+def test_skill_includes_common_blocks_that_exist():
+    text = SKILL.read_text(encoding="utf-8")
+    common = SKILL.resolve().parents[1] / "_common"
+    import re
+    includes = re.findall(r"<!-- include: (_common/[\w\-./]+) -->", text)
+    assert includes, "нет include-маркеров _common"
+    for inc in includes:
+        assert (common.parent / inc).is_file(), f"include не найден: {inc}"
+
+
+def test_skill_instructs_russian_output():
+    text = SKILL.read_text(encoding="utf-8").lower()
+    assert "russian" in text or "русск" in text
+```
+
+- [ ] **Step 2: Прогнать — падает**
+
+Run: `.venv/bin/pytest tests/skills/test_summarize_subsystems.py -q`
+Expected: FAIL (`FileNotFoundError`).
+
+- [ ] **Step 3: Создать `plugin/skills/summarize-subsystems/SKILL.md`**
+
+```markdown
+---
+name: reviewer_summarize-subsystems
+description: Precompute concise per-subsystem summaries (GraphRAG community summaries) over the base code index, so ask / PR-walkthrough get a cheap high-level prior. Use when the user asks to build/refresh subsystem summaries ("просуммируй подсистемы", "построй обзоры модулей", "summarize subsystems"). Requires a built base index + the reviewer MCP server.
+---
+
+# Summarize subsystems (community summaries)
+
+Cluster the base code graph into subsystems (by module path) and write a short, **grounded**
+summary for each, persisted for `ask` / PR-walkthrough to use as a cheap high-level prior. This
+skill reads code and writes summaries to the reviewer store; it does NOT modify code or post to
+GitHub.
+
+**Always write summaries and answer the user in Russian** (the project language), regardless of this
+file's language. Tool calls, code identifiers and `path:line` stay verbatim.
+
+## Tools
+
+<!-- include: _common/tool-usage.md -->
+Plus `list_subsystem_clusters` and `index_subsystem_summary` (reviewer MCP), and the harness `Read`.
+
+## Pipeline
+
+1. **Resolve repo/branch.**
+
+<!-- include: _common/branch-selection.md -->
+
+2. **List clusters.** Call `list_subsystem_clusters(repo, branch)`. Empty / `note` about an empty
+   index → tell the user (in Russian) to run `/reviewer_sync-codebase` first, then stop.
+
+3. **Summarize only STALE clusters.** For each cluster with `stale == true` (fresh ones are already
+   up to date — skip them, this keeps the pass incremental and cheap):
+   - `Read` a few representative files (from `files` / `top_symbols`) to ground the summary — do NOT
+     invent behavior the code does not show.
+   - Write, in Russian:
+     - `title` — one line: what this subsystem is.
+     - `summary` — a compact paragraph: what it does, its key symbols (from `top_symbols`) and
+       invariants. No `path:line` required in the text; it is a high-level prior.
+   - Persist: `index_subsystem_summary(repo, branch, cluster_key, title, summary, source_hash)` —
+     pass back the cluster's own `source_hash` from step 2.
+
+4. **Report (Russian).** How many clusters summarized vs skipped-as-fresh.
+
+## Grounding (hard rule)
+
+<!-- include: _common/anti-hallucination.md -->
+
+Every summary must reflect real code you read. If a cluster is unclear, say so briefly rather than
+guessing.
+
+## Notes
+
+- Precondition: base index built (`reviewer index`). Re-running is incremental: unchanged subsystems
+  (matching `source_hash`) are skipped.
+- Read-only on code and GitHub; only writes summaries to the reviewer store.
+```
+
+- [ ] **Step 4: Прогнать guard-тест + общий guard — проходят**
+
+Run: `.venv/bin/pytest tests/skills/ -q`
+Expected: PASS (новый тест зелёный; `test_common_blocks`/`test_assembled_prompts` не сломаны — include-маркеры валидны).
+
+- [ ] **Step 5: Коммит**
+
+```bash
+git add plugin/skills/summarize-subsystems/SKILL.md tests/skills/test_summarize_subsystems.py
+git commit -m "feat(skills): скилл summarize-subsystems для community summaries (PRI-159)"
+```
+
+---
+
+### Task 6: Интеграция приора в `ask` + guard-тест
+
+**Files:**
+- Modify: `plugin/skills/ask/SKILL.md` (шаг-приор `get_subsystem_summaries`)
+- Test: `tests/skills/test_ask_uses_summaries.py`
+
+**Interfaces:**
+- Consumes: `get_subsystem_summaries` (Task 4).
+
+- [ ] **Step 1: Написать падающий guard-тест**
+
+```python
+# tests/skills/test_ask_uses_summaries.py
+from pathlib import Path
+
+ASK = Path(__file__).resolve().parents[2] / "plugin" / "skills" / "ask" / "SKILL.md"
+
+
+def test_ask_references_subsystem_summaries_prior():
+    text = ASK.read_text(encoding="utf-8")
+    assert "get_subsystem_summaries" in text
+
+
+def test_ask_marks_prior_fail_open():
+    text = ASK.read_text(encoding="utf-8").lower()
+    assert "fail-open" in text and "get_subsystem_summaries" in ASK.read_text(encoding="utf-8")
+```
+
+- [ ] **Step 2: Прогнать — падает**
+
+Run: `.venv/bin/pytest tests/skills/test_ask_uses_summaries.py -q`
+Expected: FAIL (маркера нет в ask/SKILL.md).
+
+- [ ] **Step 3: Вставить шаг-приор в `plugin/skills/ask/SKILL.md`**
+
+После шага «1. Resolve repo/branch» и перед «2. Search» добавить пункт:
+
+```markdown
+1.5. **Subsystem prior (cheap, optional).** Call `get_subsystem_summaries(repo, branch)`. If it
+   returns summaries, use the one matching the question's subsystem as a high-level orientation
+   **before** `search_codebase` — this cuts exploration steps for architectural / "how does
+   subsystem X work" questions. The summary is only a prior: every `path:line` you cite in the
+   answer still comes from real code (`search_codebase` / `Read`), never from the summary text.
+   **Fail-open:** empty / unavailable → skip this step and proceed exactly as before.
+```
+
+- [ ] **Step 4: Прогнать — проходит**
+
+Run: `.venv/bin/pytest tests/skills/ -q`
+Expected: PASS.
+
+- [ ] **Step 5: Полный прогон + коммит**
+
+```bash
+.venv/bin/pytest -q
+git add plugin/skills/ask/SKILL.md tests/skills/test_ask_uses_summaries.py
+git commit -m "feat(skills): ask использует subsystem-summaries как приор (PRI-159)"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- Кластеризация по модулю/пути (configurable depth) → Task 1 (`cluster_key`/`build_clusters`) + `summary_cluster_depth` (Task 2).
+- Членство из Postgres-чанков, центральность из графа fail-soft → Task 3 (`list_base_members`) + Task 1 (`in_degree_fn` fail-soft) + Task 4 (wiring `graph=None` → `None`).
+- Хранилище — новая таблица `subsystem_summaries` per `(repo, branch)`, `source_hash`-свежесть → Task 2.
+- Три MCP-тула (list/index/get) → Task 4.
+- BUILD-скилл (RU, инкрементальный по `stale`, grounded) → Task 5.
+- CONSUME-интеграция в `ask` (fail-open) → Task 6.
+- Тесты: unit core, integration store, unit service (fakes), guard skills → Tasks 1–6.
+
+**Placeholder scan:** нет TBD/TODO; весь код приведён, команды и ожидаемый вывод указаны.
+
+**Type consistency:** `Member`/`Cluster` (Task 1) совпадают с использованием в `list_subsystem_clusters` (Task 4); `source_hash` пробрасывается из `list_subsystem_clusters` в `index_subsystem_summary` без переименований; `member_node_ids` в MVP хранится `[]` (колонка зарезервирована) — согласовано в Task 2/4.
+
+**Вне объёма (из спека):** вектор-поиск по summary (колонка `embedding` создана, не заполняется), кластеризация по связности, CLI-подкоманда, server-side LLM.

--- a/docs/superpowers/specs/2026-06-23-pr52-followups-design.md
+++ b/docs/superpowers/specs/2026-06-23-pr52-followups-design.md
@@ -1,0 +1,141 @@
+# Дизайн — фолоу-апы PR #52 (PRI-159 / PRI-119)
+
+**Дата:** 2026-06-23
+**Ветка:** `feat/graphrag-summaries-walkthrough` (дослать в открытый PR #52 → dev)
+**Контекст:** три опциональных фолоу-апа, отмеченных в теле PR #52 как «не блокеры мержа».
+Решение по scope/подходу принято в брейншторме: делаем **все три**, #2 — серверным
+re-derive (вариант «б»).
+
+## Цель
+
+Дошлифовать уже реализованную в PR #52 функциональность (GraphRAG community summaries +
+PR walkthrough), не меняя существующих инвариантов и **не трогая публичные сигнатуры
+MCP-тулов**. Три независимые правки в трёх слоях: skill / service / store. Каждая —
+со своим тестом.
+
+## Изменение #1 — pr-walkthrough берёт `prq.base_ref` (только скилл)
+
+### Проблема
+Единственный потребитель параметра `branch` в скилле pr-walkthrough — шаг 5
+`get_subsystem_summaries(repo, branch)`. Сейчас `branch` приходит из include
+`_common/branch-selection.md`, то есть это **локальная git-ветка ревьюера**
+(`git branch --show-current`). Но summaries индексируются по **целевой ветке PR**
+(`ref="base:<branch>"`), и локальная ветка может ей не соответствовать → walkthrough
+тянет summaries не той ветки либо пустой результат. Остальные тулы шага 2–4
+(`get_impact`, `get_changed_file_diff`, `find_callers`, `get_related_symbols`) —
+PR-сессионные и параметр `branch` не принимают, поэтому include здесь — неверная
+абстракция для PR-скоупного скилла.
+
+### Решение
+Файл: `plugin/skills/pr-walkthrough/SKILL.md`.
+- Убрать include `<!-- include: _common/branch-selection.md -->` (≈стр. 28).
+- Шаг 5: `get_subsystem_summaries(repo, pr.base_ref)` — передавать `base_ref` из ответа
+  `prepare_review` (шаг 1; `_prepared_payload` возвращает `pr.base_ref`,
+  `reviewer/mcp/service.py`). Добавить однострочное обоснование: «summaries индексируются
+  по целевой ветке PR; локальная git-ветка может отличаться».
+
+### Корректность
+`base_ref` гарантированно входит в `REVIEW_BRANCHES` — иначе `prepare_review` вернул бы
+`{"status":"skipped"}` и скилл остановился бы на шаге 1. Значит `_resolve_repo_branch`
+внутри `get_subsystem_summaries` его пропустит без `note`.
+
+### Тест
+`tests/skills/test_pr_walkthrough_skill.py`:
+- Существующие тесты остаются зелёными: после удаления остаются два include
+  (`tool-usage.md`, `anti-hallucination.md`), а `test_skill_includes_resolve_to_existing_common_files`
+  требует только `includes` непустым.
+- Добавить ассерт: шаг 5 ссылается на `base_ref` (а не на локальную ветку из
+  branch-selection).
+
+## Изменение #2 — `member_node_ids` через server-side re-derive (вариант «б»)
+
+### Проблема
+`index_subsystem_summary` зашивает `[]` в `upsert_summary`
+(`reviewer/mcp/service.py`), хотя стор и единичный `get_summary` поле `member_node_ids`
+уже поддерживают (`reviewer/index/summary_store.py`), а `Cluster.member_node_ids`
+считается в `build_clusters` (`reviewer/graph/summaries.py`). Поле — задел на будущий
+drill-down summary→символы; сейчас оно теряется на пути индексации.
+
+### Решение
+Файл: `reviewer/mcp/service.py::index_subsystem_summary`. **Сигнатура MCP-тула
+`index_subsystem_summary(repo, branch, cluster_key, title, summary, source_hash)`
+не меняется** — LLM не передаёт `member_node_ids` (в этом и выигрыш варианта «б»).
+Сервер выводит членов сам, переиспользуя чистые функции
+`reviewer.graph.summaries.cluster_key()` и `compute_source_hash()`:
+
+```python
+raw = self.components.store.list_base_members(repo, resolved)   # один SQL-скан
+depth = self.settings.summary_cluster_depth                    # тот же дефолт, что у list-шага
+members = [(f"{p}#{s}", h) for p, s, h, _ in raw
+           if cluster_key(p, depth) == cluster_key_arg]
+member_node_ids = sorted(nid for nid, _ in members)
+computed_hash = compute_source_hash(members)
+```
+
+Полный `build_clusters` не нужен — фильтр по `cluster_key` проще и дешевле.
+
+### Инвариант консистентности (выбран как рекомендованный)
+`member_node_ids` персистится **только если** `computed_hash == source_hash` (тот, что
+LLM пробросил из list-шага). При расхождении (гонка — база изменилась между `list` и
+`index`) или пустом матче — пишем `[]` и возвращаем `note` (fail-soft).
+
+Свойство: stored `member_node_ids` **всегда** соответствует stored `source_hash` (и тексту
+summary, написанному LLM по тому же составу). Транзиентный дрейф самозалечивается
+существующим механизмом свежести: следующий проход `summarize-subsystems` видит
+`stale` (новый hash ≠ stored) и пере-суммирует, восстанавливая консистентность по всем
+полям. Стоимость guard'а ≈ ноль — `computed_hash` всё равно считается при выводе членов.
+
+### Возврат тула
+Обогатить: `{"cluster_key": ..., "stored": True, "members": <N>}` (+`"note"` при
+mismatch). `upsert_summary` получает выведенный `member_node_ids` вместо `[]`.
+
+### Тест
+`tests/mcp/test_subsystem_summaries.py`:
+- После `index_subsystem_summary` единичный `get_summary` возвращает непустой
+  `member_node_ids`, совпадающий с составом кластера.
+- Кейс mismatch (передан неактуальный `source_hash`) → `member_node_ids == []` + `note`.
+
+Чистые `cluster_key`/`compute_source_hash` уже покрыты в `tests/graph/test_summaries.py`.
+
+## Изменение #3 — `get_summaries` отдаёт `updated_at` (только стор)
+
+### Проблема
+Список `get_summaries` (`reviewer/index/summary_store.py`) возвращает
+`cluster_key, title, summary` без `updated_at`; единичный `get_summary` уже отдаёт
+`updated_at.isoformat()`.
+
+### Решение
+Файл: `reviewer/index/summary_store.py::get_summaries`.
+- В SELECT добавить `updated_at`; в возвращаемый dict — `"updated_at": row[3].isoformat()`
+  (зеркало единичного `get_summary`). `ORDER BY cluster_key` без изменений.
+- `service.get_subsystem_summaries` пробрасывает результат as-is → список автоматически
+  несёт `updated_at`, правок в service не требуется.
+- `member_node_ids` в **список** не добавляем (объёмно; drill-down идёт через единичный
+  `get_summary`, который его уже отдаёт).
+
+### Корректность для потребителей
+Потребители (`ask/SKILL.md`, `pr-walkthrough/SKILL.md`) читают summaries read-only и
+fail-open — дополнительное поле их не ломает.
+
+### Тест
+`tests/index/test_summary_store.py`:
+- `get_summaries` несёт `updated_at` (ISO-строка), совпадающий с upsert-нутой строкой.
+
+## Тестовый прогон
+
+- `pytest -q` — unit (быстрые, на фейках).
+- `pytest -m integration` — стор против Postgres :5433 (#2 и #3 трогают SQL).
+
+## Границы (что НЕ трогаем)
+
+- Публичные сигнатуры MCP-тулов (`index_subsystem_summary`, `get_subsystem_summaries`,
+  `list_subsystem_clusters`).
+- `build_clusters`, `upsert_summary`, единичный `get_summary`.
+- Схему БД: `subsystem_summaries` уже содержит колонки `member_node_ids` и `updated_at`.
+- Логику свежести (`source_hash` / `stale`).
+
+## Приземление
+
+Все три правки дослать коммитами в открытый PR #52 (ветка
+`feat/graphrag-summaries-walkthrough` → dev). Conventional Commits на русском, без
+self-attribution.

--- a/docs/superpowers/specs/2026-06-23-pri-119-pr-walkthrough-design.md
+++ b/docs/superpowers/specs/2026-06-23-pri-119-pr-walkthrough-design.md
@@ -1,0 +1,103 @@
+# PRI-119 — PR walkthrough (гид по чтению для ревьюера-человека) — дизайн
+
+**Задача:** PRI-119 (ID-119), оценка S–M. Слой: Плагин/агент.
+**Ветка работы:** `feat/graphrag-summaries-walkthrough`.
+**Зависимость:** усиливается PRI-159 (subsystem-summaries как приор), но **работает и без них**.
+Реализуется **после** PRI-159 (см. `2026-06-23-pri-159-community-summaries-design.md`).
+
+## Проблема
+
+Нужно помочь ревьюеру-**человеку** ориентироваться в PR (а не искать баги): откуда начать читать,
+что меняет каждый файл, на что это влияет. Это отдельный результат, не связанный с находками-багами
+(`review-pr`).
+
+**Критерий приёмки (из задачи):** на реальном PR выдаёт осмысленное «начни отсюда» + список
+«осторожно, влияет на X».
+
+## Решения (зафиксированы на brainstorming)
+
+- Новый **скилл** `plugin/skills/pr-walkthrough/SKILL.md` (отдельный артефакт от находок-багов),
+  переиспользующий существующую PR-сессию и графовые тулы. Нового Python — минимум (опц. один метод
+  постинга).
+- Вывод — **markdown-гид**, по умолчанию в терминал; постинг в PR — **опционально и с подтверждением**
+  (outward-facing). Отдельно от находок-багов.
+- Приор подсистем (PRI-159 `get_subsystem_summaries`) — **опционально, fail-open**.
+
+## Архитектура и поток данных
+
+```
+skill ← PR number/URL (+ repo)
+  1. prepare_review(repo, pr)               [есть] → units, patches, changed_node_ids, changed_paths
+                                                     (ветка вне REVIEW_BRANCHES → status="skipped")
+  2. get_impact(repo, pr)                   [есть] → затронутые символы + вызывающие/центральность
+  3. get_changed_file_diff(path) + units    [есть] → «что меняет каждый файл»
+  4. find_callers / get_related_symbols      [есть] → «осторожно, влияет на X» (blast radius)
+  5. get_subsystem_summaries(repo, branch)  [PRI-159, опц.] → назвать затронутые подсистемы (fail-open)
+  6. LLM собирает markdown-гид:
+       «Начни отсюда» (порядок по центральности из get_impact) →
+       по файлу: 1-строчное «что меняет» →
+       «Осторожно, влияет на: …» (вызывающие)
+  7. Вывод в терминал (дефолт). Опц. постинг в PR — только по явной просьбе + подтверждение.
+```
+
+Все тулы шагов 1–4 уже существуют (PR-session MCP-тулы: `prepare_review`, `get_impact`,
+`get_changed_file_diff`, `find_callers`, `get_related_symbols`, `read_file`, `get_definition`).
+Порядок чтения по центральности строит LLM из вывода `get_impact` — отдельного Python-хелпера не
+требуется (держим скилл лёгким, S–M).
+
+## Компоненты
+
+| Компонент | Тип | Роль |
+|---|---|---|
+| `plugin/skills/pr-walkthrough/SKILL.md` | новый | Скилл-гид (тело EN, вывод RU; `_common`-include'ы) |
+| `reviewer/mcp/service.py` | правка (опц.) | `post_pr_walkthrough(repo, pr, markdown)` — постинг гида в PR |
+| `reviewer/entrypoints/mcp_server.py` | правка (опц.) | `@mcp.tool()`-обёртка над методом выше |
+
+## Контракты
+
+### Скилл `plugin/skills/pr-walkthrough/SKILL.md`
+
+- Тело — на английском (токены); **гид и вывод пользователю — на русском** (язык проекта).
+- Inputs: номер PR / URL (+ repo из git remote, как в `review-pr`).
+- Резолв repo/branch (include `_common/branch-selection.md`), tool-usage (include
+  `_common/tool-usage.md`), anti-hallucination (include `_common/anti-hallucination.md` — каждое «влияет
+  на X» подтверждено `find_callers`, без выдумок).
+- Шаги 1–6 выше. На `prepare_review → {"status":"skipped"}` (ветка не отслеживается) — сообщить и выйти.
+- Структура гида (markdown):
+  - **Начни отсюда** — упорядоченный список файлов/символов по центральности (`get_impact`).
+  - **По файлам** — на каждый изменённый файл одна строка «что меняет».
+  - **Осторожно, влияет на** — затронутые символы и их вызывающие (`find_callers`).
+  - (опц.) **Подсистемы** — 1–2 строки из `get_subsystem_summaries`, если доступны.
+- Вывод: по умолчанию печать гида в терминал/ответ. Постинг в PR — только если пользователь явно
+  попросил, и после подтверждения (outward-facing).
+
+### (опц.) `MCPReviewService.post_pr_walkthrough(repo, pr, markdown) -> dict`
+
+- Использует активную сессию (`prepared.prq.head_sha`, `prepared.vcs`); постит **review** с
+  `body=markdown`, `event="COMMENT"`, `comments=[]` (переиспользует
+  `GitHubProvider.publish_review(number, head_sha, summary=markdown, comments=[])`).
+- **Идемпотентность:** в `body` зашит скрытый маркер `<!-- ai-walkthrough -->` (отдельный от
+  `<!-- ai-review:* -->` находок) — повторный прогон не путается с ревью-комментариями.
+- Возвращает `{posted: true, pr}`. Fail-soft при сетевой ошибке.
+- Если сессии нет (не было `prepare_review`) → понятная ошибка с recovery hint (как у session-тулов).
+
+## Обработка ошибок / краевые случаи
+
+- Граф недоступен → `get_impact`/`find_callers` деградируют; порядок чтения — по файлам диффа (fail-open).
+- PRI-159 не построен / summary пусто → раздел «Подсистемы» опускается (fail-open).
+- Ветка PR вне `REVIEW_BRANCHES` → `prepare_review` вернёт `skipped` (как `review-pr`).
+- Постинг в PR никогда не выполняется без явной просьбы пользователя.
+
+## Тестирование
+
+- **Guard-тест** сборки промпта скилла (`tests/skills/` — раскрытие `_common`-include'ов).
+- **Unit** (если добавляем `post_pr_walkthrough`): постинг через фейковый VCS — проверить
+  `body`-маркер `<!-- ai-walkthrough -->`, пустой список inline-комментариев, `event="COMMENT"`
+  (зеркало существующих publish-тестов).
+- Ручная проверка на реальном PR: гид содержит «начни отсюда» + «осторожно, влияет на X».
+
+## Вне объёма (YAGNI / на потом)
+
+- Python-хелпер упорядочивания по центральности (LLM строит из `get_impact`).
+- Автопостинг без подтверждения.
+- Связка с PRI-112/PRI-115 (blast-radius/centrality усиления) — walkthrough работает на текущих тулах.

--- a/docs/superpowers/specs/2026-06-23-pri-159-community-summaries-design.md
+++ b/docs/superpowers/specs/2026-06-23-pri-159-community-summaries-design.md
@@ -1,0 +1,188 @@
+# PRI-159 — GraphRAG-сводки подсистем (community summaries) — дизайн
+
+**Задача:** PRI-159 (ID-159), оценка M–L. Слой: Движок (reviewer CLI/MCP) → ask/walkthrough.
+**Ветка работы:** `feat/graphrag-summaries-walkthrough`.
+**Связанная задача:** PRI-119 (PR-walkthrough) — второй потребитель summary; проектируется отдельным спеком
+`2026-06-23-pri-119-pr-walkthrough-design.md`. API summary в этом спеке нейтрален к потребителю.
+
+## Проблема
+
+Высокоуровневые вопросы («как устроена подсистема X») в `ask`/онбординге и PR-walkthrough требуют
+обзора подсистемы, который дорого собирать на лету из чанков (много шагов разведки, шумный ретрив).
+GraphRAG-подход: **предрасчёт кратких summary по кластерам графа кода** оффлайн; потребители берут
+summary как дешёвый высокоуровневый приор **до** детального ретрива.
+
+**Критерий приёмки (из задачи):** на архитектурный вопрос `ask` отвечает с опорой на summary
+подсистемы — меньше шагов разведки, выше качество обзора.
+
+## Решения (зафиксированы на brainstorming)
+
+1. **Объём:** полная фича — кластеризация + summary + хранилище + интеграция в `ask`; API summary
+   спроектирован так, чтобы PRI-119 переиспользовал его без переделки.
+2. **Генерация summary — скилл-оркестрация** (а не server-side LLM): ядро reviewer не имеет
+   general-purpose LLM (только Voyage embed/rerank). Python детерминированно кластеризует и отдаёт
+   материал; LLM в Claude Code пишет текст; MCP-тул персистит. Без новых зависимостей/ключей на
+   сервере, в духе `review-pr`/`sync`.
+3. **Кластеризация — по модулям/пути** (кластер = пакет/директория через префикс `node_id="path#fqn"`),
+   глубина настраивается. Дёшево, стабильно, интерпретируемо; совпадает с таблицей модулей в README.
+4. **Хранилище — новая таблица** `subsystem_summaries` (Postgres), per `(repo, branch)`, с
+   `source_hash` для инкрементальной свежести.
+5. **Ретрив у потребителя — fetch-all + by-key** (без вектор-поиска в MVP): тул отдаёт список всех
+   кластеров (key + title + summary); LLM выбирает нужный. Колонка `embedding` зарезервирована под
+   будущий вектор-поиск (без миграции).
+
+## Архитектура и поток данных
+
+Две фазы, обе скилл-оркестрируемые.
+
+### BUILD (новый скилл `/reviewer_summarize-subsystems`)
+
+```
+skill → list_subsystem_clusters(repo, branch)        [MCP → Python: кластеры + материал + freshness]
+      → для каждого STALE-кластера:
+          LLM читает представительные файлы (Read) и пишет title + summary (RU, grounded)
+      → index_subsystem_summary(repo, branch, key, title, summary, source_hash)  [MCP → Python: upsert]
+```
+Свежие кластеры (`stale=false`, `source_hash` совпал) пропускаются → инкрементально.
+Стоимость по Voyage = **0** (эмбеддингов summary в MVP нет); тратятся только LLM-токены скилла.
+
+### CONSUME (`ask`; далее PRI-119)
+
+```
+ask → get_subsystem_summaries(repo, branch)           [MCP → Python: дешёвый приор]
+    → LLM берёт релевантную подсистему как ориентир → меньше шагов разведки
+    → детальный search_codebase/expand как сейчас (citations — из реального кода)
+```
+
+## Компоненты
+
+| Компонент | Тип | Роль |
+|---|---|---|
+| `reviewer/graph/summaries.py` | новый | Чистая логика кластеризации и `source_hash`. `build_clusters(chunk_store, graph, repo, branch, *, depth, min_size) -> list[Cluster]` |
+| `reviewer/index/summary_store.py` | новый | `SummaryStore` — CRUD таблицы `subsystem_summaries` (по образцу `TaskStore`, свой пул) |
+| `reviewer/index/schema.sql` | правка | DDL `subsystem_summaries` (создаётся на `reviewer index` через `ChunkStore.init_schema`) |
+| `reviewer/index/store.py` | правка | `ChunkStore.list_base_members(repo, branch)` — состав base-индекса для кластеризации |
+| `reviewer/mcp/service.py` | правка | методы `list_subsystem_clusters`, `index_subsystem_summary`, `get_subsystem_summaries` |
+| `reviewer/entrypoints/mcp_server.py` | правка | тонкие `@mcp.tool()`-обёртки над методами выше |
+| `reviewer/app.py` | правка | `Components.summary_store: SummaryStore`; сборка в `build_components` (как `task_store`) |
+| `plugin/skills/summarize-subsystems/SKILL.md` | новый | BUILD-скилл (RU-вывод; `_common`-include'ы) |
+| `plugin/skills/ask/SKILL.md` | правка | шаг-приор `get_subsystem_summaries` (fail-open) |
+
+**Почему членство из Postgres-чанков, а не из Neo4j:** путь есть и в `chunks`, и в `:Symbol`; кластеризация
+по пути требует только путей. Берём из `chunks` (`ref="base:<branch>"`) → надёжно (не падает при
+недоступном Neo4j). Граф нужен лишь для ранжирования центральных символов (`GraphStore.in_degree`) и
+деградирует мягко.
+
+## Модель данных
+
+`reviewer/index/schema.sql` (добавить; зеркалит `tasks`/`index_meta`):
+
+```sql
+CREATE TABLE IF NOT EXISTS subsystem_summaries (
+    repo            text    NOT NULL DEFAULT '',
+    branch          text    NOT NULL,
+    cluster_key     text    NOT NULL,            -- напр. "reviewer/index"
+    title           text    NOT NULL,            -- одна строка «что это»
+    summary         text    NOT NULL,            -- сжатый абзац (RU)
+    member_node_ids text[]  NOT NULL DEFAULT '{}',
+    source_hash     text    NOT NULL,            -- ключ свежести
+    embedding       vector(1024),                -- nullable; зарезервировано под вектор-поиск
+    updated_at      timestamptz NOT NULL DEFAULT now(),
+    PRIMARY KEY (repo, branch, cluster_key)
+);
+```
+
+## Контракты
+
+### Кластеризация (`reviewer/graph/summaries.py`)
+
+- `@dataclass Cluster`: `key: str`, `member_node_ids: list[str]`, `files: list[str]`,
+  `top_symbols: list[dict]` (`{node_id, file, line}`), `num_members: int`, `source_hash: str`.
+- `cluster_key(path, depth) -> str`: директория пути, обрезанная до первых `depth` сегментов.
+  `"reviewer/index/store.py", depth=2 → "reviewer/index"`. Файл в корне (`"setup.py"`) или директория
+  короче `depth` → группа = вся директория (`"."` для корня нормализуем в `"<root>"`). Детерминирована.
+- `source_hash` = `sha256` от join'а `sorted("{node_id}:{content_hash}")` по членам кластера →
+  меняется только при изменении состава/содержимого подсистемы. Использует существующий
+  `chunks.content_hash` (тот же дедуп-инвариант).
+- `top_symbols`: топ-N членов по `GraphStore.in_degree` (центральность = сколько мест зависит;
+  N — небольшая константа, default 10). Fail-soft: граф `None`/ошибка → упорядочить по
+  `(path, start_line)`, `in_degree` опустить.
+- `min_size`: кластеры с `num_members < min_size` отбрасываются (default 1 = не отбрасывать;
+  настраивается). `depth` default 2.
+
+### `ChunkStore.list_base_members(repo, branch) -> list[tuple[path, symbol_fqn, content_hash, start_line]]`
+
+`SELECT path, symbol_fqn, content_hash, start_line FROM chunks WHERE repo=%s AND ref=%s` для
+`ref=base:<branch>` (через `reviewer.index.refs.base_ref`). `node_id = f"{path}#{symbol_fqn}"`.
+
+### `SummaryStore` (`reviewer/index/summary_store.py`)
+
+- `upsert_summary(repo, branch, cluster_key, title, summary, member_node_ids, source_hash)` —
+  UPSERT по `(repo, branch, cluster_key)`, обновляет `updated_at`.
+- `get_source_hashes(repo, branch) -> dict[cluster_key, source_hash]` — для вычисления `stale`.
+- `get_summaries(repo, branch) -> list[dict]` — все: `{cluster_key, title, summary, updated_at}`.
+- `get_summary(repo, branch, cluster_key) -> dict | None` — один полный.
+- Отсутствие таблицы (старый индекс без `init_schema`) трактуется как пусто (fail-soft, как
+  `get_index_meta`).
+
+### MCP-тулы (`service.py` методы + `mcp_server.py` обёртки)
+
+- `list_subsystem_clusters(repo, branch=None, depth=None, min_size=None) -> dict` →
+  `{"clusters": [{cluster_key, num_members, files, top_symbols, source_hash, stale}], "branch": ...}`.
+  `stale` = `source_hash != stored` (или нет stored). Пустой base-индекс → `{"clusters": [], "note": "..."}`.
+- `index_subsystem_summary(repo, branch, cluster_key, title, summary, source_hash) -> dict` →
+  `{cluster_key, stored: true}`. Idempotent.
+- `get_subsystem_summaries(repo, branch=None, cluster_key=None) -> dict` →
+  `cluster_key=None`: `{"summaries": [{cluster_key, title, summary}]}` (приор для всех);
+  `cluster_key`: один полный объект или `null`. Пусто/нет таблицы → `{"summaries": []}` (потребитель
+  fail-open). `branch=None` → первичная ветка (как у session-less тулов).
+
+### Скилл `plugin/skills/summarize-subsystems/SKILL.md`
+
+- Тело — на английском (токены), вывод пользователю и **тексты summary — на русском** (язык проекта;
+  их потребляет `ask`, отвечающий по-русски).
+- Резолв repo/branch (include `_common/branch-selection.md`).
+- (опц.) preflight-свежесть `reviewer status --json` → если `drift>0` — баннер (как в `ask`),
+  не блокировать.
+- `list_subsystem_clusters` → по `stale`-кластерам: `Read` представительных файлов (из `files`/
+  `top_symbols`) для grounding → написать `title` (1 строка) + `summary` (сжатый абзац, что делает
+  подсистема, ключевые символы/инварианты) → `index_subsystem_summary`. Свежие — пропустить.
+- Anti-hallucination: include `_common/anti-hallucination.md` — summary опирается на реальный код.
+- Fail-open: нет графа → членство всё равно есть; нет base-индекса → сообщить «сначала
+  `/reviewer_sync-codebase`».
+
+### Интеграция в `ask` (`plugin/skills/ask/SKILL.md`)
+
+- Новый шаг-приор после резолва repo/branch: вызвать `get_subsystem_summaries(repo, branch)`.
+  Непусто → для архитектурного/«как устроена X» вопроса выбрать релевантную подсистему и
+  использовать как ориентир до `search_codebase` (меньше шагов expand).
+- **Grounding-контракт без изменений:** summary — приор, но любые `path:line` в ответе по-прежнему
+  только из реального кода (`search_codebase`/`Read`). Summary сам сгенерирован из кода, но не
+  является источником цитат.
+- Fail-open: пусто/недоступно → `ask` работает как сегодня.
+
+## Обработка ошибок / краевые случаи
+
+- Нет base-индекса/графа → `list_subsystem_clusters` пуст + подсказка `reviewer index`.
+- Neo4j down → членство из чанков; `top_symbols` деградирует до порядка по файлам/строкам.
+- `ask` fail-open при пустых summary.
+- Всё per `(repo, branch)` — мульти-бранч/мульти-репо изоляция.
+- Повторный BUILD идемпотентен: совпавший `source_hash` → пропуск кластера.
+
+## Тестирование
+
+- **Unit:** `cluster_key` (пути/глубины/корень/край); детерминизм `source_hash` + детект изменения
+  состава/контента; `Cluster.top_symbols` fail-soft при `graph=None`; `SummaryStore` CRUD
+  upsert/get/get_source_hashes (на тестовом Postgres или фейке); сборка `list_subsystem_clusters`
+  (фейк-стор + фейк-граф) включая флаг `stale`.
+- **Guard-тест** сборки промпта нового скилла (`tests/skills/`, как у существующих скиллов —
+  раскрытие `_common`-include'ов).
+- **Integration** (маркер `integration`): round-trip таблицы `subsystem_summaries` на реальном Postgres.
+
+## Вне объёма (YAGNI / на потом)
+
+- Вектор-поиск по summary (колонка `embedding` зарезервирована, эмбеддинг не считается).
+- Кластеризация по связности (Louvain/Leiden) — текущий выбор по модулям достаточен.
+- Отдельная CLI-подкоманда генерации (триггер — скилл). Опционально позже: показ свежести summary в
+  `reviewer status`.
+- server-side вызов Anthropic SDK.

--- a/plugin/skills/ask/SKILL.md
+++ b/plugin/skills/ask/SKILL.md
@@ -43,6 +43,13 @@ Plus the harness file tools (`Read`, `Grep`, `Glob`) to read source from the loc
    Voyage (reads `index_meta` + local git). **Fail-open:** any error → skip the banner silently
    (Q&A is latency-sensitive).
 
+1.5. **Subsystem prior (cheap, optional).** Call `get_subsystem_summaries(repo, branch)`. If it
+   returns summaries, use the one matching the question's subsystem as a high-level orientation
+   **before** `search_codebase` — this cuts exploration steps for architectural / "how does
+   subsystem X work" questions. The summary is only a prior: every `path:line` you cite in the
+   answer still comes from real code (`search_codebase` / `Read`), never from the summary text.
+   **Fail-open:** empty / unavailable → skip this step and proceed exactly as before.
+
 2. **Search.** Call `search_codebase(repo, "<question>", branch=…)`. Parse the
    `path#fqn (path:start-end)` headers to get candidate symbols (`node_id`) and line ranges.
    If the result is `(ничего не найдено)`, go to Fallback.

--- a/plugin/skills/pr-walkthrough/SKILL.md
+++ b/plugin/skills/pr-walkthrough/SKILL.md
@@ -1,0 +1,63 @@
+---
+name: reviewer_pr-walkthrough
+description: Build a human-facing reading guide for a GitHub pull request (where to start, what each file changes, what it impacts) using the reviewer PR session + code graph. Use when the user asks to walk a human reviewer through a PR ("PR walkthrough", "гид по PR", "как читать этот PR", "проведи по PR"). NOT a bug review (see review-pr). Requires the reviewer MCP server + base index.
+---
+
+# PR walkthrough (reading guide for a human reviewer)
+
+Help a human reviewer orient in a PR — not find bugs. Produce a markdown guide: where to start
+(by centrality), what each file changes, and what it impacts ("careful, affects X"). Separate from
+bug findings (`review-pr`).
+
+**Always answer the user in Russian** (the project language). Tool calls, identifiers and `path:line`
+stay verbatim.
+
+## Tools
+
+<!-- include: _common/tool-usage.md -->
+Plus the PR-session tools (reviewer MCP): `prepare_review`, `get_impact`, `get_changed_file_diff`,
+`find_callers`, `get_related_symbols`, `read_file`; optional `get_subsystem_summaries` (PRI-159);
+optional `post_pr_walkthrough` (only on explicit user request).
+
+## Pipeline
+
+1. **Resolve repo & prepare the session.** Resolve `repo` (git remote). Call `prepare_review(repo, pr)`.
+   If it returns `{"status": "skipped"}` (branch not in REVIEW_BRANCHES), tell the user (in Russian)
+   and stop.
+
+<!-- include: _common/branch-selection.md -->
+
+2. **Reading order (centrality).** Call `get_impact(repo, pr)` → changed symbols and their callers.
+   Order "start here" by how much depends on each changed symbol (most central first). Graph down →
+   fall back to ordering by file (fail-open).
+
+3. **What each file changes.** For each changed file, `get_changed_file_diff(repo, pr, path)` → one
+   line describing what it changes.
+
+4. **Impact ("careful, affects X").** For the central changed symbols, `find_callers` /
+   `get_related_symbols` → who depends on them. Every "affects X" must be backed by a real caller.
+
+5. **Subsystem prior (optional).** `get_subsystem_summaries(repo, branch)` → name the touched
+   subsystem(s) in one line. Empty / unavailable → skip (fail-open).
+
+6. **Assemble the guide (Russian markdown):**
+   - **Начни отсюда** — ordered list (most central first).
+   - **По файлам** — one line per changed file.
+   - **Осторожно, влияет на** — impacted symbols + their callers.
+   - (optional) **Подсистемы** — 1–2 lines from summaries.
+
+7. **Output.** Print the guide to the user by default. Post to the PR ONLY on explicit user request:
+   confirm first, then call `post_pr_walkthrough(repo, pr, markdown)` (posts a PR review comment with
+   a `<!-- ai-walkthrough -->` marker, separate from bug findings).
+
+## Grounding (hard rule)
+
+<!-- include: _common/anti-hallucination.md -->
+
+Every "affects X" is backed by a real `find_callers` result. Never invent callers or impact.
+
+## Notes
+
+- This is a reading guide, NOT a bug review — no findings, no inline severity comments.
+- Posting to the PR is outward-facing and never happens without explicit user request + confirmation.
+- Works without PRI-159 summaries and degrades gracefully when the graph is unavailable.

--- a/plugin/skills/pr-walkthrough/SKILL.md
+++ b/plugin/skills/pr-walkthrough/SKILL.md
@@ -25,8 +25,6 @@ optional `post_pr_walkthrough` (only on explicit user request).
    If it returns `{"status": "skipped"}` (branch not in REVIEW_BRANCHES), tell the user (in Russian)
    and stop.
 
-<!-- include: _common/branch-selection.md -->
-
 2. **Reading order (centrality).** Call `get_impact(repo, pr)` → changed symbols and their callers.
    Order "start here" by how much depends on each changed symbol (most central first). Graph down →
    fall back to ordering by file (fail-open).
@@ -37,8 +35,10 @@ optional `post_pr_walkthrough` (only on explicit user request).
 4. **Impact ("careful, affects X").** For the central changed symbols, `find_callers` /
    `get_related_symbols` → who depends on them. Every "affects X" must be backed by a real caller.
 
-5. **Subsystem prior (optional).** `get_subsystem_summaries(repo, branch)` → name the touched
-   subsystem(s) in one line. Empty / unavailable → skip (fail-open).
+5. **Subsystem prior (optional).** `get_subsystem_summaries(repo, pr.base_ref)` → name the touched
+   subsystem(s) in one line. Pass the PR's target branch `pr.base_ref` (from the `prepare_review`
+   response), NOT the local git branch — subsystem summaries are indexed per target branch
+   (`base:<branch>`). Empty / unavailable → skip (fail-open).
 
 6. **Assemble the guide (Russian markdown):**
    - **Начни отсюда** — ordered list (most central first).

--- a/plugin/skills/summarize-subsystems/SKILL.md
+++ b/plugin/skills/summarize-subsystems/SKILL.md
@@ -1,0 +1,54 @@
+---
+name: reviewer_summarize-subsystems
+description: Precompute concise per-subsystem summaries (GraphRAG community summaries) over the base code index, so ask / PR-walkthrough get a cheap high-level prior. Use when the user asks to build/refresh subsystem summaries ("просуммируй подсистемы", "построй обзоры модулей", "summarize subsystems"). Requires a built base index + the reviewer MCP server.
+---
+
+# Summarize subsystems (community summaries)
+
+Cluster the base code graph into subsystems (by module path) and write a short, **grounded**
+summary for each, persisted for `ask` / PR-walkthrough to use as a cheap high-level prior. This
+skill reads code and writes summaries to the reviewer store; it does NOT modify code or post to
+GitHub.
+
+**Always write summaries and answer the user in Russian** (the project language), regardless of this
+file's language. Tool calls, code identifiers and `path:line` stay verbatim.
+
+## Tools
+
+<!-- include: _common/tool-usage.md -->
+Plus `list_subsystem_clusters` and `index_subsystem_summary` (reviewer MCP), and the harness `Read`.
+
+## Pipeline
+
+1. **Resolve repo/branch.**
+
+<!-- include: _common/branch-selection.md -->
+
+2. **List clusters.** Call `list_subsystem_clusters(repo, branch)`. Empty / `note` about an empty
+   index → tell the user (in Russian) to run `/reviewer_sync-codebase` first, then stop.
+
+3. **Summarize only STALE clusters.** For each cluster with `stale == true` (fresh ones are already
+   up to date — skip them, this keeps the pass incremental and cheap):
+   - `Read` a few representative files (from `files` / `top_symbols`) to ground the summary — do NOT
+     invent behavior the code does not show.
+   - Write, in Russian:
+     - `title` — one line: what this subsystem is.
+     - `summary` — a compact paragraph: what it does, its key symbols (from `top_symbols`) and
+       invariants. No `path:line` required in the text; it is a high-level prior.
+   - Persist: `index_subsystem_summary(repo, branch, cluster_key, title, summary, source_hash)` —
+     pass back the cluster's own `source_hash` from step 2.
+
+4. **Report (Russian).** How many clusters summarized vs skipped-as-fresh.
+
+## Grounding (hard rule)
+
+<!-- include: _common/anti-hallucination.md -->
+
+Every summary must reflect real code you read. If a cluster is unclear, say so briefly rather than
+guessing.
+
+## Notes
+
+- Precondition: base index built (`reviewer index`). Re-running is incremental: unchanged subsystems
+  (matching `source_hash`) are skipped.
+- Read-only on code and GitHub; only writes summaries to the reviewer store.

--- a/reviewer/app.py
+++ b/reviewer/app.py
@@ -5,6 +5,7 @@ from reviewer.config.settings import Settings
 from reviewer.index.store import ChunkStore
 from reviewer.index.embeddings import VoyageEmbedder
 from reviewer.index.reranker import VoyageReranker
+from reviewer.index.summary_store import SummaryStore
 from reviewer.graph.store import GraphStore
 from reviewer.retrieval.retriever import Retriever
 from reviewer.tasks.store import TaskStore
@@ -25,6 +26,7 @@ class Components:
     task_graph: TaskGraph | None
     task_service: TaskService
     sync_service: SyncService | None
+    summary_store: SummaryStore
 
 def _voyage_client(settings: Settings):
     import voyageai
@@ -61,5 +63,11 @@ def build_components(settings: Settings, connect: bool = True) -> Components:
     provider = make_board_provider(settings)
     sync_service = SyncService(provider, task_service, store) \
         if provider is not None else None
+    summary_store = SummaryStore(
+        settings.pg_dsn,
+        min_size=settings.pg_pool_min_size,
+        max_size=settings.pg_pool_max_size,
+    )
     return Components(settings, store, graph, embedder, reranker, retriever,
-                      task_store, task_graph, task_service, sync_service)
+                      task_store, task_graph, task_service, sync_service,
+                      summary_store)

--- a/reviewer/config/settings.py
+++ b/reviewer/config/settings.py
@@ -68,6 +68,7 @@ class Settings(BaseSettings):
     neo4j_user: str = "neo4j"
     neo4j_password: str = "reviewerpass"
     graph_backend: GraphBackend = "auto"   # auto|scip|treesitter
+    summary_cluster_depth: int = 2   # глубина пути для кластера подсистемы (PRI-159)
     # github
     github_token: str = ""
     github_retry_attempts: int = 3

--- a/reviewer/entrypoints/mcp_server.py
+++ b/reviewer/entrypoints/mcp_server.py
@@ -181,6 +181,36 @@ def create_server(service: MCPReviewService) -> FastMCP:
         return service.get_pr_diff(repo, number)
 
     @mcp.tool()
+    def list_subsystem_clusters(repo: str, branch: str | None = None,
+                                depth: int | None = None,
+                                min_size: int | None = None) -> dict:
+        """Cluster the base code graph into subsystems (by module path) for the
+        /reviewer_summarize-subsystems skill. Returns per cluster: cluster_key,
+        num_members, files, top_symbols (by centrality), source_hash, and stale
+        (true when the stored summary is missing or its source_hash differs).
+        No PR session; branch defaults to the primary tracked branch."""
+        return service.list_subsystem_clusters(repo, branch, depth, min_size)
+
+    @mcp.tool()
+    def index_subsystem_summary(repo: str, branch: str, cluster_key: str,
+                                title: str, summary: str, source_hash: str) -> dict:
+        """Persist one subsystem summary (idempotent upsert keyed by
+        repo+branch+cluster_key). Called by /reviewer_summarize-subsystems after the
+        LLM writes title+summary for a cluster. source_hash ties the summary to the
+        cluster's current content for staleness."""
+        return service.index_subsystem_summary(
+            repo, branch, cluster_key, title, summary, source_hash)
+
+    @mcp.tool()
+    def get_subsystem_summaries(repo: str, branch: str | None = None,
+                                cluster_key: str | None = None) -> dict:
+        """Cheap high-level prior for ask / PR-walkthrough: precomputed subsystem
+        summaries. cluster_key=None → all {cluster_key, title, summary}; a cluster_key
+        → one full summary (or null). Empty when none built (consumer is fail-open).
+        No PR session; branch defaults to primary."""
+        return service.get_subsystem_summaries(repo, branch, cluster_key)
+
+    @mcp.tool()
     def publish_review(
         repo: str,
         pr: int,

--- a/reviewer/entrypoints/mcp_server.py
+++ b/reviewer/entrypoints/mcp_server.py
@@ -16,7 +16,7 @@ log = logging.getLogger(__name__)
 
 
 def create_server(service: MCPReviewService) -> FastMCP:
-    """Создать и вернуть сконфигурированный FastMCP-сервер с 25 тулами.
+    """Создать и вернуть сконфигурированный FastMCP-сервер с 29 тулами.
 
     Все тулы — обычные def (sync), а не async: сервис не потокобезопасен
     и рассчитан на последовательное исполнение sync-тулов FastMCP в event loop.
@@ -240,6 +240,14 @@ def create_server(service: MCPReviewService) -> FastMCP:
     def get_candidate_findings(repo: str, pr: int) -> str:
         """Прочитать накопленных кандидатов с id (для verify)."""
         return service.get_candidate_findings(repo, pr)
+
+    @mcp.tool()
+    def post_pr_walkthrough(repo: str, pr: int, markdown: str) -> dict:
+        """Post a human-facing PR reading guide (walkthrough) as a PR review comment,
+        separate from bug findings (carries a <!-- ai-walkthrough --> marker, empty
+        inline comments). Outward-facing: the /reviewer_pr-walkthrough skill calls this
+        only on explicit user request. Requires an active prepare_review session."""
+        return service.post_pr_walkthrough(repo, pr, markdown)
 
     return mcp
 

--- a/reviewer/graph/summaries.py
+++ b/reviewer/graph/summaries.py
@@ -1,0 +1,89 @@
+"""Кластеризация графа кода по модулям/пути и расчёт ключа свежести.
+
+Чистая логика без I/O: членство и центральность приходят аргументами, поэтому
+покрывается unit-тестами без Postgres/Neo4j. Кластер = пакет/директория
+(префикс пути node_id="path#fqn"); summary каждого кластера пишет LLM-скилл.
+"""
+from __future__ import annotations
+
+import hashlib
+from dataclasses import dataclass
+from typing import Callable
+
+
+@dataclass
+class Member:
+    node_id: str          # "path#fqn"
+    path: str
+    content_hash: str
+    start_line: int
+
+
+@dataclass
+class Cluster:
+    key: str
+    member_node_ids: list[str]
+    files: list[str]
+    top_symbols: list[dict]   # [{"node_id", "file", "line"}], отсортированы по центральности
+    num_members: int
+    source_hash: str
+
+
+def cluster_key(path: str, depth: int) -> str:
+    """Ключ кластера = директория пути, обрезанная до первых ``depth`` сегментов.
+
+    "reviewer/index/store.py", depth=2 -> "reviewer/index".
+    Файл в корне -> "<root>"; директория короче depth -> вся директория.
+    """
+    dir_parts = path.split("/")[:-1]      # отбросить имя файла
+    if not dir_parts:
+        return "<root>"
+    return "/".join(dir_parts[:depth])
+
+
+def compute_source_hash(items: list[tuple[str, str]]) -> str:
+    """sha256 от sorted("node_id:content_hash") — детерминированный ключ свежести.
+
+    Меняется только при изменении состава кластера или содержимого его файлов
+    (content_hash — тот же дедуп-инвариант, что у чанков)."""
+    joined = "\n".join(sorted(f"{nid}:{h}" for nid, h in items))
+    return hashlib.sha256(joined.encode("utf-8")).hexdigest()
+
+
+def build_clusters(
+    members: list[Member],
+    in_degree_fn: Callable[[list[str]], dict[str, int]] | None,
+    *,
+    depth: int = 2,
+    min_size: int = 1,
+    top_n: int = 10,
+) -> list[Cluster]:
+    """Сгруппировать членов по cluster_key; top_symbols — по in_degree (fail-soft)."""
+    groups: dict[str, list[Member]] = {}
+    for m in members:
+        groups.setdefault(cluster_key(m.path, depth), []).append(m)
+
+    degrees: dict[str, int] = {}
+    if in_degree_fn is not None:
+        try:
+            degrees = in_degree_fn([m.node_id for m in members]) or {}
+        except Exception:
+            degrees = {}                  # граф недоступен → порядок по (path, line)
+
+    clusters: list[Cluster] = []
+    for key, ms in sorted(groups.items()):
+        if len(ms) < min_size:
+            continue
+        ranked = sorted(
+            ms, key=lambda m: (-degrees.get(m.node_id, 0), m.path, m.start_line))
+        top = [{"node_id": m.node_id, "file": m.path, "line": m.start_line}
+               for m in ranked[:top_n]]
+        clusters.append(Cluster(
+            key=key,
+            member_node_ids=sorted(m.node_id for m in ms),
+            files=sorted({m.path for m in ms}),
+            top_symbols=top,
+            num_members=len(ms),
+            source_hash=compute_source_hash([(m.node_id, m.content_hash) for m in ms]),
+        ))
+    return clusters

--- a/reviewer/index/schema.sql
+++ b/reviewer/index/schema.sql
@@ -69,3 +69,18 @@ CREATE INDEX IF NOT EXISTS tasks_bm25 ON tasks
 USING bm25 (id, text, key) WITH (key_field='id');
 CREATE INDEX IF NOT EXISTS tasks_hnsw ON tasks
 USING hnsw (embedding vector_cosine_ops) WITH (m = 16, ef_construction = 64);
+
+-- Предрасчитанные summary подсистем (PRI-159): кластер графа по модулю → краткий обзор.
+-- Отдельно от chunks — у summary нет lines/symbol и base/overlay-freshness.
+CREATE TABLE IF NOT EXISTS subsystem_summaries (
+    repo            text    NOT NULL DEFAULT '',
+    branch          text    NOT NULL,
+    cluster_key     text    NOT NULL,            -- напр. "reviewer/index"
+    title           text    NOT NULL,            -- одна строка «что это»
+    summary         text    NOT NULL,            -- сжатый абзац (RU)
+    member_node_ids text[]  NOT NULL DEFAULT '{}',
+    source_hash     text    NOT NULL,            -- ключ свежести
+    embedding       vector(1024),                -- nullable; зарезервировано под вектор-поиск
+    updated_at      timestamptz NOT NULL DEFAULT now(),
+    PRIMARY KEY (repo, branch, cluster_key)
+);

--- a/reviewer/index/store.py
+++ b/reviewer/index/store.py
@@ -199,6 +199,16 @@ class ChunkStore:
             ).fetchone()
         return row[0] if row else 0
 
+    def list_base_members(self, repo: str, branch: str) -> list[tuple[str, str, str, int]]:
+        """Состав base-индекса ветки для кластеризации подсистем (PRI-159):
+        (path, symbol_fqn, content_hash, start_line) для ref=base:<branch>."""
+        from reviewer.index.refs import base_ref
+        with self._connect() as conn:
+            rows = conn.execute(
+                "SELECT path, symbol_fqn, content_hash, start_line FROM chunks "
+                "WHERE repo=%s AND ref=%s", (repo, base_ref(branch))).fetchall()
+        return [(p, s, h, sl) for p, s, h, sl in rows]
+
     def list_refs(self, repo: str) -> list[str]:
         """Отсортированный список distinct ref репо (для поиска overlay)."""
         with self._connect() as conn:

--- a/reviewer/index/summary_store.py
+++ b/reviewer/index/summary_store.py
@@ -68,12 +68,13 @@ class SummaryStore:
         try:
             with self._connect() as conn:
                 rows = conn.execute(
-                    "SELECT cluster_key, title, summary FROM subsystem_summaries "
+                    "SELECT cluster_key, title, summary, updated_at FROM subsystem_summaries "
                     "WHERE repo=%s AND branch=%s ORDER BY cluster_key",
                     (repo, branch)).fetchall()
         except psycopg.errors.UndefinedTable:
             return []
-        return [{"cluster_key": k, "title": t, "summary": s} for k, t, s in rows]
+        return [{"cluster_key": k, "title": t, "summary": s, "updated_at": u.isoformat()}
+                for k, t, s, u in rows]
 
     def get_summary(self, repo: str, branch: str, cluster_key: str) -> dict | None:
         try:

--- a/reviewer/index/summary_store.py
+++ b/reviewer/index/summary_store.py
@@ -1,0 +1,91 @@
+# reviewer/index/summary_store.py
+"""Хранилище предрасчитанных summary подсистем (таблица subsystem_summaries).
+
+Зеркалит паттерн TaskStore: ленивый пул, register_vector на каждое соединение.
+Таблицу создаёт ChunkStore.init_schema (общий schema.sql)."""
+from __future__ import annotations
+
+import threading
+
+import psycopg.errors
+from pgvector.psycopg import register_vector
+from psycopg_pool import ConnectionPool
+
+
+class SummaryStore:
+    def __init__(self, dsn: str, *, min_size: int = 1, max_size: int = 4) -> None:
+        self.dsn = dsn
+        self._min_size = min_size
+        self._max_size = max_size
+        self._pool: ConnectionPool | None = None
+        self._init_lock = threading.Lock()
+
+    def _ensure_pool(self) -> ConnectionPool:
+        if self._pool is None:
+            with self._init_lock:
+                if self._pool is None:
+                    self._pool = ConnectionPool(
+                        self.dsn, min_size=self._min_size, max_size=self._max_size,
+                        open=False, configure=lambda conn: register_vector(conn))
+                    self._pool.open()
+        return self._pool
+
+    def _connect(self):
+        return self._ensure_pool().connection()
+
+    def close(self) -> None:
+        if self._pool is not None:
+            self._pool.close()
+            self._pool = None
+
+    def upsert_summary(self, repo: str, branch: str, cluster_key: str, title: str,
+                       summary: str, member_node_ids: list[str], source_hash: str) -> None:
+        sql = """
+        INSERT INTO subsystem_summaries
+            (repo, branch, cluster_key, title, summary, member_node_ids, source_hash, updated_at)
+        VALUES (%s,%s,%s,%s,%s,%s,%s, now())
+        ON CONFLICT (repo, branch, cluster_key) DO UPDATE SET
+            title=EXCLUDED.title, summary=EXCLUDED.summary,
+            member_node_ids=EXCLUDED.member_node_ids,
+            source_hash=EXCLUDED.source_hash, updated_at=now()
+        """
+        with self._connect() as conn:
+            conn.execute(sql, (repo, branch, cluster_key, title, summary,
+                               member_node_ids, source_hash))
+            conn.commit()
+
+    def get_source_hashes(self, repo: str, branch: str) -> dict[str, str]:
+        try:
+            with self._connect() as conn:
+                rows = conn.execute(
+                    "SELECT cluster_key, source_hash FROM subsystem_summaries "
+                    "WHERE repo=%s AND branch=%s", (repo, branch)).fetchall()
+        except psycopg.errors.UndefinedTable:
+            return {}
+        return {k: h for k, h in rows}
+
+    def get_summaries(self, repo: str, branch: str) -> list[dict]:
+        try:
+            with self._connect() as conn:
+                rows = conn.execute(
+                    "SELECT cluster_key, title, summary FROM subsystem_summaries "
+                    "WHERE repo=%s AND branch=%s ORDER BY cluster_key",
+                    (repo, branch)).fetchall()
+        except psycopg.errors.UndefinedTable:
+            return []
+        return [{"cluster_key": k, "title": t, "summary": s} for k, t, s in rows]
+
+    def get_summary(self, repo: str, branch: str, cluster_key: str) -> dict | None:
+        try:
+            with self._connect() as conn:
+                row = conn.execute(
+                    "SELECT cluster_key, title, summary, member_node_ids, source_hash, updated_at "
+                    "FROM subsystem_summaries WHERE repo=%s AND branch=%s AND cluster_key=%s",
+                    (repo, branch, cluster_key)).fetchone()
+        except psycopg.errors.UndefinedTable:
+            return None
+        if row is None:
+            return None
+        return {"cluster_key": row[0], "title": row[1], "summary": row[2],
+                "member_node_ids": list(row[3] or []), "source_hash": row[4],
+                "updated_at": row[5].isoformat()}

--- a/reviewer/mcp/service.py
+++ b/reviewer/mcp/service.py
@@ -36,6 +36,7 @@ from reviewer.vcs.diff import commentable_lines
 
 log = logging.getLogger(__name__)
 
+WALKTHROUGH_MARKER = "<!-- ai-walkthrough -->"
 
 
 @dataclass
@@ -691,6 +692,23 @@ class MCPReviewService:
             "moved_to_summary": asm.moved_to_summary,
             "capped": asm.capped,
         }
+
+    def post_pr_walkthrough(self, repo: str, pr: int, markdown: str) -> dict:
+        """Опубликовать walkthrough-гид в PR как review-комментарий (без inline-находок).
+
+        Маркер ``<!-- ai-walkthrough -->`` в body отделяет гид от ревью-находок
+        (``<!-- ai-review:* -->``). Outward-facing — вызывается только по явной
+        просьбе пользователя. Fail-soft при сетевой ошибке."""
+        from reviewer.services.repo_id import normalize_repo
+        sess = self._session(normalize_repo(repo), pr)
+        prepared = sess.prepared
+        body = f"{WALKTHROUGH_MARKER}\n\n{markdown}"
+        try:
+            prepared.vcs.publish_review(pr, prepared.prq.head_sha, body, [])
+        except Exception as e:
+            log.warning("post_pr_walkthrough: сбой постинга", exc_info=True)
+            return {"posted": False, "reason": f"{type(e).__name__}: {e}"}
+        return {"posted": True, "pr": pr}
 
     def _record_history(
         self,

--- a/reviewer/mcp/service.py
+++ b/reviewer/mcp/service.py
@@ -448,14 +448,29 @@ class MCPReviewService:
 
     def index_subsystem_summary(self, repo: str, branch: str, cluster_key: str,
                                 title: str, summary: str, source_hash: str) -> dict:
-        """Персистнуть один summary подсистемы (idempotent upsert)."""
+        """Персистнуть один summary подсистемы (idempotent upsert).
+
+        member_node_ids выводятся сервером (re-derive по cluster_key над base-составом)
+        и пишутся только при совпадении пере-вычисленного source_hash с переданным —
+        иначе [] + note (состав базы изменился между list и index; самозалечивается
+        следующим проходом summarize-subsystems)."""
+        from reviewer.graph.summaries import cluster_key as cluster_key_of, compute_source_hash
         rb = self._resolve_repo_branch(repo, branch)
         if isinstance(rb, str):
             return {"stored": False, "note": rb}
         repo, resolved = rb
+        depth = self.settings.summary_cluster_depth
+        raw = self.components.store.list_base_members(repo, resolved)
+        members = [(f"{p}#{s}", h) for p, s, h, _ in raw
+                   if cluster_key_of(p, depth) == cluster_key]
+        consistent = compute_source_hash(members) == source_hash
+        member_node_ids = sorted(nid for nid, _ in members) if consistent else []
         self.components.summary_store.upsert_summary(
-            repo, resolved, cluster_key, title, summary, [], source_hash)
-        return {"cluster_key": cluster_key, "stored": True}
+            repo, resolved, cluster_key, title, summary, member_node_ids, source_hash)
+        out = {"cluster_key": cluster_key, "stored": True, "members": len(member_node_ids)}
+        if not consistent:
+            out["note"] = "состав кластера изменился с момента list — member_node_ids не сохранены"
+        return out
 
     def get_subsystem_summaries(self, repo: str, branch: str | None = None,
                                 cluster_key: str | None = None) -> dict:

--- a/reviewer/mcp/service.py
+++ b/reviewer/mcp/service.py
@@ -459,6 +459,9 @@ class MCPReviewService:
         if isinstance(rb, str):
             return {"stored": False, "note": rb}
         repo, resolved = rb
+        # depth берём дефолтный (как list_subsystem_clusters без явного depth): cluster_key и
+        # source_hash зависят от depth, поэтому совпадение хешей гарантировано только когда
+        # кластеры листались тем же дефолтом. При нестандартном depth — fail-soft []+note ниже.
         depth = self.settings.summary_cluster_depth
         raw = self.components.store.list_base_members(repo, resolved)
         members = [(f"{p}#{s}", h) for p, s, h, _ in raw

--- a/reviewer/mcp/service.py
+++ b/reviewer/mcp/service.py
@@ -415,6 +415,59 @@ class MCPReviewService:
             log.warning("definition: сбой", exc_info=True)
             return "(определение не найдено)"
 
+    def list_subsystem_clusters(self, repo: str, branch: str | None = None,
+                                depth: int | None = None,
+                                min_size: int | None = None) -> dict:
+        """Кластеризовать base-граф по модулям → кластеры для /summarize-subsystems."""
+        from reviewer.graph.summaries import Member, build_clusters
+        rb = self._resolve_repo_branch(repo, branch)
+        if isinstance(rb, str):
+            return {"clusters": [], "note": rb}
+        repo, resolved = rb
+        raw = self.components.store.list_base_members(repo, resolved)
+        if not raw:
+            return {"clusters": [],
+                    "note": "(base-индекс пуст — выполните /reviewer_sync-codebase)"}
+        members = [Member(node_id=f"{p}#{s}", path=p, content_hash=h, start_line=sl)
+                   for p, s, h, sl in raw]
+        graph = self.components.graph
+        in_degree_fn = (
+            (lambda ids: graph.in_degree(repo, ids, branch=resolved))
+            if graph is not None else None)
+        clusters = build_clusters(
+            members, in_degree_fn,
+            depth=depth or self.settings.summary_cluster_depth,
+            min_size=min_size or 1)
+        stored = self.components.summary_store.get_source_hashes(repo, resolved)
+        return {"branch": resolved, "clusters": [
+            {"cluster_key": c.key, "num_members": c.num_members, "files": c.files,
+             "top_symbols": c.top_symbols, "source_hash": c.source_hash,
+             "stale": stored.get(c.key) != c.source_hash}
+            for c in clusters]}
+
+    def index_subsystem_summary(self, repo: str, branch: str, cluster_key: str,
+                                title: str, summary: str, source_hash: str) -> dict:
+        """Персистнуть один summary подсистемы (idempotent upsert)."""
+        rb = self._resolve_repo_branch(repo, branch)
+        if isinstance(rb, str):
+            return {"stored": False, "note": rb}
+        repo, resolved = rb
+        self.components.summary_store.upsert_summary(
+            repo, resolved, cluster_key, title, summary, [], source_hash)
+        return {"cluster_key": cluster_key, "stored": True}
+
+    def get_subsystem_summaries(self, repo: str, branch: str | None = None,
+                                cluster_key: str | None = None) -> dict:
+        """Дешёвый приор: предрасчитанные summary подсистем (fail-open у потребителя)."""
+        rb = self._resolve_repo_branch(repo, branch)
+        if isinstance(rb, str):
+            return {"summaries": [], "note": rb}
+        repo, resolved = rb
+        store = self.components.summary_store
+        if cluster_key:
+            return {"summary": store.get_summary(repo, resolved, cluster_key)}
+        return {"summaries": store.get_summaries(repo, resolved)}
+
     def get_pr_diff(self, repo: str, number: int) -> str:
         """Unified diff изменённых файлов PR (session-less) — ленивая подтяжка для /solve-task.
 

--- a/tests/graph/test_summaries.py
+++ b/tests/graph/test_summaries.py
@@ -1,0 +1,57 @@
+from reviewer.graph.summaries import (
+    Member, cluster_key, compute_source_hash, build_clusters,
+)
+
+
+def _m(node_id, path, h="h", line=1):
+    return Member(node_id=node_id, path=path, content_hash=h, start_line=line)
+
+
+def test_cluster_key_takes_first_depth_dir_segments():
+    assert cluster_key("reviewer/index/store.py", 2) == "reviewer/index"
+    assert cluster_key("reviewer/graph/store.py", 2) == "reviewer/graph"
+    assert cluster_key("reviewer/index/sub/x.py", 2) == "reviewer/index"
+
+
+def test_cluster_key_root_file_and_short_dir():
+    assert cluster_key("setup.py", 2) == "<root>"
+    assert cluster_key("reviewer/app.py", 2) == "reviewer"
+
+
+def test_compute_source_hash_is_order_independent_and_changes_with_content():
+    a = compute_source_hash([("x#f", "h1"), ("y#g", "h2")])
+    b = compute_source_hash([("y#g", "h2"), ("x#f", "h1")])
+    assert a == b                       # детерминирован, не зависит от порядка
+    assert a != compute_source_hash([("x#f", "h1"), ("y#g", "CHANGED")])
+
+
+def test_build_clusters_groups_by_module_and_filters_min_size():
+    members = [
+        _m("reviewer/index/a.py#A", "reviewer/index/a.py"),
+        _m("reviewer/index/b.py#B", "reviewer/index/b.py"),
+        _m("reviewer/graph/c.py#C", "reviewer/graph/c.py"),
+    ]
+    clusters = build_clusters(members, None, depth=2, min_size=2)
+    keys = {c.key for c in clusters}
+    assert keys == {"reviewer/index"}     # graph отброшен (1 < min_size=2)
+    idx = next(c for c in clusters if c.key == "reviewer/index")
+    assert idx.num_members == 2
+    assert idx.files == ["reviewer/index/a.py", "reviewer/index/b.py"]
+
+
+def test_build_clusters_ranks_top_symbols_by_in_degree():
+    members = [
+        _m("reviewer/x/a.py#A", "reviewer/x/a.py", line=10),
+        _m("reviewer/x/b.py#B", "reviewer/x/b.py", line=20),
+    ]
+    deg = {"reviewer/x/b.py#B": 5, "reviewer/x/a.py#A": 1}
+    [c] = build_clusters(members, lambda ids: deg, depth=2, top_n=10)
+    assert c.top_symbols[0]["node_id"] == "reviewer/x/b.py#B"   # выше in_degree → первый
+
+
+def test_build_clusters_fail_soft_when_in_degree_raises():
+    members = [_m("reviewer/x/a.py#A", "reviewer/x/a.py")]
+    def boom(ids):
+        raise RuntimeError("neo4j down")
+    [c] = build_clusters(members, boom, depth=2)   # не падает
+    assert c.top_symbols[0]["node_id"] == "reviewer/x/a.py#A"

--- a/tests/index/test_summary_store.py
+++ b/tests/index/test_summary_store.py
@@ -1,0 +1,38 @@
+import os
+import pytest
+
+from reviewer.index.store import ChunkStore
+from reviewer.index.summary_store import SummaryStore
+
+pytestmark = pytest.mark.integration
+
+DSN = os.getenv("PG_DSN", "postgresql://postgres:postgres@localhost:5433/postgres")
+
+
+@pytest.fixture()
+def store():
+    ChunkStore(DSN).init_schema()        # создаёт subsystem_summaries (schema.sql)
+    s = SummaryStore(DSN)
+    yield s
+    with s._connect() as conn:
+        conn.execute("DELETE FROM subsystem_summaries WHERE repo='t/t'")
+        conn.commit()
+    s.close()
+
+
+def test_upsert_then_get_roundtrip(store):
+    store.upsert_summary("t/t", "dev", "reviewer/index", "Индекс",
+                         "Хранилище чанков и ретрив.", ["reviewer/index/store.py#X"], "h1")
+    assert store.get_source_hashes("t/t", "dev") == {"reviewer/index": "h1"}
+    rows = store.get_summaries("t/t", "dev")
+    assert rows == [{"cluster_key": "reviewer/index", "title": "Индекс",
+                     "summary": "Хранилище чанков и ретрив."}]
+    one = store.get_summary("t/t", "dev", "reviewer/index")
+    assert one["member_node_ids"] == ["reviewer/index/store.py#X"]
+
+
+def test_upsert_is_idempotent_update(store):
+    store.upsert_summary("t/t", "dev", "reviewer/index", "A", "old", [], "h1")
+    store.upsert_summary("t/t", "dev", "reviewer/index", "A", "new", [], "h2")
+    assert store.get_source_hashes("t/t", "dev") == {"reviewer/index": "h2"}
+    assert store.get_summaries("t/t", "dev")[0]["summary"] == "new"

--- a/tests/index/test_summary_store.py
+++ b/tests/index/test_summary_store.py
@@ -36,3 +36,18 @@ def test_upsert_is_idempotent_update(store):
     store.upsert_summary("t/t", "dev", "reviewer/index", "A", "new", [], "h2")
     assert store.get_source_hashes("t/t", "dev") == {"reviewer/index": "h2"}
     assert store.get_summaries("t/t", "dev")[0]["summary"] == "new"
+
+
+def test_list_base_members_reads_base_ref_rows():
+    from reviewer.index.store import ChunkStore, ChunkRow
+    cs = ChunkStore(DSN)
+    cs.init_schema()
+    cs.upsert([ChunkRow(repo="t/t", ref="base:dev", content_hash="h", path="reviewer/x/a.py",
+                        lang="python", symbol_fqn="A", kind="function",
+                        start_line=3, end_line=9, text="def a(): ...", embedding=[0.0]*1024)])
+    try:
+        members = cs.list_base_members("t/t", "dev")
+        assert ("reviewer/x/a.py", "A", "h", 3) in members
+    finally:
+        cs.delete_ref("t/t", "base:dev")
+        cs.close()

--- a/tests/index/test_summary_store.py
+++ b/tests/index/test_summary_store.py
@@ -1,12 +1,12 @@
-import os
 import pytest
 
+from reviewer.config.settings import Settings
 from reviewer.index.store import ChunkStore
 from reviewer.index.summary_store import SummaryStore
 
 pytestmark = pytest.mark.integration
 
-DSN = os.getenv("PG_DSN", "postgresql://postgres:postgres@localhost:5433/postgres")
+DSN = Settings().pg_dsn
 
 
 @pytest.fixture()

--- a/tests/index/test_summary_store.py
+++ b/tests/index/test_summary_store.py
@@ -25,8 +25,12 @@ def test_upsert_then_get_roundtrip(store):
                          "Хранилище чанков и ретрив.", ["reviewer/index/store.py#X"], "h1")
     assert store.get_source_hashes("t/t", "dev") == {"reviewer/index": "h1"}
     rows = store.get_summaries("t/t", "dev")
-    assert rows == [{"cluster_key": "reviewer/index", "title": "Индекс",
-                     "summary": "Хранилище чанков и ретрив."}]
+    assert len(rows) == 1
+    row = rows[0]
+    assert row["cluster_key"] == "reviewer/index"
+    assert row["title"] == "Индекс"
+    assert row["summary"] == "Хранилище чанков и ретрив."
+    assert "T" in row["updated_at"]        # ISO-таймстамп (зеркало единичного get_summary)
     one = store.get_summary("t/t", "dev", "reviewer/index")
     assert one["member_node_ids"] == ["reviewer/index/store.py#X"]
 

--- a/tests/mcp/test_pr_walkthrough.py
+++ b/tests/mcp/test_pr_walkthrough.py
@@ -1,0 +1,45 @@
+"""Unit-тест постинга walkthrough-гида (PRI-119). Сессия и VCS — фейки."""
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+from reviewer.config.settings import Settings
+from reviewer.mcp.service import MCPReviewService
+
+
+def _settings() -> Settings:
+    s = Settings()
+    s.voyage_api_key = "test"
+    s.github_token = "test"
+    s.default_repo = ""
+    return s
+
+
+def test_post_pr_walkthrough_posts_body_with_marker_and_no_comments():
+    svc = MCPReviewService(_settings(), MagicMock())
+    vcs = MagicMock()
+    prepared = SimpleNamespace(vcs=vcs, prq=SimpleNamespace(head_sha="head456"))
+    svc._session = lambda repo, pr: SimpleNamespace(prepared=prepared)   # изолируем сессию
+
+    out = svc.post_pr_walkthrough("o/n", 7, "## Начни отсюда\n- a.py")
+
+    assert out == {"posted": True, "pr": 7}
+    vcs.publish_review.assert_called_once()
+    number, head_sha, body, comments = vcs.publish_review.call_args.args
+    assert number == 7 and head_sha == "head456"
+    assert body.startswith("<!-- ai-walkthrough -->")
+    assert "Начни отсюда" in body
+    assert comments == []      # гид — без inline-находок
+
+
+def test_post_pr_walkthrough_fail_soft_on_network_error():
+    svc = MCPReviewService(_settings(), MagicMock())
+    vcs = MagicMock()
+    vcs.publish_review.side_effect = RuntimeError("boom")
+    prepared = SimpleNamespace(vcs=vcs, prq=SimpleNamespace(head_sha="h"))
+    svc._session = lambda repo, pr: SimpleNamespace(prepared=prepared)
+
+    out = svc.post_pr_walkthrough("o/n", 7, "guide")
+    assert out["posted"] is False
+    assert "RuntimeError" in out["reason"]

--- a/tests/mcp/test_server.py
+++ b/tests/mcp/test_server.py
@@ -88,7 +88,7 @@ def _make_mcp_service(number: int = 7) -> MCPReviewService:
 # ---------------------------------------------------------------------------
 
 def test_server_registers_all_tools() -> None:
-    """create_server регистрирует ровно 25 ожидаемых MCP-тулов."""
+    """create_server регистрирует ровно 28 ожидаемых MCP-тулов."""
     from reviewer.entrypoints.mcp_server import create_server
 
     server = create_server(_make_mcp_service())
@@ -120,6 +120,9 @@ def test_server_registers_all_tools() -> None:
         "callers",
         "definition",
         "get_pr_diff",
+        "list_subsystem_clusters",
+        "index_subsystem_summary",
+        "get_subsystem_summaries",
     }
 
 

--- a/tests/mcp/test_server.py
+++ b/tests/mcp/test_server.py
@@ -88,7 +88,7 @@ def _make_mcp_service(number: int = 7) -> MCPReviewService:
 # ---------------------------------------------------------------------------
 
 def test_server_registers_all_tools() -> None:
-    """create_server регистрирует ровно 28 ожидаемых MCP-тулов."""
+    """create_server регистрирует ровно 29 ожидаемых MCP-тулов."""
     from reviewer.entrypoints.mcp_server import create_server
 
     server = create_server(_make_mcp_service())
@@ -115,6 +115,7 @@ def test_server_registers_all_tools() -> None:
         "submit_findings",
         "submit_verdicts",
         "get_candidate_findings",
+        "post_pr_walkthrough",
         "search_codebase",
         "related_symbols",
         "callers",

--- a/tests/mcp/test_subsystem_summaries.py
+++ b/tests/mcp/test_subsystem_summaries.py
@@ -1,0 +1,71 @@
+"""Unit-тесты MCP-методов community summaries (PRI-159). Фейки вместо Postgres/Neo4j."""
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from reviewer.config.settings import Settings
+from reviewer.mcp.service import MCPReviewService
+
+
+def _settings() -> Settings:
+    s = Settings()
+    s.voyage_api_key = "test"
+    s.default_repo = ""
+    return s
+
+
+def _svc(components) -> MCPReviewService:
+    svc = MCPReviewService(_settings(), components)
+    # изолируем резолв repo/ветки от REVIEW_BRANCHES в .env
+    svc._resolve_repo_branch = lambda repo, branch: ("o/n", "dev")
+    return svc
+
+
+def test_list_subsystem_clusters_marks_stale():
+    c = MagicMock()
+    c.store.list_base_members.return_value = [
+        ("reviewer/index/a.py", "A", "h1", 1),
+        ("reviewer/index/b.py", "B", "h2", 2),
+    ]
+    c.graph = None                                  # граф недоступен → fail-soft
+    c.summary_store.get_source_hashes.return_value = {}   # ничего не сохранено → stale=True
+    svc = _svc(c)
+    out = svc.list_subsystem_clusters("o/n", "dev", depth=2, min_size=1)
+    [cl] = out["clusters"]
+    assert cl["cluster_key"] == "reviewer/index"
+    assert cl["num_members"] == 2
+    assert cl["stale"] is True
+
+
+def test_list_subsystem_clusters_fresh_when_hash_matches():
+    c = MagicMock()
+    c.store.list_base_members.return_value = [("reviewer/index/a.py", "A", "h1", 1)]
+    c.graph = None
+    # вычисляем эталонный source_hash так же, как продакшен
+    from reviewer.graph.summaries import compute_source_hash
+    sh = compute_source_hash([("reviewer/index/a.py#A", "h1")])
+    c.summary_store.get_source_hashes.return_value = {"reviewer/index": sh}
+    svc = _svc(c)
+    [cl] = svc.list_subsystem_clusters("o/n", "dev")["clusters"]
+    assert cl["stale"] is False
+
+
+def test_list_subsystem_clusters_empty_index_returns_note():
+    c = MagicMock()
+    c.store.list_base_members.return_value = []
+    svc = _svc(c)
+    out = svc.list_subsystem_clusters("o/n", "dev")
+    assert out["clusters"] == []
+    assert "note" in out
+
+
+def test_index_and_get_subsystem_summaries_roundtrip_via_store():
+    c = MagicMock()
+    c.summary_store.get_summaries.return_value = [
+        {"cluster_key": "reviewer/index", "title": "Индекс", "summary": "..."}]
+    svc = _svc(c)
+    assert svc.index_subsystem_summary("o/n", "dev", "reviewer/index", "Индекс", "...", "h1") == {
+        "cluster_key": "reviewer/index", "stored": True}
+    c.summary_store.upsert_summary.assert_called_once()
+    got = svc.get_subsystem_summaries("o/n", "dev")
+    assert got["summaries"][0]["cluster_key"] == "reviewer/index"

--- a/tests/mcp/test_subsystem_summaries.py
+++ b/tests/mcp/test_subsystem_summaries.py
@@ -60,12 +60,37 @@ def test_list_subsystem_clusters_empty_index_returns_note():
 
 
 def test_index_and_get_subsystem_summaries_roundtrip_via_store():
+    from reviewer.graph.summaries import compute_source_hash
     c = MagicMock()
+    # base-состав кластера reviewer/index (depth=2) — сервер выведет member_node_ids из него
+    c.store.list_base_members.return_value = [
+        ("reviewer/index/a.py", "A", "h1", 1),
+        ("reviewer/index/b.py", "B", "h2", 2),
+    ]
+    sh = compute_source_hash([("reviewer/index/a.py#A", "h1"),
+                              ("reviewer/index/b.py#B", "h2")])
     c.summary_store.get_summaries.return_value = [
-        {"cluster_key": "reviewer/index", "title": "Индекс", "summary": "..."}]
+        {"cluster_key": "reviewer/index", "title": "Индекс", "summary": "...",
+         "updated_at": "2026-06-23T00:00:00+00:00"}]
     svc = _svc(c)
-    assert svc.index_subsystem_summary("o/n", "dev", "reviewer/index", "Индекс", "...", "h1") == {
-        "cluster_key": "reviewer/index", "stored": True}
-    c.summary_store.upsert_summary.assert_called_once()
+
+    out = svc.index_subsystem_summary("o/n", "dev", "reviewer/index", "Индекс", "...", sh)
+    assert out == {"cluster_key": "reviewer/index", "stored": True, "members": 2}
+    # upsert получил выведенный (отсортированный) member_node_ids, а не []
+    args = c.summary_store.upsert_summary.call_args.args
+    assert args[5] == ["reviewer/index/a.py#A", "reviewer/index/b.py#B"]
+
     got = svc.get_subsystem_summaries("o/n", "dev")
     assert got["summaries"][0]["cluster_key"] == "reviewer/index"
+
+
+def test_index_subsystem_summary_stale_hash_empties_members():
+    c = MagicMock()
+    c.store.list_base_members.return_value = [("reviewer/index/a.py", "A", "h1", 1)]
+    svc = _svc(c)
+    # передан неактуальный source_hash → пере-вычисленный не совпадёт
+    out = svc.index_subsystem_summary("o/n", "dev", "reviewer/index", "Индекс", "...", "STALE")
+    assert out["stored"] is True
+    assert out["members"] == 0
+    assert "note" in out
+    assert c.summary_store.upsert_summary.call_args.args[5] == []   # member_node_ids пуст

--- a/tests/skills/test_ask_uses_summaries.py
+++ b/tests/skills/test_ask_uses_summaries.py
@@ -1,0 +1,13 @@
+from pathlib import Path
+
+ASK = Path(__file__).resolve().parents[2] / "plugin" / "skills" / "ask" / "SKILL.md"
+
+
+def test_ask_references_subsystem_summaries_prior():
+    text = ASK.read_text(encoding="utf-8")
+    assert "get_subsystem_summaries" in text
+
+
+def test_ask_marks_prior_fail_open():
+    text = ASK.read_text(encoding="utf-8").lower()
+    assert "fail-open" in text and "get_subsystem_summaries" in ASK.read_text(encoding="utf-8")

--- a/tests/skills/test_pr_walkthrough_skill.py
+++ b/tests/skills/test_pr_walkthrough_skill.py
@@ -22,6 +22,14 @@ def test_skill_includes_resolve_to_existing_common_files():
         assert (base / inc).is_file(), f"include не найден: {inc}"
 
 
+def test_step5_summaries_use_pr_base_ref():
+    text = SKILL.read_text(encoding="utf-8")
+    # summaries индексируются по целевой ветке PR, не по локальной git-ветке
+    assert "base_ref" in text
+    # include branch-selection убран — неверная абстракция для PR-скоупного скилла
+    assert "branch-selection" not in text
+
+
 def test_skill_posting_is_opt_in_and_russian():
     text = SKILL.read_text(encoding="utf-8")
     assert "post_pr_walkthrough" in text

--- a/tests/skills/test_pr_walkthrough_skill.py
+++ b/tests/skills/test_pr_walkthrough_skill.py
@@ -1,0 +1,31 @@
+# tests/skills/test_pr_walkthrough_skill.py
+from pathlib import Path
+import re
+
+SKILL = (Path(__file__).resolve().parents[2]
+         / "plugin" / "skills" / "pr-walkthrough" / "SKILL.md")
+
+
+def test_skill_exists_and_uses_session_tools():
+    text = SKILL.read_text(encoding="utf-8")
+    assert "prepare_review" in text
+    assert "get_impact" in text
+    assert "find_callers" in text
+
+
+def test_skill_includes_resolve_to_existing_common_files():
+    text = SKILL.read_text(encoding="utf-8")
+    includes = re.findall(r"<!-- include: (_common/[\w\-./]+) -->", text)
+    assert includes, "нет include-маркеров _common"
+    base = SKILL.resolve().parents[1]
+    for inc in includes:
+        assert (base / inc).is_file(), f"include не найден: {inc}"
+
+
+def test_skill_posting_is_opt_in_and_russian():
+    text = SKILL.read_text(encoding="utf-8")
+    assert "post_pr_walkthrough" in text
+    low = text.lower()
+    assert "russian" in low or "русск" in low
+    # постинг — только по явной просьбе (outward-facing)
+    assert "explicit" in low or "only on explicit" in low or "явн" in low

--- a/tests/skills/test_summarize_subsystems.py
+++ b/tests/skills/test_summarize_subsystems.py
@@ -1,0 +1,25 @@
+from pathlib import Path
+
+SKILL = (Path(__file__).resolve().parents[2]
+         / "plugin" / "skills" / "summarize-subsystems" / "SKILL.md")
+
+
+def test_skill_exists_and_mentions_tools():
+    text = SKILL.read_text(encoding="utf-8")
+    assert "list_subsystem_clusters" in text
+    assert "index_subsystem_summary" in text
+
+
+def test_skill_includes_common_blocks_that_exist():
+    text = SKILL.read_text(encoding="utf-8")
+    common = SKILL.resolve().parents[1] / "_common"
+    import re
+    includes = re.findall(r"<!-- include: (_common/[\w\-./]+) -->", text)
+    assert includes, "нет include-маркеров _common"
+    for inc in includes:
+        assert (common.parent / inc).is_file(), f"include не найден: {inc}"
+
+
+def test_skill_instructs_russian_output():
+    text = SKILL.read_text(encoding="utf-8").lower()
+    assert "russian" in text or "русск" in text

--- a/tests/test_app_wiring.py
+++ b/tests/test_app_wiring.py
@@ -13,3 +13,9 @@ def test_build_components_wires_task_components(monkeypatch):
     assert c.task_store is not None
     assert c.task_service is not None
     assert c.task_graph is None  # connect=False → graph None → task_graph None
+
+
+def test_build_components_wires_summary_store(monkeypatch):
+    monkeypatch.setenv("VOYAGE_API_KEY", "v")
+    c = build_components(Settings(), connect=False)
+    assert c.summary_store is not None


### PR DESCRIPTION
## Что это

Две последовательные фичи на одной ветке (дизайн утверждён на brainstorming, реализовано через subagent-driven-development, финальное whole-branch ревью — Ready to merge):

### PRI-159 — GraphRAG community summaries
Предрасчёт кратких сводок по подсистемам (кластеры графа кода по модулям) — дешёвый высокоуровневый «приор» для `ask`/walkthrough до детального ретрива. Генерацию текста делает LLM-скилл, Python — только детерминированный ETL/хранение/кластеризация (ядро reviewer не имеет general-purpose LLM).

- `reviewer/graph/summaries.py` — чистая кластеризация (`cluster_key` по пути модуля, `compute_source_hash`, `build_clusters` с fail-soft-ранжированием по in-degree).
- Таблица `subsystem_summaries` (`schema.sql`) + `SummaryStore` (зеркало `TaskStore`, fail-soft на `UndefinedTable`); `Settings.summary_cluster_depth=2`.
- `ChunkStore.list_base_members` — состав base-индекса ветки для кластеризации.
- Wiring `summary_store` в `Components`; 3 MCP-метода/тула: `list_subsystem_clusters` / `index_subsystem_summary` / `get_subsystem_summaries` (скоуп по `(repo, branch)`, граф fail-soft, `stale = stored.get(key) != source_hash`).
- Скилл `/reviewer_summarize-subsystems` (LLM пишет summary, инкрементально по `stale`) + интеграция приора в `ask` (шаг 1.5, fail-open).

### PRI-119 — PR walkthrough
Markdown-гид по PR для ревьюера-**человека** (откуда читать, что меняет файл, на что влияет) — отдельно от находок-багов.

- `post_pr_walkthrough(repo, pr, markdown)` + MCP-тул: постинг гида как review-комментарий с маркером `<!-- ai-walkthrough -->` (отделён от `<!-- ai-review:* -->`), fail-soft.
- Скилл `/reviewer_pr-walkthrough` поверх существующей PR-сессии (`prepare_review` → `get_impact`/`get_changed_file_diff`/`find_callers`); опц. приор PRI-159; постинг в PR — **только по явной просьбе + подтверждение** (outward-facing).

## Тесты
- Полный unit-набор: **643 passed** (исключая pre-existing провал `tests/web` — fastapi без `[web]`-extra, не связан с PR).
- Integration-тесты `SummaryStore` / `list_base_members` — проходят против Postgres :5433.
- Guard-тесты скиллов (`tests/skills/`) — 30/30, include-маркеры `_common` резолвятся.
- TDD по каждой задаче (RED→GREEN), ревью каждой задачи + финальное whole-branch ревью (Opus).

## Заметки / опциональные follow-up (не блокеры)
- `get_subsystem_summaries` в walkthrough берёт branch из локального git — для PR корректнее `prq.base_ref` (fail-open маскирует расхождение).
- `index_subsystem_summary` пока пишет `member_node_ids=[]` (поле зарезервировано, потребителей нет).
- `get_summaries` не отдаёт `updated_at` (дрейф спек↔код, безвреден).
