### PR TITLE
feat: свежесть сводок подсистем по структуре + cap (PRI-165)

### DIFF
--- a/docs/superpowers/plans/2026-06-23-pri-165-summary-skeleton-freshness.md
+++ b/docs/superpowers/plans/2026-06-23-pri-165-summary-skeleton-freshness.md
@@ -1,0 +1,582 @@
+# PRI-165 — Freshness сводок по структуре + cap — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ключ свежести сводок подсистем считать от структурного скелета символов (`skeleton_hash` на лету), а не от полного `content_hash`, + server-side cap пересборок + выбор модели в скилле — чтобы body-only правки не гнали LLM-пересборку.
+
+**Architecture:** Новый чистый хелпер `symbol_skeleton_hash` (tree-sitter, в `chunker.py`) хэширует только строки скелета символа. `ChunkStore.list_base_members` отдаёт его 5-м элементом кортежа (на лету из `text`, без миграции). `build_clusters` и `index_subsystem_summary` подают `skeleton_hash` в `compute_source_hash` (синхронно). `list_subsystem_clusters` применяет cap (порядок: без сводки → старейшие `updated_at`) и отдаёт `deferred`. Скилл `summarize-subsystems` репортит `deferred` и спрашивает дешёвую модель для генерации.
+
+**Tech Stack:** Python 3.11–3.13, tree-sitter-python, pydantic-settings, psycopg/pgvector (ParadeDB :5433), pytest, FastMCP. Граф — Neo4j (не затрагивается).
+
+## Global Constraints
+
+- **Язык проекта — русский:** все новые комментарии, докстринги, тексты — на русском. Тело `SKILL.md` — на английском (токены), но инструктирует отвечать пользователю по-русски.
+- **Коммиты:** Conventional Commits на русском, **без self-attribution** (никаких `Co-Authored-By`/упоминаний Claude). Ветка: `feat/pri-165-summary-skeleton-freshness` (уже создана от `dev`), PR → `dev`.
+- **TDD:** сначала падающий тест, затем минимальная реализация.
+- **Линт:** `ruff check .` (line-length 100, target py311). Прогонять перед коммитом по затронутым файлам.
+- **Тесты по умолчанию исключают `integration`** (`addopts = -m 'not integration'`). Integration-тесты требуют поднятых Postgres/Neo4j: `docker compose up -d`.
+- **Инвариант:** `symbol_skeleton_hash` хэширует **нормализованный текст** строк скелета (`rstrip`, как `content_hash`), не их номера → позиция/порядок символа в файл не протекают в хэш.
+- **Спека:** `docs/superpowers/specs/2026-06-23-pri-165-summary-skeleton-freshness-design.md`.
+
+---
+
+### Task 1: `symbol_skeleton_hash` — хэш структурного скелета символа
+
+**Files:**
+- Modify: `reviewer/index/chunker.py` (добавить `import hashlib` + функцию после `python_skeleton`, ~строка 90)
+- Test: `tests/index/test_chunker.py`
+
+**Interfaces:**
+- Consumes: существующий `python_skeleton(source: bytes) -> list[int]` (`chunker.py:46`).
+- Produces: `symbol_skeleton_hash(text: str) -> str` — sha256 нормализованного текста строк скелета символа; позиционно-независим; fallback на полный текст при пустом скелете. Потребляется в Task 2 (`store.list_base_members`).
+
+- [ ] **Step 1: Написать падающие тесты**
+
+В конец `tests/index/test_chunker.py` добавить (импорт расширить в строке 1):
+
+```python
+from reviewer.index.chunker import chunk_python, python_skeleton, symbol_skeleton_hash
+
+_FN = (
+    'def search(query: str, top_k: int = 10) -> list:\n'
+    '    """Поиск по индексу."""\n'
+    '    return rrf(query)[:top_k]\n'
+)
+
+
+def test_skeleton_hash_ignores_body_change():
+    body = _FN.replace("rrf(query)[:top_k]", "rrf(query, k=60)[:top_k]")
+    assert symbol_skeleton_hash(_FN) == symbol_skeleton_hash(body)   # тело не влияет
+
+
+def test_skeleton_hash_changes_on_signature():
+    sig = _FN.replace("top_k: int = 10)", "top_k: int = 10, *, rerank: bool = True)")
+    assert symbol_skeleton_hash(_FN) != symbol_skeleton_hash(sig)    # сигнатура влияет
+
+
+def test_skeleton_hash_changes_on_docstring_first_line():
+    doc = _FN.replace('"""Поиск по индексу."""', '"""Другое описание."""')
+    assert symbol_skeleton_hash(_FN) != symbol_skeleton_hash(doc)
+
+
+def test_skeleton_hash_is_position_independent():
+    shifted = "\n\n" + _FN                                           # сдвиг символа вниз
+    assert symbol_skeleton_hash(_FN) == symbol_skeleton_hash(shifted)
+
+
+def test_skeleton_hash_fallback_without_definitions():
+    # нет def/class → fallback на нормализованный полный текст (детерминирован, реагирует на правку)
+    assert symbol_skeleton_hash("X = 1\n") == symbol_skeleton_hash("X = 1")
+    assert symbol_skeleton_hash("X = 1\n") != symbol_skeleton_hash("X = 2\n")
+```
+
+- [ ] **Step 2: Запустить — убедиться, что падают**
+
+Run: `.venv/bin/pytest tests/index/test_chunker.py -k skeleton_hash -q`
+Expected: FAIL — `ImportError: cannot import name 'symbol_skeleton_hash'`.
+
+- [ ] **Step 3: Реализовать функцию**
+
+В `reviewer/index/chunker.py`: добавить в начало `import hashlib` (рядом с существующими импортами, строки 1–4), затем после `python_skeleton` (после строки 90) добавить:
+
+```python
+def symbol_skeleton_hash(text: str) -> str:
+    """Хэш структурного скелета символа: сигнатуры def/class (до ':') + 1-я строка docstring.
+
+    Ключ свежести сводок подсистем по структуре (PRI-165): меняется при смене сигнатуры/
+    docstring, но НЕ при правке тела. Хэшируется ТЕКСТ строк скелета (rstrip, как content_hash),
+    а не их номера, поэтому сдвиг/реордеринг символа в файл не протекают в хэш. Пустой скелет
+    (битый код / нет определений) → fallback на нормализованный полный текст (безопасно: любая
+    правка ре-стейлит)."""
+    nums = python_skeleton(text.encode("utf-8"))      # 1-based строки скелета относительно text
+    lines = text.splitlines()
+    if nums:
+        body = "\n".join(lines[n - 1].rstrip() for n in nums if 1 <= n <= len(lines))
+    else:
+        body = "\n".join(ln.rstrip() for ln in lines)
+    return hashlib.sha256(body.strip().encode("utf-8")).hexdigest()
+```
+
+- [ ] **Step 4: Запустить — убедиться, что проходят**
+
+Run: `.venv/bin/pytest tests/index/test_chunker.py -q`
+Expected: PASS (все, включая существующие `python_skeleton`-тесты).
+
+- [ ] **Step 5: Линт + коммит**
+
+```bash
+.venv/bin/ruff check reviewer/index/chunker.py tests/index/test_chunker.py
+git add reviewer/index/chunker.py tests/index/test_chunker.py
+git commit -m "feat(index): symbol_skeleton_hash — хэш структурного скелета символа (PRI-165)"
+```
+
+---
+
+### Task 2: `list_base_members` отдаёт `skeleton_hash`; `SummaryStore.get_updated_ats`
+
+**Files:**
+- Modify: `reviewer/index/store.py:202-210` (`list_base_members`)
+- Modify: `reviewer/index/summary_store.py` (добавить `get_updated_ats` после `get_source_hashes`, ~строка 65)
+- Test: `tests/index/test_summary_store.py` (integration; `pytestmark = pytest.mark.integration`)
+
+**Interfaces:**
+- Consumes: `symbol_skeleton_hash(text)` (Task 1); существующий `reviewer.index.refs.base_ref`.
+- Produces:
+  - `ChunkStore.list_base_members(repo, branch) -> list[tuple[path, fqn, content_hash, start_line, skeleton_hash]]` (5-кортеж; позиции 0–3 без изменений).
+  - `SummaryStore.get_updated_ats(repo, branch) -> dict[str, datetime]` — `updated_at` по `cluster_key`; нет таблицы → `{}`. Потребляются в Task 3 (`service`).
+
+**Примечание о порядке:** этот таск — продюсер 5-кортежа. До Task 3 `service` ещё распаковывает 4-кортеж, поэтому **реальный** `list_subsystem_clusters` между Task 2 и Task 3 несогласован. Unit-suite остаётся зелёным (service-тесты мокают `list_base_members`); согласованность реального пути закрывает Task 3. Не запускать реальный MCP между Task 2 и Task 3.
+
+- [ ] **Step 1: Обновить integration-тесты (падающие)**
+
+В `tests/index/test_summary_store.py`: расширить `test_list_base_members_reads_base_ref_rows` и добавить тест `get_updated_ats`:
+
+```python
+def test_list_base_members_reads_base_ref_rows():
+    from reviewer.index.store import ChunkStore, ChunkRow
+    from reviewer.index.chunker import symbol_skeleton_hash
+    cs = ChunkStore(DSN)
+    cs.init_schema()
+    cs.upsert([ChunkRow(repo="t/t", ref="base:dev", content_hash="h", path="reviewer/x/a.py",
+                        lang="python", symbol_fqn="A", kind="function",
+                        start_line=3, end_line=9, text="def a(): ...", embedding=[0.0]*1024)])
+    try:
+        members = cs.list_base_members("t/t", "dev")
+        # 5-кортеж: skeleton_hash считается на лету из text
+        assert ("reviewer/x/a.py", "A", "h", 3, symbol_skeleton_hash("def a(): ...")) in members
+    finally:
+        cs.delete_ref("t/t", "base:dev")
+        cs.close()
+
+
+def test_get_updated_ats_returns_datetime_per_cluster(store):
+    from datetime import datetime
+    store.upsert_summary("t/t", "dev", "reviewer/index", "A", "s", [], "h1")
+    ats = store.get_updated_ats("t/t", "dev")
+    assert "reviewer/index" in ats
+    assert isinstance(ats["reviewer/index"], datetime)   # сырой datetime, не isoformat
+```
+
+- [ ] **Step 2: Запустить — убедиться, что падают** (нужен Postgres: `docker compose up -d`)
+
+Run: `.venv/bin/pytest -m integration tests/index/test_summary_store.py -q`
+Expected: FAIL — `test_list_base_members...` падает на 4-кортеже vs 5-кортеж; `test_get_updated_ats...` падает на `AttributeError: get_updated_ats`.
+
+- [ ] **Step 3: Реализовать `list_base_members` (5-кортеж)**
+
+Заменить `reviewer/index/store.py:202-210` на:
+
+```python
+    def list_base_members(self, repo: str, branch: str
+                          ) -> list[tuple[str, str, str, int, str]]:
+        """Состав base-индекса ветки для кластеризации подсистем (PRI-159):
+        (path, symbol_fqn, content_hash, start_line, skeleton_hash) для ref=base:<branch>.
+        skeleton_hash (PRI-165) считается на лету из text символа — ключ свежести сводок
+        по структуре (правка тела не ре-стейлит)."""
+        from reviewer.index.refs import base_ref
+        from reviewer.index.chunker import symbol_skeleton_hash
+        with self._connect() as conn:
+            rows = conn.execute(
+                "SELECT path, symbol_fqn, content_hash, start_line, text FROM chunks "
+                "WHERE repo=%s AND ref=%s", (repo, base_ref(branch))).fetchall()
+        return [(p, s, h, sl, symbol_skeleton_hash(t)) for p, s, h, sl, t in rows]
+```
+
+- [ ] **Step 4: Реализовать `get_updated_ats`**
+
+В `reviewer/index/summary_store.py` после `get_source_hashes` (после строки 65) добавить:
+
+```python
+    def get_updated_ats(self, repo: str, branch: str) -> dict[str, "datetime"]:
+        """updated_at по cluster_key — для упорядочивания stale-кластеров под cap (PRI-165:
+        без сводки → старейшие первыми). Нет таблицы → {} (fail-soft, как get_source_hashes)."""
+        try:
+            with self._connect() as conn:
+                rows = conn.execute(
+                    "SELECT cluster_key, updated_at FROM subsystem_summaries "
+                    "WHERE repo=%s AND branch=%s", (repo, branch)).fetchall()
+        except psycopg.errors.UndefinedTable:
+            return {}
+        return {k: u for k, u in rows}
+```
+
+Добавить импорт для аннотации в начало файла (после строки 8 `import threading`):
+
+```python
+from datetime import datetime
+```
+
+И заменить аннотацию возврата на `dict[str, datetime]` (убрать кавычки вокруг `datetime`).
+
+- [ ] **Step 5: Запустить — убедиться, что проходят**
+
+Run: `.venv/bin/pytest -m integration tests/index/test_summary_store.py -q`
+Expected: PASS.
+
+- [ ] **Step 6: Линт + коммит**
+
+```bash
+.venv/bin/ruff check reviewer/index/store.py reviewer/index/summary_store.py tests/index/test_summary_store.py
+git add reviewer/index/store.py reviewer/index/summary_store.py tests/index/test_summary_store.py
+git commit -m "feat(index): list_base_members отдаёт skeleton_hash + SummaryStore.get_updated_ats (PRI-165)"
+```
+
+---
+
+### Task 3: freshness по `skeleton_hash` в `summaries`/`service` + cap
+
+**Files:**
+- Modify: `reviewer/graph/summaries.py` (`Member` :14-19, `compute_source_hash` :44-50 докстринг, `build_clusters` :87)
+- Modify: `reviewer/config/settings.py:71` (добавить поле после `summary_cluster_depth`)
+- Modify: `reviewer/mcp/service.py` (`list_subsystem_clusters` :419-447, `index_subsystem_summary` :466-469)
+- Test: `tests/graph/test_summaries.py`, `tests/mcp/test_subsystem_summaries.py`
+
+**Interfaces:**
+- Consumes: `list_base_members` 5-кортеж + `get_updated_ats` (Task 2); `Settings.summary_rebuild_cap`.
+- Produces:
+  - `Member(node_id, path, content_hash, skeleton_hash, start_line)` (новое поле `skeleton_hash`).
+  - `build_clusters` `source_hash` теперь из `skeleton_hash`.
+  - `list_subsystem_clusters(repo, branch=None, depth=None, min_size=None, cap=None) -> {"branch", "deferred", "clusters":[{cluster_key, num_members, files, top_symbols, source_hash, stale}]}` — cap отбрасывает наименее приоритетные stale.
+  - `index_subsystem_summary` — consistency-check на `skeleton_hash`.
+
+- [ ] **Step 1: Тесты `summaries` (падающие)**
+
+В `tests/graph/test_summaries.py` обновить `_m` (строки 6-7) и добавить тест freshness:
+
+```python
+def _m(node_id, path, h="h", line=1, sk=None):
+    return Member(node_id=node_id, path=path, content_hash=h, start_line=line,
+                  skeleton_hash=sk if sk is not None else h)
+
+
+def test_build_clusters_source_hash_uses_skeleton_not_body():
+    base = [_m("p/a.py#A", "p/a.py", h="body1", sk="sig1"),
+            _m("p/b.py#B", "p/b.py", h="body2", sk="sig2")]
+    [c0] = build_clusters(base, None, depth=1)
+    # правка только тела (skeleton тот же) → тот же source_hash
+    body = [_m("p/a.py#A", "p/a.py", h="BODYX", sk="sig1"),
+            _m("p/b.py#B", "p/b.py", h="body2", sk="sig2")]
+    [c1] = build_clusters(body, None, depth=1)
+    assert c1.source_hash == c0.source_hash
+    # смена сигнатуры (skeleton изменился) → другой source_hash
+    sig = [_m("p/a.py#A", "p/a.py", h="body1", sk="SIGX"),
+           _m("p/b.py#B", "p/b.py", h="body2", sk="sig2")]
+    [c2] = build_clusters(sig, None, depth=1)
+    assert c2.source_hash != c0.source_hash
+```
+
+- [ ] **Step 2: Запустить — убедиться, что падают**
+
+Run: `.venv/bin/pytest tests/graph/test_summaries.py -q`
+Expected: FAIL — `TypeError: __init__() got an unexpected keyword argument 'skeleton_hash'`.
+
+- [ ] **Step 3: Реализовать `summaries.py`**
+
+`reviewer/graph/summaries.py` — `Member` (строки 14-19): добавить поле `skeleton_hash`:
+
+```python
+@dataclass
+class Member:
+    node_id: str          # "path#fqn"
+    path: str
+    content_hash: str
+    skeleton_hash: str    # хэш структурного скелета — ключ свежести по структуре (PRI-165)
+    start_line: int
+```
+
+`compute_source_hash` (строки 44-50) — обновить докстринг (логика без изменений):
+
+```python
+def compute_source_hash(items: list[tuple[str, str]]) -> str:
+    """sha256 от sorted("node_id:skeleton_hash") — детерминированный ключ свежести.
+
+    Меняется при изменении состава кластера или СТРУКТУРЫ его членов (сигнатуры/docstring),
+    но НЕ при правке тела (PRI-165: вход — skeleton_hash, не content_hash). Сортировка пар
+    делает ключ независимым от порядка членов."""
+    joined = "\n".join(sorted(f"{nid}:{h}" for nid, h in items))
+    return hashlib.sha256(joined.encode("utf-8")).hexdigest()
+```
+
+`build_clusters` (строка 87): заменить `m.content_hash` на `m.skeleton_hash`:
+
+```python
+            source_hash=compute_source_hash([(m.node_id, m.skeleton_hash) for m in ms]),
+```
+
+- [ ] **Step 4: Запустить — `summaries` проходят**
+
+Run: `.venv/bin/pytest tests/graph/test_summaries.py -q`
+Expected: PASS.
+
+- [ ] **Step 5: Добавить поле в `Settings`**
+
+`reviewer/config/settings.py` — после строки 71 (`summary_cluster_depth`) добавить:
+
+```python
+    summary_rebuild_cap: int | None = None   # макс. кластеров на пересборку за проход
+    # (PRI-165); None/0 = безлимит; env SUMMARY_REBUILD_CAP
+```
+
+- [ ] **Step 6: Тесты `service` (падающие)**
+
+В `tests/mcp/test_subsystem_summaries.py`:
+1. Во ВСЕХ моках `list_base_members.return_value` заменить 4-кортежи на 5-кортежи (добавить 5-й элемент — skeleton_hash). Пример для `test_list_subsystem_clusters_marks_stale`:
+
+```python
+    c.store.list_base_members.return_value = [
+        ("reviewer/index/a.py", "A", "h1", 1, "sk1"),
+        ("reviewer/index/b.py", "B", "h2", 2, "sk2"),
+    ]
+```
+
+2. В `test_list_subsystem_clusters_fresh_when_hash_matches` мок → 5-кортеж и эталон от `skeleton_hash`:
+
+```python
+    c.store.list_base_members.return_value = [("reviewer/index/a.py", "A", "h1", 1, "sk1")]
+    c.graph = None
+    from reviewer.graph.summaries import compute_source_hash
+    sh = compute_source_hash([("reviewer/index/a.py#A", "sk1")])   # по skeleton_hash, не "h1"
+    c.summary_store.get_source_hashes.return_value = {"reviewer/index": sh}
+```
+
+3. В `test_index_and_get_subsystem_summaries_roundtrip_via_store` мок → 5-кортежи, эталон `sh` от skeleton_hash (5-й элемент):
+
+```python
+    c.store.list_base_members.return_value = [
+        ("reviewer/index/a.py", "A", "h1", 1, "sk1"),
+        ("reviewer/index/b.py", "B", "h2", 2, "sk2"),
+    ]
+    sh = compute_source_hash([("reviewer/index/a.py#A", "sk1"),
+                              ("reviewer/index/b.py#B", "sk2")])
+```
+
+4. В `test_index_subsystem_summary_stale_hash_empties_members` мок → 5-кортеж:
+
+```python
+    c.store.list_base_members.return_value = [("reviewer/index/a.py", "A", "h1", 1, "sk1")]
+```
+
+5. Добавить тесты cap + порядка:
+
+```python
+def test_list_subsystem_clusters_cap_defers_lowest_priority():
+    from datetime import datetime
+    c = MagicMock()
+    # три кластера-одиночки (depth=2 даёт разные ключи), все stale
+    c.store.list_base_members.return_value = [
+        ("a/x/f.py", "F", "h", 1, "skf"),
+        ("b/y/g.py", "G", "h", 1, "skg"),
+        ("c/z/h.py", "H", "h", 1, "skh"),
+    ]
+    c.graph = None
+    c.summary_store.get_source_hashes.return_value = {}          # все stale
+    # a/x — без сводки (нет в updated); b/y старее c/z
+    c.summary_store.get_updated_ats.return_value = {
+        "b/y": datetime(2026, 1, 1), "c/z": datetime(2026, 6, 1)}
+    svc = _svc(c)
+    out = svc.list_subsystem_clusters("o/n", "dev", min_size=1, cap=2)
+    keys = {cl["cluster_key"] for cl in out["clusters"]}
+    assert out["deferred"] == 1
+    assert keys == {"a/x", "b/y"}        # без сводки + старейший; c/z отложен
+
+
+def test_list_subsystem_clusters_no_cap_returns_all():
+    c = MagicMock()
+    c.store.list_base_members.return_value = [
+        ("a/x/f.py", "F", "h", 1, "skf"), ("b/y/g.py", "G", "h", 1, "skg")]
+    c.graph = None
+    c.summary_store.get_source_hashes.return_value = {}
+    svc = _svc(c)
+    out = svc.list_subsystem_clusters("o/n", "dev", min_size=1)   # cap=None
+    assert out["deferred"] == 0
+    assert len(out["clusters"]) == 2
+    c.summary_store.get_updated_ats.assert_not_called()           # порядок не нужен без cap
+```
+
+- [ ] **Step 7: Запустить — `service` падают**
+
+Run: `.venv/bin/pytest tests/mcp/test_subsystem_summaries.py -q`
+Expected: FAIL — `list_subsystem_clusters` ещё распаковывает 4-кортеж / нет `cap`/`deferred`.
+
+- [ ] **Step 8: Реализовать `list_subsystem_clusters`**
+
+Заменить `reviewer/mcp/service.py:419-447` на:
+
+```python
+    def list_subsystem_clusters(self, repo: str, branch: str | None = None,
+                                depth: int | None = None, min_size: int | None = None,
+                                cap: int | None = None) -> dict:
+        """Кластеризовать base-граф по модулям → кластеры для /summarize-subsystems.
+        cap (дефолт Settings.summary_rebuild_cap; None/0=безлимит) отбрасывает наименее
+        приоритетные stale-кластеры (без сводки → старейшие updated_at первыми) и считает
+        их в deferred (PRI-165)."""
+        from reviewer.graph.summaries import Member, build_clusters
+        rb = self._resolve_repo_branch(repo, branch)
+        if isinstance(rb, str):
+            return {"clusters": [], "note": rb}
+        repo, resolved = rb
+        raw = self.components.store.list_base_members(repo, resolved)
+        if not raw:
+            return {"clusters": [],
+                    "note": "(base-индекс пуст — выполните /reviewer_sync-codebase)"}
+        members = [Member(node_id=f"{p}#{s}", path=p, content_hash=h, start_line=sl,
+                          skeleton_hash=sk)
+                   for p, s, h, sl, sk in raw]
+        graph = self.components.graph
+        in_degree_fn = (
+            (lambda ids: graph.in_degree(repo, ids, branch=resolved))
+            if graph is not None else None)
+        clusters = build_clusters(
+            members, in_degree_fn,
+            depth=depth or self.settings.summary_cluster_depth,
+            min_size=min_size or 1)
+        stored = self.components.summary_store.get_source_hashes(repo, resolved)
+        stale = {c.key: (stored.get(c.key) != c.source_hash) for c in clusters}
+        effective_cap = cap if cap is not None else self.settings.summary_rebuild_cap
+        deferred_keys: set[str] = set()
+        if effective_cap and effective_cap > 0:
+            stale_cl = [c for c in clusters if stale[c.key]]
+            if len(stale_cl) > effective_cap:
+                updated = self.components.summary_store.get_updated_ats(repo, resolved)
+                never = [c for c in stale_cl if c.key not in updated]      # без сводки — первыми
+                aged = sorted((c for c in stale_cl if c.key in updated),
+                              key=lambda c: updated[c.key])                # старейшие — раньше
+                deferred_keys = {c.key for c in (never + aged)[effective_cap:]}
+        return {"branch": resolved, "deferred": len(deferred_keys), "clusters": [
+            {"cluster_key": c.key, "num_members": c.num_members, "files": c.files,
+             "top_symbols": c.top_symbols, "source_hash": c.source_hash,
+             "stale": stale[c.key]}
+            for c in clusters if c.key not in deferred_keys]}
+```
+
+- [ ] **Step 9: Реализовать `index_subsystem_summary` (skeleton-консистентность)**
+
+В `reviewer/mcp/service.py` заменить строки 466-469 (внутри `index_subsystem_summary`):
+
+```python
+        raw = self.components.store.list_base_members(repo, resolved)
+        members = [(f"{p}#{s}", sk) for p, s, _h, _sl, sk in raw
+                   if cluster_key_of(p, depth) == cluster_key]
+        consistent = compute_source_hash(members) == source_hash
+```
+
+(было: `for p, s, h, _ in raw` и пара `(f"{p}#{s}", h)` — теперь 5-кортеж и `skeleton_hash`, синхронно с `build_clusters`.)
+
+- [ ] **Step 10: Запустить — весь unit-suite зелёный**
+
+Run: `.venv/bin/pytest tests/mcp/test_subsystem_summaries.py tests/graph/test_summaries.py -q`
+Expected: PASS.
+Run (полный unit-прогон — ничего не сломали): `.venv/bin/pytest -q`
+Expected: PASS.
+
+- [ ] **Step 11: Линт + коммит**
+
+```bash
+.venv/bin/ruff check reviewer/graph/summaries.py reviewer/config/settings.py reviewer/mcp/service.py tests/graph/test_summaries.py tests/mcp/test_subsystem_summaries.py
+git add reviewer/graph/summaries.py reviewer/config/settings.py reviewer/mcp/service.py tests/graph/test_summaries.py tests/mcp/test_subsystem_summaries.py
+git commit -m "feat(mcp): freshness сводок по skeleton_hash + cap пересборок (PRI-165)"
+```
+
+- [ ] **Step 12: Integration-санити (нужен Postgres) — реальный путь снова согласован**
+
+Run: `docker compose up -d && .venv/bin/pytest -m integration tests/index/test_summary_store.py -q`
+Expected: PASS (закрывает «не запускать реальный MCP между Task 2 и Task 3» — теперь согласовано).
+
+---
+
+### Task 4: скилл `summarize-subsystems` — репорт `deferred` + выбор модели
+
+**Files:**
+- Modify: `plugin/skills/summarize-subsystems/SKILL.md` (шаги 2–4 + новый шаг выбора модели)
+- Test: `tests/skills/` (существующий guard — должен остаться зелёным)
+
+**Interfaces:**
+- Consumes: `list_subsystem_clusters(...) -> {..., "deferred": int, "clusters": [...]}` (Task 3).
+- Produces: инструкции скилла (репорт `deferred`; выбор дешёвой модели; диспатч summary-субагентов где харнесс умеет). Изменения только в прозе промпта; `<!-- include: ... -->`-маркеры сохраняются.
+
+- [ ] **Step 1: Зафиксировать базовое состояние guard-теста**
+
+Run: `.venv/bin/pytest tests/skills/ -q`
+Expected: PASS (до правок).
+
+- [ ] **Step 2: Переписать шаги Pipeline в `SKILL.md`**
+
+Заменить блок «## Pipeline» (строки 21–48, до «## Grounding (hard rule)») на:
+
+````markdown
+## Pipeline
+
+1. **Resolve repo/branch.**
+
+<!-- include: _common/branch-selection.md -->
+
+2. **List clusters.** Call `list_subsystem_clusters(repo, branch)`. Empty / `note` about an empty
+   index → tell the user (in Russian) to run `/reviewer_sync-codebase` first, then stop. The response
+   also carries `deferred` — the number of stale clusters the server held back this pass under the
+   cost cap (env `SUMMARY_REBUILD_CAP`); the `clusters` it returns are already capped, so just process
+   them and report `deferred` in step 4.
+
+3. **Choose the summary model (only if any cluster is `stale == true`).** A subsystem summary is a
+   coarse, high-level prior — a small/cheap model is appropriate, and reviewing on an expensive model
+   burns tokens. Ask the user which model tier to use for writing summaries, defaulting to a cheap
+   tier (e.g. Haiku/Sonnet/Fable). Remember the choice for this run. If nothing is stale, skip this
+   step (nothing to generate).
+
+4. **Summarize only STALE clusters.** For each cluster with `stale == true` (fresh ones are already
+   up to date — skip them, this keeps the pass incremental and cheap):
+   - Where your harness supports per-subagent model override, **dispatch a subagent on the chosen
+     model** to read a few representative files (from `files` / `top_symbols`) and return
+     `{title, summary}` (Russian, grounded — see Grounding below); the orchestrator then persists it.
+     Where override is unavailable, write the summary inline on the session model and note this in the
+     report. Either way:
+     - `title` — one line: what this subsystem is.
+     - `summary` — a compact paragraph: what it does, its key symbols (from `top_symbols`) and
+       invariants. No `path:line` required; it is a high-level prior.
+   - Persist: `index_subsystem_summary(repo, branch, cluster_key, title, summary, source_hash)` —
+     pass back the cluster's own `source_hash` from step 2.
+
+5. **Report (Russian).** How many clusters summarized vs skipped-as-fresh vs **deferred by the cap**
+   (`deferred` from step 2 — never silently truncate). If summaries were written inline (no model
+   override), say so.
+````
+
+(Существующая нумерация шага «4. Report» становится шагом 5; `<!-- include: _common/branch-selection.md -->` сохранён в шаге 1.)
+
+- [ ] **Step 3: Запустить guard-тест**
+
+Run: `.venv/bin/pytest tests/skills/ -q`
+Expected: PASS (маркеры include не тронуты, сборка промпта валидна).
+
+- [ ] **Step 4: Полный unit-прогон (регрессия)**
+
+Run: `.venv/bin/pytest -q`
+Expected: PASS.
+
+- [ ] **Step 5: Коммит**
+
+```bash
+git add plugin/skills/summarize-subsystems/SKILL.md
+git commit -m "feat(skills): summarize-subsystems — репорт deferred + выбор модели для сводок (PRI-165)"
+```
+
+---
+
+## Self-Review (выполнено автором плана)
+
+**1. Покрытие спеки:**
+- Freshness по скелету → Task 1 (`symbol_skeleton_hash`) + Task 3 (`build_clusters` использует `skeleton_hash`). ✓
+- skeleton-хэш на лету (без миграции) → Task 2 (`list_base_members` SELECT `text`). ✓
+- Оба call-site синхронно → Task 3 Steps 8–9 (`list_subsystem_clusters` + `index_subsystem_summary`). ✓
+- Cap server-side + порядок (без сводки → старейшие) + `deferred` → Task 3 Step 8 + тесты Step 6. ✓
+- `updated_at` для порядка → Task 2 (`get_updated_ats`). ✓
+- `Settings.summary_rebuild_cap` → Task 3 Step 5. ✓
+- Выбор модели + диспатч + репорт `deferred` → Task 4. ✓
+- Тесты (критерии приёмки 1–3): Task 1 (сигнатура vs тело vs позиция), Task 3 (body-only не ре-стейлит / cap / порядок / consistency). ✓
+- Инвариант позиционной независимости → Task 1 `test_skeleton_hash_is_position_independent`. ✓
+- Одноразовый шторм при апгрейде — поведенческий, гасится cap'ом; зафиксирован в спеке + репорте скилла (Task 4 шаг 5). ✓
+
+**2. Плейсхолдеры:** нет — каждый шаг содержит полный код/команды.
+
+**3. Согласованность типов:** `Member(node_id, path, content_hash, skeleton_hash, start_line)` — конструируется в `service` (Task 3 Step 8, kwargs) и `_m` (Task 3 Step 1, kwargs). `list_base_members` 5-кортеж `(path, fqn, content_hash, start_line, skeleton_hash)` — продюсер Task 2, потребители Task 3 (`for p,s,h,sl,sk`) и `index_subsystem_summary` (`for p,s,_h,_sl,sk`). `compute_source_hash` сигнатура неизменна. `get_updated_ats -> dict[str, datetime]`. Порядок зелёности per-task задокументирован (unit мокает границу store↔service).
+
+## Execution Handoff

--- a/docs/superpowers/specs/2026-06-23-pri-165-summary-skeleton-freshness-design.md
+++ b/docs/superpowers/specs/2026-06-23-pri-165-summary-skeleton-freshness-design.md
@@ -1,0 +1,218 @@
+# PRI-165 — Сводки подсистем (C): freshness по структуре + cap/выбор модели — дизайн
+
+**Задача:** PRI-165 (ID-165), оценка M. Слой: Движок (`reviewer/graph/summaries.py` + store + скилл
+`summarize-subsystems`) — стоимость/надёжность под прод-масштаб.
+**Порядок программы:** первая из трёх связанных задач (**C (эта) → B (PRI-166) → A (PRI-167)**).
+**Связи:** PRI-159 (community summaries — фича, которую правим), PRI-154 (`python_skeleton` — переиспользуем).
+**Ветка работы:** фича-ветка от `dev` (напр. `feat/pri-165-summary-skeleton-freshness`), PR → `dev`.
+
+## Проблема
+
+`source_hash` кластера сводки (`reviewer/graph/summaries.py:44,87`) = `sha256` от множества пар
+`(node_id, content_hash)` всех членов, где `content_hash` (`reviewer/index/models.py:19`) — хэш
+**полного** нормализованного текста символа (заголовок + тело). → **любая** правка тела (багфикс,
+рефактор внутри функции) меняет `content_hash` → ре-стейлит **весь** грубый кластер (при `depth=2`
+кластер = целый пакет) → LLM-скилл пересобирает сводку, хотя публичная поверхность подсистемы не
+менялась. На проде с авто-реиндексом и частыми коммитами это даёт постоянный LLM-churn (стоимость +
+латентность). Сейчас спасает только ручной запуск `/summarize-subsystems`, но на проде его привяжут
+к реиндексу/крону.
+
+**Критерии приёмки (из задачи):**
+1. body-only правка члена **НЕ** ре-стейлит кластер; add/remove члена или смена сигнатуры — ре-стейлит.
+2. cap ограничивает число LLM-пересборок за проход и репортит число отложенных.
+3. unit на новой freshness-функции: смена сигнатуры vs смена только тела.
+
+## Решения (зафиксированы на brainstorming)
+
+1. **Freshness по скелету, а не по телу.** Ключ свежести члена считать от **структурного скелета**
+   (сигнатуры `def`/`class` до `:`, первая строка docstring) через существующий `python_skeleton`
+   (PRI-154, `reviewer/index/chunker.py:46`), а не от полного `content_hash`. Body-only правка →
+   `skeleton_hash` тот же → не ре-стейлит.
+2. **Skeleton-хэш — на лету из текста чанка** (а не колонка в БД): `list_base_members` добавляет
+   `text` в `SELECT`, новый чистый хелпер считает `skeleton_hash` из текста символа. **Без миграции
+   схемы, без реиндекса, без расхода Voyage.** Цена — tree-sitter-парс на члена при вызове
+   `list_subsystem_clusters` (только путь скилла `summarize-subsystems`, не горячий).
+3. **Cap — server-side**, в `list_subsystem_clusters` (детерминированно, токен-дёшево, в духе
+   `sync_board`), а не дисциплиной LLM. Параметр `cap`, дефолт из `Settings` (env `SUMMARY_REBUILD_CAP`),
+   **дефолт `None` = безлимит** (текущее поведение без явной настройки не меняется).
+4. **Порядок stale для cap:** кластеры **без сохранённой сводки** (`updated_at IS NULL`) — первыми
+   (пропущенные хуже устаревших), затем по `updated_at` по возрастанию (дольше всех не обновлялись).
+5. **Выбор модели для генерации сводок — спросить при запуске, дешёвый дефолт.** Скилл спрашивает
+   тир модели (дефолт — дешёвый: Haiku/Sonnet/Fable; сводка — грубый приор, точность не критична) и,
+   где харнесс умеет per-subagent override (Claude Code), диспатчит per-cluster summary-субагентов на
+   выбранной модели; где не умеет — пишет inline на модели сессии с пометкой. Формулировки в `SKILL.md`
+   — харнес-нейтральные («dispatch a subagent»). cap × модель = двойной контроль стоимости.
+6. **Гранулярность — атомарная пересборка кластера** (одна сводка на кластер, при stale — целиком).
+   Дельта-суммаризация (патч сводки по изменённым членам) — **не делаем** (риск дрейфа, scope > M);
+   радиус пересборки независимо дробит PRI-166 (depth).
+7. **Кадэнс (пункт 3 задачи) — вне объёма** (оркестрация запуска: крон/триггер), follow-up.
+
+## Инвариант: skeleton-хэш позиционно- и порядко-независим
+
+Ключевая корректность фичи: сдвиг/перенос символа **не должен** ре-стейлить. Гарантируется тем, что:
+- `node_id = path#fqn` (`models.py:15`) — **без номера строки**; `start_line` **не входит** в
+  `compute_source_hash`;
+- `symbol_skeleton_hash` хэширует **нормализованный текст** строк скелета (rstrip, как `content_hash`),
+  **а не их номера** — позиция символа в файле в хэш не протекает;
+- `compute_source_hash` **сортирует** пары перед хэшированием (`summaries.py:49`) → порядок членов в
+  кластере не важен (множество).
+
+| Изменение | Ре-стейлит? | Почему |
+|---|---|---|
+| Сдвиг символа по файлу (пустые строки/комменты вокруг) | нет | текст скелета и `fqn` те же |
+| Реордеринг символов | нет | `compute_source_hash` сортирует множество |
+| Правка тела / переформатирование тела | нет | строки скелета не изменились |
+| Смена сигнатуры / 1-й строки docstring | **да** | строка скелета изменилась |
+| Add/remove символа | **да** | изменился состав множества `node_id` |
+| Перенос символа в другой файл / в класс (fqn `Class.method`) | **да** | `node_id` изменился |
+
+## Разграничение: вектор-поиск НЕ затрагивается
+
+PRI-165 трогает **только** ключ свежести сводок. Эмбеддинги/ретрив остаются как есть:
+
+| Механизм | Над чем | Меняет PRI-165? |
+|---|---|---|
+| Эмбеддинг / вектор-поиск | полный текст чанка (заголовок+тело) | нет |
+| `content_hash` (дедуп/реюз эмбеддингов) | полный текст чанка | нет |
+| `node_id = path#fqn` (связь RAG↔граф) | — | нет |
+| **`skeleton_hash`** (новый, на лету) | только строки скелета | **да (только это)** |
+
+Body-only правка по-прежнему переэмбеддит этот один чанк при реиндексе (вектор-поиск свеж), но
+сводку кластера не дёргает.
+
+## Компоненты
+
+| Компонент | Тип | Роль |
+|---|---|---|
+| `reviewer/index/chunker.py` | правка | новый чистый хелпер `symbol_skeleton_hash(text: str) -> str` рядом с `python_skeleton` (там tree-sitter; `summaries.py` остаётся без tree-sitter) |
+| `reviewer/index/store.py` | правка | `ChunkStore.list_base_members` — добавить `text` в `SELECT`, вернуть 5-кортеж со `skeleton_hash` |
+| `reviewer/graph/summaries.py` | правка | `Member.skeleton_hash`; `build_clusters` подаёт `skeleton_hash` в `compute_source_hash`; докстринг `compute_source_hash` |
+| `reviewer/mcp/service.py` | правка | `list_subsystem_clusters`: cap + порядок + `deferred` + `updated_at`; `index_subsystem_summary`: consistency-check на `skeleton_hash` |
+| `reviewer/index/summary_store.py` | правка | выдать `updated_at` по `cluster_key` для упорядочивания stale |
+| `reviewer/config/settings.py` (Settings) | правка | `summary_rebuild_cap: int \| None = None` (env `SUMMARY_REBUILD_CAP`), рядом с `summary_cluster_depth` |
+| `plugin/skills/summarize-subsystems/SKILL.md` | правка | репорт `deferred` (cap); выбор модели при запуске + диспатч summary-субагентов |
+
+## Контракты
+
+### `reviewer/index/chunker.py` — `symbol_skeleton_hash(text: str) -> str`
+
+```python
+def symbol_skeleton_hash(text: str) -> str:
+    """Хэш структурного скелета символа: сигнатуры def/class (до ':') + 1-я строка docstring.
+    Позиция/порядок в хэш не входят — берётся ТЕКСТ строк скелета, не их номера.
+    Пустой скелет (битый код / нет определений) → fallback на нормализованный полный текст."""
+    nums = python_skeleton(text.encode("utf-8"))     # 1-based строки скелета относительно text
+    lines = text.splitlines()
+    if nums:
+        body = "\n".join(lines[n - 1].rstrip() for n in nums if 1 <= n <= len(lines))
+    else:
+        body = "\n".join(l.rstrip() for l in lines)  # fallback — как content_hash
+    return hashlib.sha256(body.strip().encode("utf-8")).hexdigest()
+```
+Нормализация (`rstrip` строк + `strip`) — та же, что у `Chunk.content_hash` (`models.py:20`), чтобы
+скелет-ключ был согласованным подмножеством. `python_skeleton` не падает на битом коде → fallback
+покрывает редкий случай чанка без распознанных определений (для def/class-чанков не наступает).
+
+### `ChunkStore.list_base_members(repo, branch) -> list[tuple[path, fqn, content_hash, start_line, skeleton_hash]]`
+
+`SELECT path, symbol_fqn, content_hash, start_line, text FROM chunks WHERE repo=%s AND ref=%s`
+(`ref=base:<branch>`). Для каждой строки `skeleton_hash = symbol_skeleton_hash(text)`. Возврат —
+**5-кортеж**: существующие позиции 0–3 без изменений (обратная совместимость распаковки), `skeleton_hash`
+добавлен 5-м элементом. `text` наружу не отдаётся (только источник хэша). `content_hash` сохранён в
+кортеже (читатели вне freshness; в самом freshness больше не участвует).
+
+### `reviewer/graph/summaries.py`
+
+- `@dataclass Member`: добавить `skeleton_hash: str` (после `content_hash`).
+- `build_clusters` (строка 87): `source_hash=compute_source_hash([(m.node_id, m.skeleton_hash) for m in ms])`.
+- `compute_source_hash` — **код без изменений** (хэширует пары `id:hash`); обновить докстринг
+  («content_hash» → «skeleton_hash — ключ свежести по структуре»).
+
+### `reviewer/mcp/service.py`
+
+- `list_subsystem_clusters(repo, branch=None, depth=None, min_size=None, cap=None) -> dict`:
+  - `cap` дефолтится в `self.settings.summary_rebuild_cap` (если параметр `None`).
+  - `Member(... skeleton_hash=sk ...)` из 5-кортежа `list_base_members`.
+  - `stored = summary_store.get_source_hashes(...)`, `updated = summary_store.get_updated_ats(...)`
+    (новый метод, см. ниже). `stale = stored.get(key) != c.source_hash`.
+  - **Cap:** если `cap` задан (не `None`) и число stale > `cap` — отсортировать stale по
+    `(updated_at is not None, updated_at)` (None/нет-сводки первыми, затем `updated_at` возр.), взять
+    первые `cap`, остальные stale **исключить** из `clusters`; `deferred = len(stale) - cap`.
+    Свежие (`stale=false`) кластеры в `clusters` остаются всегда. `cap=None` → ничего не исключаем,
+    `deferred=0`.
+  - Возврат: `{"branch": resolved, "clusters": [...], "deferred": <int>}` (каждый кластер как сейчас:
+    `cluster_key, num_members, files, top_symbols, source_hash, stale`).
+- `index_subsystem_summary` (строки 466–470): `members` строить из **`skeleton_hash`** (5-й элемент
+  5-кортежа), а не `content_hash`: `members = [(f"{p}#{s}", sk) for p, s, _h, _sl, sk in raw if
+  cluster_key_of(p, depth) == cluster_key]`. **Синхронно** с `build_clusters` — иначе consistency-check
+  (`compute_source_hash(members) == source_hash`) разъедется и `member_node_ids` всегда будут `[]`.
+
+### `reviewer/index/summary_store.py`
+
+- Новый `get_updated_ats(repo, branch) -> dict[cluster_key, datetime]` (или расширить
+  `get_source_hashes` до `dict[cluster_key, tuple[source_hash, updated_at]]`). `updated_at` уже хранится
+  (`subsystem_summaries.updated_at`). Отсутствие таблицы → `{}` (fail-soft, как `get_source_hashes`).
+
+### `reviewer/config/settings.py` (Settings)
+
+- `summary_rebuild_cap: int | None = None` (env `SUMMARY_REBUILD_CAP`). Рядом с существующим
+  `summary_cluster_depth` (`settings.py:71`). `None`/0 трактуем как безлимит (нормализовать:
+  `cap if cap and cap > 0 else None`).
+
+### Скилл `plugin/skills/summarize-subsystems/SKILL.md`
+
+- **Шаг 2 (list):** `list_subsystem_clusters` теперь применяет cap server-side; в ответе поле `deferred`.
+- **Выбор модели (новый шаг, только если есть stale-кластеры):** спросить пользователя тир модели для
+  написания сводок; дефолт — дешёвый (с пояснением: сводка — высокоуровневый приор). Харнес-нейтрально.
+- **Шаг 3 (summarize):** для каждого stale-кластера — где харнесс умеет, **dispatch summary-субагента**
+  на выбранной модели: субагент `Read`'ит представительные файлы (`files`/`top_symbols`), возвращает
+  `{title, summary}` (RU, grounded; `_common/anti-hallucination.md` применяется к субагенту);
+  оркестратор персистит `index_subsystem_summary(..., source_hash)`. Где override нет — писать inline
+  на модели сессии, пометить в репорте.
+- **Шаг 4 (report, RU):** «N просуммировано, K пропущено как свежие, M отложено по cap (`deferred`)» —
+  без молчаливого усечения.
+
+## Обработка ошибок / краевые случаи
+
+- **Одноразовый «шторм» при апгрейде:** существующие сводки имеют `source_hash` от старого
+  (`content_hash`) входа. Первый проход после деплоя пересчитает `source_hash` от `skeleton_hash` → все
+  кластеры разово окажутся stale → одноразовая полная пересборка. Ожидаемо и приемлемо (далее —
+  стабильность по скелету). **cap естественно растягивает шторм** на несколько проходов; скилл репортит
+  `deferred`. Зафиксировать в `SKILL.md`-репорте.
+- Чанк без распознанных определений → `symbol_skeleton_hash` fallback на полный текст (безопасно: любая
+  правка ре-стейлит). Для def/class-чанков не наступает.
+- `depth`-mismatch consistency-check в `index_subsystem_summary` сохраняется (теперь над `skeleton_hash`).
+- Пустой base-индекс / нет таблицы summary → как сейчас (`{"clusters": [], "note": ...}`, fail-soft).
+- Всё per `(repo, branch)` — мульти-бранч/мульти-репо изоляция сохранена.
+- Где харнесс не даёт выбрать модель субагента — деградирует на модель сессии, без ошибки.
+
+## Тестирование
+
+- **Unit (ядро, критерий 3) — `tests/index/test_chunker.py`:** `symbol_skeleton_hash`:
+  - смена сигнатуры (новый параметр/аннотация) ⇒ **другой** хэш;
+  - правка только тела ⇒ **тот же** хэш;
+  - сдвиг символа (пустые строки вокруг тела) / переформатирование тела ⇒ **тот же** хэш
+    (позиционная независимость);
+  - смена 1-й строки docstring ⇒ другой хэш; fallback на чанке без определений.
+- **Unit — `tests/graph/test_summaries.py`:** `build_clusters` `source_hash` из `skeleton_hash`:
+  body-only (тот же `skeleton_hash`) ⇒ тот же `source_hash`; смена сигнатуры ⇒ другой; add/remove
+  члена ⇒ другой; реордеринг ⇒ тот же. Обновить конструирование `Member` (поле `skeleton_hash`).
+- **Unit — `tests/mcp/test_subsystem_summaries.py`:** моки `list_base_members` → 5-кортежи;
+  `index_subsystem_summary` консистентен на `skeleton_hash`; **cap**: при `cap=N` и >N stale — ровно N в
+  `clusters`, `deferred = stale-N`; **порядок**: кластер без сводки (нет в `get_source_hashes`/
+  `updated_at`) идёт раньше устаревшего; `cap=None` → ничего не отложено.
+- **Unit — `tests/index/test_summary_store.py`:** `list_base_members` отдаёт 5-кортеж со
+  `skeleton_hash`; `get_updated_ats` (или расширенный `get_source_hashes`).
+- **Guard-тест скилла** (`tests/skills/`): сборка промпта `summarize-subsystems` с раскрытием
+  `_common`-include'ов остаётся валидной после правок шагов.
+- **Integration** (маркер `integration`): round-trip `list_subsystem_clusters` с cap на реальном
+  Postgres — body-only правка не ре-стейлит, смена сигнатуры ре-стейлит.
+
+## Вне объёма (YAGNI / follow-up)
+
+- **Дельта-суммаризация** (патч сводки по изменённым членам, чтение только изменённых файлов) — отдельный
+  follow-up; риск дрейфа + scope > M.
+- **Кадэнс** (пункт 3: пересборка по расписанию/триггеру) — оркестрация запуска, follow-up.
+- **Колонка `skeleton_hash` в `chunks`** — не вводим; считаем на лету (без миграции/реиндекса).
+- **Embedding-экономия при body-only правках** — другой рычаг, другая задача.
+- **depth кластеризации** (радиус пересборки) — PRI-166 (B).

--- a/plugin/skills/summarize-subsystems/SKILL.md
+++ b/plugin/skills/summarize-subsystems/SKILL.md
@@ -25,20 +25,33 @@ Plus `list_subsystem_clusters` and `index_subsystem_summary` (reviewer MCP), and
 <!-- include: _common/branch-selection.md -->
 
 2. **List clusters.** Call `list_subsystem_clusters(repo, branch)`. Empty / `note` about an empty
-   index → tell the user (in Russian) to run `/reviewer_sync-codebase` first, then stop.
+   index → tell the user (in Russian) to run `/reviewer_sync-codebase` first, then stop. The response
+   also carries `deferred` — the number of stale clusters the server held back this pass under the
+   cost cap (env `SUMMARY_REBUILD_CAP`); the `clusters` it returns are already capped, so just process
+   them and report `deferred` in step 4.
 
-3. **Summarize only STALE clusters.** For each cluster with `stale == true` (fresh ones are already
+3. **Choose the summary model (only if any cluster is `stale == true`).** A subsystem summary is a
+   coarse, high-level prior — a small/cheap model is appropriate, and reviewing on an expensive model
+   burns tokens. Ask the user which model tier to use for writing summaries, defaulting to a cheap
+   tier (e.g. Haiku/Sonnet/Fable). Remember the choice for this run. If nothing is stale, skip this
+   step (nothing to generate).
+
+4. **Summarize only STALE clusters.** For each cluster with `stale == true` (fresh ones are already
    up to date — skip them, this keeps the pass incremental and cheap):
-   - `Read` a few representative files (from `files` / `top_symbols`) to ground the summary — do NOT
-     invent behavior the code does not show.
-   - Write, in Russian:
+   - Where your harness supports per-subagent model override, **dispatch a subagent on the chosen
+     model** to read a few representative files (from `files` / `top_symbols`) and return
+     `{title, summary}` (Russian, grounded — see Grounding below); the orchestrator then persists it.
+     Where override is unavailable, write the summary inline on the session model and note this in the
+     report. Either way:
      - `title` — one line: what this subsystem is.
      - `summary` — a compact paragraph: what it does, its key symbols (from `top_symbols`) and
-       invariants. No `path:line` required in the text; it is a high-level prior.
+       invariants. No `path:line` required; it is a high-level prior.
    - Persist: `index_subsystem_summary(repo, branch, cluster_key, title, summary, source_hash)` —
      pass back the cluster's own `source_hash` from step 2.
 
-4. **Report (Russian).** How many clusters summarized vs skipped-as-fresh.
+5. **Report (Russian).** How many clusters summarized vs skipped-as-fresh vs **deferred by the cap**
+   (`deferred` from step 2 — never silently truncate). If summaries were written inline (no model
+   override), say so.
 
 ## Grounding (hard rule)
 

--- a/reviewer/config/settings.py
+++ b/reviewer/config/settings.py
@@ -69,6 +69,8 @@ class Settings(BaseSettings):
     neo4j_password: str = "reviewerpass"
     graph_backend: GraphBackend = "auto"   # auto|scip|treesitter
     summary_cluster_depth: int = 2   # глубина пути для кластера подсистемы (PRI-159)
+    summary_rebuild_cap: int | None = None   # макс. кластеров на пересборку за проход
+    # (PRI-165); None/0 = безлимит; env SUMMARY_REBUILD_CAP
     # github
     github_token: str = ""
     github_retry_attempts: int = 3

--- a/reviewer/entrypoints/mcp_server.py
+++ b/reviewer/entrypoints/mcp_server.py
@@ -183,13 +183,21 @@ def create_server(service: MCPReviewService) -> FastMCP:
     @mcp.tool()
     def list_subsystem_clusters(repo: str, branch: str | None = None,
                                 depth: int | None = None,
-                                min_size: int | None = None) -> dict:
-        """Cluster the base code graph into subsystems (by module path) for the
-        /reviewer_summarize-subsystems skill. Returns per cluster: cluster_key,
-        num_members, files, top_symbols (by centrality), source_hash, and stale
-        (true when the stored summary is missing or its source_hash differs).
-        No PR session; branch defaults to the primary tracked branch."""
-        return service.list_subsystem_clusters(repo, branch, depth, min_size)
+                                min_size: int | None = None,
+                                cap: int | None = None) -> dict:
+        """Кластеризовать base-граф кода по путям модулей для скилла
+        /reviewer_summarize-subsystems. Возвращает {branch, deferred, clusters:[...]},
+        где каждый кластер содержит cluster_key, num_members, files, top_symbols
+        (по центральности), source_hash и stale (true, если сводка отсутствует
+        или её source_hash устарел). Без PR-сессии; branch по умолчанию —
+        первичная отслеживаемая ветка.
+
+        cap (по умолчанию — env SUMMARY_REBUILD_CAP; None/0 = без ограничений)
+        отбрасывает наименее приоритетные stale-кластеры за один проход: сначала
+        кластеры без сводки, затем с наиболее старым updated_at. Отложенные
+        кластеры не попадают в clusters, но учитываются в deferred — количестве
+        задержанных этим проходом кластеров."""
+        return service.list_subsystem_clusters(repo, branch, depth, min_size, cap)
 
     @mcp.tool()
     def index_subsystem_summary(repo: str, branch: str, cluster_key: str,

--- a/reviewer/graph/summaries.py
+++ b/reviewer/graph/summaries.py
@@ -16,6 +16,7 @@ class Member:
     node_id: str          # "path#fqn"
     path: str
     content_hash: str
+    skeleton_hash: str    # хэш структурного скелета — ключ свежести по структуре (PRI-165)
     start_line: int
 
 
@@ -42,10 +43,11 @@ def cluster_key(path: str, depth: int) -> str:
 
 
 def compute_source_hash(items: list[tuple[str, str]]) -> str:
-    """sha256 от sorted("node_id:content_hash") — детерминированный ключ свежести.
+    """sha256 от sorted("node_id:skeleton_hash") — детерминированный ключ свежести.
 
-    Меняется только при изменении состава кластера или содержимого его файлов
-    (content_hash — тот же дедуп-инвариант, что у чанков)."""
+    Меняется при изменении состава кластера или СТРУКТУРЫ его членов (сигнатуры/docstring),
+    но НЕ при правке тела (PRI-165: вход — skeleton_hash, не content_hash). Сортировка пар
+    делает ключ независимым от порядка членов."""
     joined = "\n".join(sorted(f"{nid}:{h}" for nid, h in items))
     return hashlib.sha256(joined.encode("utf-8")).hexdigest()
 
@@ -84,6 +86,6 @@ def build_clusters(
             files=sorted({m.path for m in ms}),
             top_symbols=top,
             num_members=len(ms),
-            source_hash=compute_source_hash([(m.node_id, m.content_hash) for m in ms]),
+            source_hash=compute_source_hash([(m.node_id, m.skeleton_hash) for m in ms]),
         ))
     return clusters

--- a/reviewer/index/chunker.py
+++ b/reviewer/index/chunker.py
@@ -1,3 +1,5 @@
+import hashlib
+
 import tree_sitter_python as tspython
 from tree_sitter import Language, Parser
 
@@ -88,3 +90,20 @@ def python_skeleton(source: bytes) -> list[int]:
 
     visit(tree.root_node)
     return sorted(lines)
+
+
+def symbol_skeleton_hash(text: str) -> str:
+    """Хэш структурного скелета символа: сигнатуры def/class (до ':') + 1-я строка docstring.
+
+    Ключ свежести сводок подсистем по структуре (PRI-165): меняется при смене сигнатуры/
+    docstring, но НЕ при правке тела. Хэшируется ТЕКСТ строк скелета (rstrip, как content_hash),
+    а не их номера, поэтому сдвиг/реордеринг символа в файл не протекают в хэш. Пустой скелет
+    (битый код / нет определений) → fallback на нормализованный полный текст (безопасно: любая
+    правка ре-стейлит)."""
+    nums = python_skeleton(text.encode("utf-8"))      # 1-based строки скелета относительно text
+    lines = text.splitlines()
+    if nums:
+        body = "\n".join(lines[n - 1].rstrip() for n in nums if 1 <= n <= len(lines))
+    else:
+        body = "\n".join(ln.rstrip() for ln in lines)
+    return hashlib.sha256(body.strip().encode("utf-8")).hexdigest()

--- a/reviewer/index/store.py
+++ b/reviewer/index/store.py
@@ -199,15 +199,19 @@ class ChunkStore:
             ).fetchone()
         return row[0] if row else 0
 
-    def list_base_members(self, repo: str, branch: str) -> list[tuple[str, str, str, int]]:
+    def list_base_members(self, repo: str, branch: str
+                          ) -> list[tuple[str, str, str, int, str]]:
         """Состав base-индекса ветки для кластеризации подсистем (PRI-159):
-        (path, symbol_fqn, content_hash, start_line) для ref=base:<branch>."""
+        (path, symbol_fqn, content_hash, start_line, skeleton_hash) для ref=base:<branch>.
+        skeleton_hash (PRI-165) считается на лету из text символа — ключ свежести сводок
+        по структуре (правка тела не ре-стейлит)."""
         from reviewer.index.refs import base_ref
+        from reviewer.index.chunker import symbol_skeleton_hash
         with self._connect() as conn:
             rows = conn.execute(
-                "SELECT path, symbol_fqn, content_hash, start_line FROM chunks "
+                "SELECT path, symbol_fqn, content_hash, start_line, text FROM chunks "
                 "WHERE repo=%s AND ref=%s", (repo, base_ref(branch))).fetchall()
-        return [(p, s, h, sl) for p, s, h, sl in rows]
+        return [(p, s, h, sl, symbol_skeleton_hash(t)) for p, s, h, sl, t in rows]
 
     def list_refs(self, repo: str) -> list[str]:
         """Отсортированный список distinct ref репо (для поиска overlay)."""

--- a/reviewer/index/summary_store.py
+++ b/reviewer/index/summary_store.py
@@ -6,6 +6,7 @@
 from __future__ import annotations
 
 import threading
+from datetime import datetime
 
 import psycopg.errors
 from pgvector.psycopg import register_vector
@@ -63,6 +64,18 @@ class SummaryStore:
         except psycopg.errors.UndefinedTable:
             return {}
         return {k: h for k, h in rows}
+
+    def get_updated_ats(self, repo: str, branch: str) -> dict[str, datetime]:
+        """updated_at по cluster_key — для упорядочивания stale-кластеров под cap (PRI-165:
+        без сводки → старейшие первыми). Нет таблицы → {} (fail-soft, как get_source_hashes)."""
+        try:
+            with self._connect() as conn:
+                rows = conn.execute(
+                    "SELECT cluster_key, updated_at FROM subsystem_summaries "
+                    "WHERE repo=%s AND branch=%s", (repo, branch)).fetchall()
+        except psycopg.errors.UndefinedTable:
+            return {}
+        return {k: u for k, u in rows}
 
     def get_summaries(self, repo: str, branch: str) -> list[dict]:
         try:

--- a/reviewer/mcp/service.py
+++ b/reviewer/mcp/service.py
@@ -417,9 +417,12 @@ class MCPReviewService:
             return "(определение не найдено)"
 
     def list_subsystem_clusters(self, repo: str, branch: str | None = None,
-                                depth: int | None = None,
-                                min_size: int | None = None) -> dict:
-        """Кластеризовать base-граф по модулям → кластеры для /summarize-subsystems."""
+                                depth: int | None = None, min_size: int | None = None,
+                                cap: int | None = None) -> dict:
+        """Кластеризовать base-граф по модулям → кластеры для /summarize-subsystems.
+        cap (дефолт Settings.summary_rebuild_cap; None/0=безлимит) отбрасывает наименее
+        приоритетные stale-кластеры (без сводки → старейшие updated_at первыми) и считает
+        их в deferred (PRI-165)."""
         from reviewer.graph.summaries import Member, build_clusters
         rb = self._resolve_repo_branch(repo, branch)
         if isinstance(rb, str):
@@ -429,8 +432,9 @@ class MCPReviewService:
         if not raw:
             return {"clusters": [],
                     "note": "(base-индекс пуст — выполните /reviewer_sync-codebase)"}
-        members = [Member(node_id=f"{p}#{s}", path=p, content_hash=h, start_line=sl)
-                   for p, s, h, sl in raw]
+        members = [Member(node_id=f"{p}#{s}", path=p, content_hash=h, start_line=sl,
+                          skeleton_hash=sk)
+                   for p, s, h, sl, sk in raw]
         graph = self.components.graph
         in_degree_fn = (
             (lambda ids: graph.in_degree(repo, ids, branch=resolved))
@@ -440,11 +444,22 @@ class MCPReviewService:
             depth=depth or self.settings.summary_cluster_depth,
             min_size=min_size or 1)
         stored = self.components.summary_store.get_source_hashes(repo, resolved)
-        return {"branch": resolved, "clusters": [
+        stale = {c.key: (stored.get(c.key) != c.source_hash) for c in clusters}
+        effective_cap = cap if cap is not None else self.settings.summary_rebuild_cap
+        deferred_keys: set[str] = set()
+        if effective_cap and effective_cap > 0:
+            stale_cl = [c for c in clusters if stale[c.key]]
+            if len(stale_cl) > effective_cap:
+                updated = self.components.summary_store.get_updated_ats(repo, resolved)
+                never = [c for c in stale_cl if c.key not in updated]      # без сводки — первыми
+                aged = sorted((c for c in stale_cl if c.key in updated),
+                              key=lambda c: updated[c.key])                # старейшие — раньше
+                deferred_keys = {c.key for c in (never + aged)[effective_cap:]}
+        return {"branch": resolved, "deferred": len(deferred_keys), "clusters": [
             {"cluster_key": c.key, "num_members": c.num_members, "files": c.files,
              "top_symbols": c.top_symbols, "source_hash": c.source_hash,
-             "stale": stored.get(c.key) != c.source_hash}
-            for c in clusters]}
+             "stale": stale[c.key]}
+            for c in clusters if c.key not in deferred_keys]}
 
     def index_subsystem_summary(self, repo: str, branch: str, cluster_key: str,
                                 title: str, summary: str, source_hash: str) -> dict:
@@ -464,7 +479,7 @@ class MCPReviewService:
         # кластеры листались тем же дефолтом. При нестандартном depth — fail-soft []+note ниже.
         depth = self.settings.summary_cluster_depth
         raw = self.components.store.list_base_members(repo, resolved)
-        members = [(f"{p}#{s}", h) for p, s, h, _ in raw
+        members = [(f"{p}#{s}", sk) for p, s, _h, _sl, sk in raw
                    if cluster_key_of(p, depth) == cluster_key]
         consistent = compute_source_hash(members) == source_hash
         member_node_ids = sorted(nid for nid, _ in members) if consistent else []

--- a/reviewer/mcp/service.py
+++ b/reviewer/mcp/service.py
@@ -426,11 +426,11 @@ class MCPReviewService:
         from reviewer.graph.summaries import Member, build_clusters
         rb = self._resolve_repo_branch(repo, branch)
         if isinstance(rb, str):
-            return {"clusters": [], "note": rb}
+            return {"branch": branch or "", "deferred": 0, "clusters": [], "note": rb}
         repo, resolved = rb
         raw = self.components.store.list_base_members(repo, resolved)
         if not raw:
-            return {"clusters": [],
+            return {"branch": resolved, "deferred": 0, "clusters": [],
                     "note": "(base-индекс пуст — выполните /reviewer_sync-codebase)"}
         members = [Member(node_id=f"{p}#{s}", path=p, content_hash=h, start_line=sl,
                           skeleton_hash=sk)

--- a/tests/graph/test_summaries.py
+++ b/tests/graph/test_summaries.py
@@ -3,8 +3,9 @@ from reviewer.graph.summaries import (
 )
 
 
-def _m(node_id, path, h="h", line=1):
-    return Member(node_id=node_id, path=path, content_hash=h, start_line=line)
+def _m(node_id, path, h="h", line=1, sk=None):
+    return Member(node_id=node_id, path=path, content_hash=h, start_line=line,
+                  skeleton_hash=sk if sk is not None else h)
 
 
 def test_cluster_key_takes_first_depth_dir_segments():
@@ -55,3 +56,19 @@ def test_build_clusters_fail_soft_when_in_degree_raises():
         raise RuntimeError("neo4j down")
     [c] = build_clusters(members, boom, depth=2)   # не падает
     assert c.top_symbols[0]["node_id"] == "reviewer/x/a.py#A"
+
+
+def test_build_clusters_source_hash_uses_skeleton_not_body():
+    base = [_m("p/a.py#A", "p/a.py", h="body1", sk="sig1"),
+            _m("p/b.py#B", "p/b.py", h="body2", sk="sig2")]
+    [c0] = build_clusters(base, None, depth=1)
+    # правка только тела (skeleton тот же) → тот же source_hash
+    body = [_m("p/a.py#A", "p/a.py", h="BODYX", sk="sig1"),
+            _m("p/b.py#B", "p/b.py", h="body2", sk="sig2")]
+    [c1] = build_clusters(body, None, depth=1)
+    assert c1.source_hash == c0.source_hash
+    # смена сигнатуры (skeleton изменился) → другой source_hash
+    sig = [_m("p/a.py#A", "p/a.py", h="body1", sk="SIGX"),
+           _m("p/b.py#B", "p/b.py", h="body2", sk="sig2")]
+    [c2] = build_clusters(sig, None, depth=1)
+    assert c2.source_hash != c0.source_hash

--- a/tests/index/test_chunker.py
+++ b/tests/index/test_chunker.py
@@ -1,4 +1,4 @@
-from reviewer.index.chunker import chunk_python, python_skeleton
+from reviewer.index.chunker import chunk_python, python_skeleton, symbol_skeleton_hash
 
 SRC = b'''\
 import os
@@ -75,3 +75,36 @@ def test_skeleton_empty_for_source_without_definitions():
 
 def test_skeleton_does_not_crash_on_syntax_error():
     assert isinstance(python_skeleton(b"def f(:\n  pass\n"), list)
+
+
+_FN = (
+    'def search(query: str, top_k: int = 10) -> list:\n'
+    '    """Поиск по индексу."""\n'
+    '    return rrf(query)[:top_k]\n'
+)
+
+
+def test_skeleton_hash_ignores_body_change():
+    body = _FN.replace("rrf(query)[:top_k]", "rrf(query, k=60)[:top_k]")
+    assert symbol_skeleton_hash(_FN) == symbol_skeleton_hash(body)   # тело не влияет
+
+
+def test_skeleton_hash_changes_on_signature():
+    sig = _FN.replace("top_k: int = 10)", "top_k: int = 10, *, rerank: bool = True)")
+    assert symbol_skeleton_hash(_FN) != symbol_skeleton_hash(sig)    # сигнатура влияет
+
+
+def test_skeleton_hash_changes_on_docstring_first_line():
+    doc = _FN.replace('"""Поиск по индексу."""', '"""Другое описание."""')
+    assert symbol_skeleton_hash(_FN) != symbol_skeleton_hash(doc)
+
+
+def test_skeleton_hash_is_position_independent():
+    shifted = "\n\n" + _FN                                           # сдвиг символа вниз
+    assert symbol_skeleton_hash(_FN) == symbol_skeleton_hash(shifted)
+
+
+def test_skeleton_hash_fallback_without_definitions():
+    # нет def/class → fallback на нормализованный полный текст (детерминирован, реагирует на правку)
+    assert symbol_skeleton_hash("X = 1\n") == symbol_skeleton_hash("X = 1")
+    assert symbol_skeleton_hash("X = 1\n") != symbol_skeleton_hash("X = 2\n")

--- a/tests/index/test_summary_store.py
+++ b/tests/index/test_summary_store.py
@@ -44,6 +44,7 @@ def test_upsert_is_idempotent_update(store):
 
 def test_list_base_members_reads_base_ref_rows():
     from reviewer.index.store import ChunkStore, ChunkRow
+    from reviewer.index.chunker import symbol_skeleton_hash
     cs = ChunkStore(DSN)
     cs.init_schema()
     cs.upsert([ChunkRow(repo="t/t", ref="base:dev", content_hash="h", path="reviewer/x/a.py",
@@ -51,7 +52,16 @@ def test_list_base_members_reads_base_ref_rows():
                         start_line=3, end_line=9, text="def a(): ...", embedding=[0.0]*1024)])
     try:
         members = cs.list_base_members("t/t", "dev")
-        assert ("reviewer/x/a.py", "A", "h", 3) in members
+        # 5-кортеж: skeleton_hash считается на лету из text
+        assert ("reviewer/x/a.py", "A", "h", 3, symbol_skeleton_hash("def a(): ...")) in members
     finally:
         cs.delete_ref("t/t", "base:dev")
         cs.close()
+
+
+def test_get_updated_ats_returns_datetime_per_cluster(store):
+    from datetime import datetime
+    store.upsert_summary("t/t", "dev", "reviewer/index", "A", "s", [], "h1")
+    ats = store.get_updated_ats("t/t", "dev")
+    assert "reviewer/index" in ats
+    assert isinstance(ats["reviewer/index"], datetime)   # сырой datetime, не isoformat

--- a/tests/mcp/test_subsystem_summaries.py
+++ b/tests/mcp/test_subsystem_summaries.py
@@ -24,8 +24,8 @@ def _svc(components) -> MCPReviewService:
 def test_list_subsystem_clusters_marks_stale():
     c = MagicMock()
     c.store.list_base_members.return_value = [
-        ("reviewer/index/a.py", "A", "h1", 1),
-        ("reviewer/index/b.py", "B", "h2", 2),
+        ("reviewer/index/a.py", "A", "h1", 1, "sk1"),
+        ("reviewer/index/b.py", "B", "h2", 2, "sk2"),
     ]
     c.graph = None                                  # граф недоступен → fail-soft
     c.summary_store.get_source_hashes.return_value = {}   # ничего не сохранено → stale=True
@@ -39,11 +39,11 @@ def test_list_subsystem_clusters_marks_stale():
 
 def test_list_subsystem_clusters_fresh_when_hash_matches():
     c = MagicMock()
-    c.store.list_base_members.return_value = [("reviewer/index/a.py", "A", "h1", 1)]
+    c.store.list_base_members.return_value = [("reviewer/index/a.py", "A", "h1", 1, "sk1")]
     c.graph = None
     # вычисляем эталонный source_hash так же, как продакшен
     from reviewer.graph.summaries import compute_source_hash
-    sh = compute_source_hash([("reviewer/index/a.py#A", "h1")])
+    sh = compute_source_hash([("reviewer/index/a.py#A", "sk1")])   # по skeleton_hash, не "h1"
     c.summary_store.get_source_hashes.return_value = {"reviewer/index": sh}
     svc = _svc(c)
     [cl] = svc.list_subsystem_clusters("o/n", "dev")["clusters"]
@@ -64,11 +64,11 @@ def test_index_and_get_subsystem_summaries_roundtrip_via_store():
     c = MagicMock()
     # base-состав кластера reviewer/index (depth=2) — сервер выведет member_node_ids из него
     c.store.list_base_members.return_value = [
-        ("reviewer/index/a.py", "A", "h1", 1),
-        ("reviewer/index/b.py", "B", "h2", 2),
+        ("reviewer/index/a.py", "A", "h1", 1, "sk1"),
+        ("reviewer/index/b.py", "B", "h2", 2, "sk2"),
     ]
-    sh = compute_source_hash([("reviewer/index/a.py#A", "h1"),
-                              ("reviewer/index/b.py#B", "h2")])
+    sh = compute_source_hash([("reviewer/index/a.py#A", "sk1"),
+                              ("reviewer/index/b.py#B", "sk2")])
     c.summary_store.get_summaries.return_value = [
         {"cluster_key": "reviewer/index", "title": "Индекс", "summary": "...",
          "updated_at": "2026-06-23T00:00:00+00:00"}]
@@ -86,7 +86,7 @@ def test_index_and_get_subsystem_summaries_roundtrip_via_store():
 
 def test_index_subsystem_summary_stale_hash_empties_members():
     c = MagicMock()
-    c.store.list_base_members.return_value = [("reviewer/index/a.py", "A", "h1", 1)]
+    c.store.list_base_members.return_value = [("reviewer/index/a.py", "A", "h1", 1, "sk1")]
     svc = _svc(c)
     # передан неактуальный source_hash → пере-вычисленный не совпадёт
     out = svc.index_subsystem_summary("o/n", "dev", "reviewer/index", "Индекс", "...", "STALE")
@@ -94,3 +94,37 @@ def test_index_subsystem_summary_stale_hash_empties_members():
     assert out["members"] == 0
     assert "note" in out
     assert c.summary_store.upsert_summary.call_args.args[5] == []   # member_node_ids пуст
+
+
+def test_list_subsystem_clusters_cap_defers_lowest_priority():
+    from datetime import datetime
+    c = MagicMock()
+    # три кластера-одиночки (depth=2 даёт разные ключи), все stale
+    c.store.list_base_members.return_value = [
+        ("a/x/f.py", "F", "h", 1, "skf"),
+        ("b/y/g.py", "G", "h", 1, "skg"),
+        ("c/z/h.py", "H", "h", 1, "skh"),
+    ]
+    c.graph = None
+    c.summary_store.get_source_hashes.return_value = {}          # все stale
+    # a/x — без сводки (нет в updated); b/y старее c/z
+    c.summary_store.get_updated_ats.return_value = {
+        "b/y": datetime(2026, 1, 1), "c/z": datetime(2026, 6, 1)}
+    svc = _svc(c)
+    out = svc.list_subsystem_clusters("o/n", "dev", min_size=1, cap=2)
+    keys = {cl["cluster_key"] for cl in out["clusters"]}
+    assert out["deferred"] == 1
+    assert keys == {"a/x", "b/y"}        # без сводки + старейший; c/z отложен
+
+
+def test_list_subsystem_clusters_no_cap_returns_all():
+    c = MagicMock()
+    c.store.list_base_members.return_value = [
+        ("a/x/f.py", "F", "h", 1, "skf"), ("b/y/g.py", "G", "h", 1, "skg")]
+    c.graph = None
+    c.summary_store.get_source_hashes.return_value = {}
+    svc = _svc(c)
+    out = svc.list_subsystem_clusters("o/n", "dev", min_size=1)   # cap=None
+    assert out["deferred"] == 0
+    assert len(out["clusters"]) == 2
+    c.summary_store.get_updated_ats.assert_not_called()           # порядок не нужен без cap

--- a/tests/mcp/test_subsystem_summaries.py
+++ b/tests/mcp/test_subsystem_summaries.py
@@ -57,6 +57,8 @@ def test_list_subsystem_clusters_empty_index_returns_note():
     out = svc.list_subsystem_clusters("o/n", "dev")
     assert out["clusters"] == []
     assert "note" in out
+    assert "branch" in out
+    assert out["deferred"] == 0
 
 
 def test_index_and_get_subsystem_summaries_roundtrip_via_store():

--- a/tests/skills/test_summarize_subsystems.py
+++ b/tests/skills/test_summarize_subsystems.py
@@ -23,3 +23,40 @@ def test_skill_includes_common_blocks_that_exist():
 def test_skill_instructs_russian_output():
     text = SKILL.read_text(encoding="utf-8").lower()
     assert "russian" in text or "русск" in text
+
+
+def test_skill_reports_deferred():
+    """Шаг 5 должен упоминать deferred и cap — чтобы скилл не усекал молча."""
+    text = SKILL.read_text(encoding="utf-8")
+    assert "deferred" in text, "скилл не упоминает deferred"
+    assert "SUMMARY_REBUILD_CAP" in text, "скилл не упоминает env-настройку cap"
+
+
+def test_skill_asks_model_choice():
+    """Скилл должен предлагать выбор модели для сводок (шаг 3)."""
+    text = SKILL.read_text(encoding="utf-8")
+    assert "model" in text.lower(), "скилл не упоминает выбор модели"
+    # Хотя бы один дешёвый вариант должен быть упомянут как дефолт
+    assert any(m in text for m in ("Haiku", "Sonnet", "Fable")), (
+        "скилл не предлагает дешёвую модель по умолчанию"
+    )
+
+
+def test_skill_dispatches_subagent_on_chosen_model():
+    """Шаг 4 должен описывать диспатч субагента на выбранной модели."""
+    text = SKILL.read_text(encoding="utf-8")
+    assert "subagent" in text.lower(), "скилл не упоминает субагент"
+    assert "chosen" in text.lower() or "override" in text.lower(), (
+        "скилл не упоминает override модели субагента"
+    )
+
+
+def test_skill_has_five_pipeline_steps():
+    """Пайплайн должен содержать шаг 5 (Report) — прежний шаг 4 сдвинут."""
+    import re
+    text = SKILL.read_text(encoding="utf-8")
+    # Ищем нумерованные шаги внутри ## Pipeline
+    pipeline_section = re.search(r"## Pipeline(.*?)## Grounding", text, re.DOTALL)
+    assert pipeline_section, "не найдена секция Pipeline"
+    steps = re.findall(r"^\d+\.", pipeline_section.group(1), re.MULTILINE)
+    assert len(steps) >= 5, f"ожидалось ≥5 шагов, найдено {len(steps)}"

--- a/tests/skills/test_summarize_subsystems.py
+++ b/tests/skills/test_summarize_subsystems.py
@@ -35,7 +35,10 @@ def test_skill_reports_deferred():
 def test_skill_asks_model_choice():
     """Скилл должен предлагать выбор модели для сводок (шаг 3)."""
     text = SKILL.read_text(encoding="utf-8")
-    assert "model" in text.lower(), "скилл не упоминает выбор модели"
+    # Фраза уникальна для шага 3 и отсутствует в SKILL.md за пределами этого шага
+    assert "Ask the user which model tier to use for writing summaries" in text, (
+        "шаг 3 не спрашивает пользователя о модели (уникальная фраза шага удалена)"
+    )
     # Хотя бы один дешёвый вариант должен быть упомянут как дефолт
     assert any(m in text for m in ("Haiku", "Sonnet", "Fable")), (
         "скилл не предлагает дешёвую модель по умолчанию"
@@ -45,9 +48,9 @@ def test_skill_asks_model_choice():
 def test_skill_dispatches_subagent_on_chosen_model():
     """Шаг 4 должен описывать диспатч субагента на выбранной модели."""
     text = SKILL.read_text(encoding="utf-8")
-    assert "subagent" in text.lower(), "скилл не упоминает субагент"
-    assert "chosen" in text.lower() or "override" in text.lower(), (
-        "скилл не упоминает override модели субагента"
+    # Фраза уникальна для шага 4 и отсутствует в SKILL.md за пределами этого шага
+    assert "dispatch a subagent on the chosen" in text, (
+        "шаг 4 не предписывает диспатч субагента на выбранной модели (уникальная фраза шага удалена)"
     )
 
 


### PR DESCRIPTION
## PRI-165 — Свежесть сводок подсистем по структуре + cap

Ключ свежести кластера сводки (`source_hash`) теперь считается от **структурного скелета** членов (сигнатуры `def`/`class` + 1-я строка docstring через `python_skeleton`), а не от полного `content_hash`. Плюс server-side **cap** на число пересборок за проход.

### Зачем
Раньше любая правка тела функции (багфикс, рефактор внутри тела) меняла `content_hash` члена → ре-стейлила весь кластер → дорогая пересборка сводки. Теперь:
- правка **тела** без смены сигнатуры/состава — **не** ре-стейлит кластер;
- смена **сигнатуры**, добавление/удаление члена — ре-стейлит.

Это churn-контроль: высокоуровневая сводка допустимо слегка отстаёт от тел, но не пересобирается на каждый багфикс.

### Что внутри
- `reviewer/index/chunker.py`: `symbol_skeleton_hash(text)` — хэш rstrip-текста строк скелета (не номеров) → позиционно-независим; fallback на полный текст.
- `reviewer/index/store.py`: `list_base_members` отдаёт 5-кортеж со `skeleton_hash` (на лету из колонки `text`, без миграции).
- `reviewer/index/summary_store.py`: `get_updated_ats` (для приоритезации cap).
- `reviewer/graph/summaries.py`: `Member.skeleton_hash`; `build_clusters` подаёт его в `compute_source_hash`.
- `reviewer/mcp/service.py`: `list_subsystem_clusters` — cap + порядок (никогда-не-сводившиеся → самые старые по `updated_at`) + `deferred`; `index_subsystem_summary` — consistency-check по `skeleton_hash`. Оба call-site'а `compute_source_hash` переведены синхронно.
- `reviewer/config/settings.py`: `summary_rebuild_cap` (env `SUMMARY_REBUILD_CAP`, дефолт безлимит).
- `reviewer/entrypoints/mcp_server.py`: тул `list_subsystem_clusters` прокидывает `cap`, докстринг про `{branch, deferred, clusters}`.
- `plugin/skills/summarize-subsystems/SKILL.md`: репорт `deferred` + выбор дешёвой модели для генерации сводок.

### Инварианты
- `source_hash` order-независим (`compute_source_hash` сортирует пары) и position-независим (хэш текста скелета). `node_id = path#fqn` един во всех call-site'ах.
- Вектор-поиск не затронут: `skeleton_hash` только для свежести сводок, эмбеддинги/ретрив по-прежнему по полному чанку.
- **Одноразовый «шторм» при апгрейде:** сохранённые `source_hash` были content_hash-based → первый проход после деплоя ре-стейлит все кластеры один раз; cap — throttle. Рекомендуется выставить `SUMMARY_REBUILD_CAP` перед первым проходом.
- Cadence (кадэнс) — вне объёма (отложен).

### Тестирование
- Полный unit-suite: **657 passed** (`--ignore=tests/web` — пред-существующий env-gap fastapi).
- Integration (store, ParadeDB :5433): green.
- TDD по всем задачам; guard-тесты скилла усилены до load-bearing строк.

Спека: `docs/superpowers/specs/2026-06-23-pri-165-summary-skeleton-freshness-design.md`
План: `docs/superpowers/plans/2026-06-23-pri-165-summary-skeleton-freshness.md`
