### PR TITLE
docs(skills): solve-task — явный запрет цитировать path:line из summary (PRI-161)

### DIFF
--- a/plugin/skills/solve-task/SKILL.md
+++ b/plugin/skills/solve-task/SKILL.md
@@ -99,6 +99,8 @@ brief to `superpowers:brainstorming` (which leads to writing-plans → subagent-
      → top-k relevant subsystems by proximity (top-k vs all is server-side; PRI-167).
      Use the same `branch` as `search_codebase`. Fail-open: an empty list / a `(… недоступно)`
      note / an error is non-fatal — omit the `## Subsystems` brief section and note the gap.
+     The summary is only a prior — every `path:line` in the brief still comes from
+     `search_codebase` snippets, never from the summary text.
    - **Project scope.** Pass `project=<task_board.project>` (from Step 1; empty = unscoped) to
      `get_task`, `get_task_context`, and `search_tasks` so only this repo's project surfaces (PRI-170).
    - If you have a task key: `get_task_context(key, project=<task_board.project>)` → linked tasks, their PRs, and the code those PRs

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "rag-reviewer"
-version = "0.2.15"
+version = "0.2.16"
 description = "AI pull-request reviewer: hybrid RAG + a code graph + Claude Code. Whole-repo context, inline GitHub comments grounded on exact code."
 readme = "README.md"
 license = { text = "MIT" }

--- a/tests/skills/test_ask_uses_summaries.py
+++ b/tests/skills/test_ask_uses_summaries.py
@@ -41,3 +41,10 @@ def test_solve_task_passes_query_to_summaries():
 def test_solve_task_has_subsystems_brief_section():
     text = SOLVE.read_text(encoding="utf-8")
     assert "## Subsystems" in text
+
+
+def test_solve_task_marks_summary_prior_only():
+    # Приор сводок — только ориентир: grounding (path:line) идёт из search_codebase,
+    # а не из текста summary (зеркало ask/SKILL.md). Критерий приёмки PRI-161.
+    text = SOLVE.read_text(encoding="utf-8")
+    assert "never from the summary text" in text


### PR DESCRIPTION
## Что и зачем

Закрывает последний **буквальный** зазор PRI-161 (приор подсистемных сводок в `solve-task`). Критерий приёмки требовал «запрет цитировать `path:line` из текста summary, **как в `ask`**». В `ask` это явная фраза (`ask/SKILL.md:50-52`); в `solve-task` дисциплина обеспечивалась только **структурно** (секция `## Subsystems` несёт `cluster_key`+суть без `path:line`; grounding — лишь в `## Relevant code` из сниппетов `search_codebase`), но не была сформулирована дословно в под-шаге «Subsystem prior».

Остальные части PRI-161 (ignore-на-входе, per-prefix depth, сам приор) уже в `main` (0.2.11) — это финальный штрих по букве критерия.

## Изменения

- `plugin/skills/solve-task/SKILL.md` — +1 строка в под-шаг «Subsystem prior»: «the summary is only a prior … never from the summary text» (зеркало `ask`).
- `tests/skills/test_ask_uses_summaries.py` — guard-тест `test_solve_task_marks_summary_prior_only` (якорь `"never from the summary text"`).
- `pyproject.toml` — версия `0.2.15 → 0.2.16`.

## Проверка

TDD red→green. `tests/skills` — 62 passed; ruff чист. Логика кода не затронута (правка документа скилла + guard).