### PR TITLE
feat(solve-task): brief hygiene — резолв subtask-criteria при тонком description + дедуп related (PRI-164)

### DIFF
--- a/docs/superpowers/briefs/2026-06-26-PRI-164-solve-task-brief-hygiene.md
+++ b/docs/superpowers/briefs/2026-06-26-PRI-164-solve-task-brief-hygiene.md
@@ -1,0 +1,36 @@
+# Brief — PRI-164 solve-task brief hygiene: резолв subtask-criteria при тонком description + дедуп linked vs similar
+url: https://ru.yougile.com/team/686c049c8af8/#PRI-164
+
+## Task
+- **Слой:** плагин/скил `solve-task` (+ опц. движок `reviewer/tasks`). Качество, низкий приоритет (S).
+- **(a) criteria из подзадач.** Store-first `get_task` и server-side `normalize` оба ставят `criteria=[]` (осознанный YAGNI: критерии живут в `description`). Но если приёмка вынесена в **подзадачи**, бриф её теряет. Надо: когда `description` тонкий на критерии (нет секции «Критерии приёмки/Acceptance») и у задачи есть subtask-links — дорезолвить их в `criteria[]` (board-MCP-фолбэк уже описан в плейбуке; опц. server-side в `yougile.py::normalize`).
+- **(b) дедуп related-источников.** «Related work» собирается из двух источников — `get_task_context` (linked) + `search_tasks` (similar) — без дедупа; задача может попасть в бриф дважды. Шаг 4 должен явно требовать дедуп `linked ∪ similar` по ключу задачи.
+- **Где:** `plugin/skills/solve-task/SKILL.md` (шаги 2–4); опц. `reviewer/tasks/boards/yougile.py`.
+- **Критерии приёмки:** (1) задача с критериями-подзадачами и тонким description → непустые `criteria` в брифе; (2) «Related work» без дублей linked/similar.
+- _Данные задачи — из стора reviewer (после preflight sync). Статус доски: «Плагин/агент (скилы)»._
+
+## Related work
+- **PRI-160 (ID-160)** — store-first `get_task`: тот самый путь, где `criteria=[]` зашит (`service.py:264`). Менять резолв criteria надо согласованно с ним.
+- **PRI-153 (ID-153)** — `search_tasks`/`get_task_context`: ровно два источника related-work, которые (b) требует дедупить; несут relevance-score/усечение.
+- **PRI-146 (ID-146)** — спека brief + relevance-фильтр (лимиты top-N, drop): задаёт скелет брифа и шаг 4, куда вписывается дедуп.
+- (dropped 4: PRI-139 авто-линковка PR — другой механизм; PRI-161 приор сводок — другая фича; PRI-96 batch embeddings — Готово; PRI-162 include_tests для TDD — другая фича.)
+
+## Subsystems
+- **reviewer/tasks** — жизненный цикл задач (enumerate→normalize→index, store-first `get_task`); здесь живёт server-side опция (a) и инвариант идемпотентности по content_hash.
+- **reviewer/mcp** — MCPReviewService экспонирует `get_task`/`get_task_context`/`search_tasks` как тулы (контракт, который потребляет скил).
+
+## Relevant code
+- `plugin/skills/solve-task/SKILL.md` — **главная цель правки** (шаги 2–4): нет ни резолва subtask-criteria при тонком description, ни дедупа linked∪similar. Подтверждено grep'ом — обе фичи отсутствуют.
+- `reviewer/tasks/service.py:259-267` — store-first `get_task` жёстко возвращает `criteria: []` (строка 264); комментарий 249-250 фиксирует YAGNI «требования несёт description».
+- `reviewer/tasks/boards/yougile.py:59-67` — `normalize_yougile` ставит `criteria: []` (строка 64), хотя `subtask_titles` уже инжектятся в `links` с `title` (строки 38-44) → server-side опция (a) почти бесплатна на уровне normalize.
+- `reviewer/tasks/boards/yougile.py:134-146` — `YougileBoard.normalize` уже REST-резолвит титулы подзадач (`subtask_titles[sid]=f"{code}:{title}"`). Blast radius server-side пути: данные есть, но чтобы они дошли до брифа, нужно протащить criteria через `index_task` (`service.py:35`) + TaskStore-персист + снять хардкод `[]` в `get_task` (`service.py:264`).
+- `plugin/skills/review-pr/references/task-context-yougile.md:35,44-47` — плейбук **уже** описывает резолв subtask-titles → `criteria[]` «только когда description тонкий», а строка 37 уже дедупит `links[]` по ключу (готовый прецедент формулировки для (b) и client-side пути (a)).
+- (dropped 1: `reviewer/tasks/boards/base.py#TaskBoardProvider` — протокол, фон, не правим.)
+
+## Constraints / open questions
+- **Сохранить YAGNI инлайн-критериев.** Менять только ветку «description тонкий на критерии»; при инлайн-секции «Критерии приёмки» оставлять `criteria=[]` (плейбук:44-47). Нужно определить детектор «тонкого» description (отсутствие заголовка «Критерии приёмки/Acceptance»?) — дизайн-решение для brainstorming.
+- **Две поверхности для (a):** client-side (скил резолвит подзадачи через board-MCP-фолбэк, когда description тонкий — плейбук review-pr это уже умеет) vs server-side (`normalize`→`criteria`, дёшево т.к. титулы уже фетчатся, но требует персиста через TaskStore + чтения в `get_task:264`). Выбор/оба — открытый вопрос.
+- **(b) — чистая doc-правка** `SKILL.md` (шаги 3–4): добавить «дедуп linked ∪ similar по ключу задачи»; прецедент формулировки — плейбук:37.
+- **PRI-164 ещё не реализована** — нет коммитов/PR, в `SKILL.md` нет обеих фич (проверено git log + grep).
+- `get_task_context(PRI-164)` вернул только саму задачу (граф-связанных linked-задач/PR нет) — `get_pr_diff` тянуть не из чего; PRI-160/153/146 в description — «related»-ссылки без PR.
+- Индекс свежий: drift=0, переиндексирован в `ca51509`, граф через SCIP (1888 узлов). Корпус задач прогрет (62 задачи). Доска yougile подключена, project=PRI, store-first hit.

--- a/docs/superpowers/plans/2026-06-26-pri-164-solve-task-brief-hygiene.md
+++ b/docs/superpowers/plans/2026-06-26-pri-164-solve-task-brief-hygiene.md
@@ -1,0 +1,166 @@
+# PRI-164 solve-task brief hygiene — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** В скиле `solve-task` дорезолвить `criteria` из подзадач при тонком `description` и явно дедупить related-источники (linked ∪ similar) — обе правки только в `SKILL.md` + guard-тесты.
+
+**Architecture:** Изменения исключительно в промпт-доке `plugin/skills/solve-task/SKILL.md` (шаги 2–4). TDD здесь = guard-тесты в `tests/skills/test_solve_task_brief.py`, которые grep'ают стабильные маркеры инструкций (репо-конвенция `tests/skills/`). Сначала падающий ассерт на отсутствующий маркер → правка `SKILL.md` → зелёный.
+
+**Tech Stack:** Python 3.11+, pytest. Тело `SKILL.md` — на английском (токены), как и весь скил; тест-докстринги/комментарии — на русском (как соседние тесты).
+
+## Global Constraints
+
+- Тело `SKILL.md` пишется **по-английски** (соответствие существующему скилу); ответы пользователю скил инструктирует по-русски — этого не меняем.
+- Без правок движка/БД/миграций — серверный путь criteria-колонки **вне скоупа** (спека).
+- Часть (a) — **fail-open** и **не вызывает `index_task`**; обогащённые criteria идут только в бриф.
+- Сохранить YAGNI инлайн-критериев: при наличии заголовка критериев в `description` поведение не меняется (`criteria=[]`).
+- Коммиты: Conventional Commits на русском, **без self-attribution** (никаких Co-Authored-By/упоминаний Claude).
+- Ветка работы: `feat/pri-164-solve-task-brief-hygiene` (уже создана; спека+бриф закоммичены).
+- Прогон тестов: `.venv/bin/pytest tests/skills/test_solve_task_brief.py -q`. Линт: `.venv/bin/ruff check tests/skills/`.
+
+---
+
+### Task 1: (b) Дедуп related-источников по ключу
+
+**Files:**
+- Modify: `plugin/skills/solve-task/SKILL.md` (шаг 3 — после bullet'а `search_tasks`, ~строка 109; шаг 4 — relevance-фильтр, после bullet'а «Report what you dropped», ~строка 157)
+- Test: `tests/skills/test_solve_task_brief.py`
+
+**Interfaces:**
+- Consumes: текущий `SKILL.md` шаги 3–4 (см. якоря ниже).
+- Produces: стабильные маркеры `Dedup related sources by key` и `linked ∪ similar` в `SKILL.md`.
+
+- [ ] **Step 1: Написать падающий тест**
+
+В `tests/skills/test_solve_task_brief.py` добавить в конец файла:
+
+```python
+def test_solve_task_dedupes_related_sources():
+    """PRI-164(b): «Related work» дедупится по ключу между linked и similar."""
+    text = SOLVE.read_text(encoding="utf-8")
+    assert "Dedup related sources by key" in text   # явный шаг дедупа
+    assert "linked ∪ similar" in text               # оба источника, слитые
+    assert "canonical task key" in text             # дедуп по каноническому ключу
+```
+
+- [ ] **Step 2: Запустить тест — убедиться, что падает**
+
+Run: `.venv/bin/pytest tests/skills/test_solve_task_brief.py::test_solve_task_dedupes_related_sources -q`
+Expected: FAIL — `assert "Dedup related sources by key" in text` (маркера ещё нет).
+
+- [ ] **Step 3: Добавить инструкцию дедупа в `SKILL.md`**
+
+(3a) В **шаге 3**, сразу ПОСЛЕ bullet'а `search_tasks` (строки 108–109, заканчивается на «…for fuller detail.»), вставить новый bullet:
+
+```markdown
+   - **Related work = linked ∪ similar.** The «Related work» brief section draws from two sources —
+     `get_task_context` (linked) and `search_tasks` (similar). They overlap; the Step 4 filter
+     deduplicates them by key before the cap.
+```
+
+(3b) В **шаге 4**, в списке relevance-фильтра, сразу ПОСЛЕ bullet'а «**Report what you dropped:** …» (строки 156–157), вставить новый bullet:
+
+```markdown
+   - **Dedup related sources by key (linked ∪ similar).** «Related work» draws from
+     `get_task_context` (linked) and `search_tasks` (similar). Deduplicate by canonical task key
+     BEFORE the ≤3 cap, matching `PRI-N`↔`ID-N` via `aliases` (one task, two codes). On collision
+     keep the linked entry (richer — carries PR/graph context) and drop the similar duplicate, so a
+     task never appears twice in the brief.
+```
+
+- [ ] **Step 4: Запустить тест — убедиться, что проходит**
+
+Run: `.venv/bin/pytest tests/skills/test_solve_task_brief.py::test_solve_task_dedupes_related_sources -q`
+Expected: PASS.
+
+- [ ] **Step 5: Коммит**
+
+```bash
+git add plugin/skills/solve-task/SKILL.md tests/skills/test_solve_task_brief.py
+git commit -m "feat(solve-task): дедуп related-источников linked ∪ similar по ключу (PRI-164)"
+```
+
+---
+
+### Task 2: (a) Резолв subtask-criteria при тонком description
+
+**Files:**
+- Modify: `plugin/skills/solve-task/SKILL.md` (шаг 2, ветка **Hit**, после строки 81 «…came from the reviewer store (after sync).»)
+- Test: `tests/skills/test_solve_task_brief.py`
+
+**Interfaces:**
+- Consumes: текущий `SKILL.md` шаг 2 ветка Hit (см. якорь ниже).
+- Produces: стабильные маркеры `Thin-criteria enrichment` и детектор `(?i)(критери|приёмк|acceptance)` в `SKILL.md`.
+
+- [ ] **Step 1: Написать падающий тест**
+
+В `tests/skills/test_solve_task_brief.py` добавить в конец файла:
+
+```python
+def test_solve_task_resolves_subtask_criteria_when_thin():
+    """PRI-164(a): при тонком description критерии дорезолвятся из подзадач (fail-open, без index_task)."""
+    text = SOLVE.read_text(encoding="utf-8")
+    assert "Thin-criteria enrichment" in text                 # шаг присутствует
+    assert "(?i)(критери|приёмк|acceptance)" in text          # детектор «тонкого» description
+    assert "subtasks" in text                                  # источник критериев — подзадачи
+    assert "do NOT call `index_task`" in text                  # обогащение только в бриф
+```
+
+- [ ] **Step 2: Запустить тест — убедиться, что падает**
+
+Run: `.venv/bin/pytest tests/skills/test_solve_task_brief.py::test_solve_task_resolves_subtask_criteria_when_thin -q`
+Expected: FAIL — `assert "Thin-criteria enrichment" in text` (маркера ещё нет).
+
+- [ ] **Step 3: Добавить инструкцию обогащения в `SKILL.md` (шаг 2, ветка Hit)**
+
+В **шаге 2**, в ветке **Hit**, сразу ПОСЛЕ строки «…Note in the brief that the task data came from the reviewer store (after sync).» (строка 81), вставить вложенный bullet (отступ 10 пробелов — уровень вложенности под Hit):
+
+```markdown
+          - **Thin-criteria enrichment (optional, fail-open).** The store returns `criteria=[]` —
+            requirements normally live in `description`. If `description` has NO acceptance-criteria
+            heading (no section matching `(?i)(критери|приёмк|acceptance)`) AND a board is connected,
+            resolve the task's subtasks into `criteria[]` via the board-MCP playbook
+            `../review-pr/references/task-context-<task_board.type>.md` (its «Criteria note»):
+            one board `get_task(key)` → for each `subtasks[]` id resolve its title. Fold the resolved
+            criteria into the brief's `## Task` section only — do NOT call `index_task`. When the
+            heading IS present, criteria are inline in `description` → skip (leave `[]`). No board /
+            no subtasks / any error → leave `criteria` empty.
+```
+
+- [ ] **Step 4: Запустить тест — убедиться, что проходит**
+
+Run: `.venv/bin/pytest tests/skills/test_solve_task_brief.py::test_solve_task_resolves_subtask_criteria_when_thin -q`
+Expected: PASS.
+
+- [ ] **Step 5: Регрессионный прогон всей skills-сьюты + линт**
+
+Run: `.venv/bin/pytest tests/skills/ -q && .venv/bin/ruff check tests/skills/`
+Expected: все тесты PASS (включая существующие `test_solve_task_*` и `assemble`-guard'ы); ruff — чисто на затронутом файле.
+
+> Если упадёт `test_assembled_prompts` или другой include/guard-тест — значит правка задела include-маркеры или обязательные шаги; вернуться к Step 3 и поправить, не удаляя существующих маркеров (`# Brief —`, `≤3`, `≤5`, `(dropped`, `directly informs`, `project=`, `docs/superpowers/briefs/`).
+
+- [ ] **Step 6: Коммит**
+
+```bash
+git add plugin/skills/solve-task/SKILL.md tests/skills/test_solve_task_brief.py
+git commit -m "feat(solve-task): резолв subtask-criteria при тонком description (PRI-164)"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- (a) резолв subtask-criteria при тонком description → Task 2. ✓ (детектор по заголовку, board-MCP-плейбук, только в бриф, fail-open, без `index_task`).
+- (b) дедуп related-источников linked ∪ similar по ключу → Task 1. ✓ (дедуп до капа ≤3, `PRI-N↔ID-N` через aliases, linked в приоритете).
+- Тесты в `tests/skills/test_solve_task_brief.py` → Task 1 Step 1 + Task 2 Step 1. ✓
+- Серверный путь вне скоупа → не планируется. ✓
+- Fail-open / без `index_task` / YAGNI инлайн-критериев → зашиты в текст инструкции Task 2 Step 3 и в тест-ассерты. ✓
+
+**Placeholder scan:** план содержит полный текст всех правок и тестов; плейсхолдеров нет. ✓
+
+**Type/marker consistency:** маркеры, на которые ассертит тест, совпадают с текстом, вставляемым в `SKILL.md`:
+- Task 1: `Dedup related sources by key`, `linked ∪ similar`, `canonical task key` — все присутствуют в тексте Step 3b. ✓
+- Task 2: `Thin-criteria enrichment`, `(?i)(критери|приёмк|acceptance)`, `subtasks`, `do NOT call \`index_task\`` — все присутствуют в тексте Step 3. ✓
+
+**Порядок задач:** Task 1 (b, проще, шаги 3–4) → Task 2 (a, шаг 2 + регрессионный прогон). Каждая задача независимо тестируема и коммитится отдельно.

--- a/docs/superpowers/specs/2026-06-26-pri-164-solve-task-brief-hygiene-design.md
+++ b/docs/superpowers/specs/2026-06-26-pri-164-solve-task-brief-hygiene-design.md
@@ -1,0 +1,70 @@
+# PRI-164 — solve-task brief hygiene: резолв subtask-criteria + дедуп related-источников
+
+**Задача:** https://ru.yougile.com/team/686c049c8af8/#PRI-164
+**Бриф:** `docs/superpowers/briefs/2026-06-26-PRI-164-solve-task-brief-hygiene.md`
+**Размер:** S (низкий приоритет). **Слой:** плагин/скил `solve-task`.
+
+## Проблема
+
+Скил `solve-task` собирает бриф для последующей разработки. Две гигиенические дыры:
+
+1. **criteria всегда пусты при тонком description.** Store-first `get_task` (`reviewer/tasks/service.py:259-267`) и server-side `normalize_yougile` (`reviewer/tasks/boards/yougile.py:64`) оба возвращают `criteria=[]` — критерии живут в `description`. Это осознанный YAGNI, пока приёмку пишут инлайн. Но для задач, где приёмка вынесена в **подзадачи**, бриф теряет критерии.
+2. **Нет дедупа related-источников.** Секция «Related work» собирается из двух источников — `get_task_context` (граф-связанные) ∪ `search_tasks` (семантически похожие) — без указания дедупа; одна задача может попасть в бриф дважды.
+
+## Решение (обзор)
+
+Обе части — **изменения только в `plugin/skills/solve-task/SKILL.md`** + guard-тесты в `tests/skills/`. Без правок движка, БД и миграций.
+
+**Серверный путь явно отложен (out of scope).** `TaskRow` (`reviewer/tasks/service.py:52-55`) не имеет колонки `criteria` — поле используется лишь для текста эмбеддинга (`build_task_text`, `service.py:41`). Поэтому server-side резолв criteria — это DB-миграция (новая колонка + протяжка через `index_task`/`index_batch` + чтение в `get_task`), что несоразмерно размеру S. Если criteria из подзадач понадобятся и в `review-pr` без LLM-токенов — отдельная задача.
+
+## Часть (a): резолв subtask-criteria при тонком description (client-side)
+
+**Где:** шаги 2–3 `SKILL.md`.
+
+**Механика (board-MCP-фолбэк):**
+
+1. После идентификации задачи (store-first hit отдаёт `criteria=[]`), оценить «тонкий ли `description` на критерии».
+2. **Детектор «тонкого» description:** в `description` **нет** секции-заголовка, матчащего `(?i)(критери|приёмк|acceptance)`. Если такой заголовок есть → критерии инлайн → ничего не делаем (`criteria` остаётся `[]`; `description` и так несёт требования — порт ноты плейбука `task-context-yougile.md:44-47`).
+3. Если description тонкий **И доска подключена** (`task_board` резолвлен, board-MCP доступен):
+   - один board-MCP `get_task(key)` → прочитать `subtasks[]`;
+   - если `subtasks[]` непуст — резолвить титул каждой подзадачи в `criteria[]` **ровно по плейбуку** `../review-pr/references/task-context-<task_board.type>.md` (механика резолва subtasks→criteria уже описана там, строки 35, 44–47). Не дублировать механику в `solve-task`, а сослаться на плейбук (как это уже делает шаг 2 для miss-ветки).
+4. Если подзадач нет, доска не подключена, или резолв упал → `criteria` остаётся `[]` (fail-open, как остальной шаг 3).
+5. **Обогащённые `criteria` идут только в бриф** (контекст + файл) — НЕ ре-индексировать задачу (никакого `index_task`; синк уже персистил задачу). Дёшево, фолбэк-only.
+
+**Зачем гейт «тонкий description»:** не тратить board-вызовы и LLM-токены на обычном инлайн-кейсе (большинство задач проекта PRI пишут критерии инлайн).
+
+**В скелете брифа (шаг 4):** секция `## Task` уже включает `criteria` — резолвнутые подзадачи попадают туда.
+
+## Часть (b): дедуп related-источников
+
+**Где:** шаги 3 и 4 `SKILL.md`.
+
+«Related work» собирается из `get_task_context` (linked) ∪ `search_tasks` (similar). Добавить явную инструкцию:
+
+- **дедупить по каноническому ключу задачи** до применения капа ≤3;
+- учитывать `PRI-N` ↔ `ID-N`: одна задача имеет канонический `key` (`ID-N`) и alias (`PRI-N`) — сопоставлять с учётом `aliases`, чтобы один и тот же таск из двух источников не задвоился;
+- при коллизии оставлять **linked**-запись (богаче: несёт PR/граф-контекст из `get_task_context`), similar-дубль отбрасывать.
+
+Прецедент формулировки уже есть в плейбуке: `task-context-yougile.md:37` дедупит `links[]` «merged and deduplicated by key».
+
+## Тесты
+
+Guard-тесты в `tests/skills/test_solve_task_brief.py` (репо-конвенция: `tests/skills/` стережёт инварианты `SKILL.md` grep'ом стабильных маркеров, не пиня формулировки). Добавить:
+
+- **(a)** ассерт, что `SKILL.md` несёт инструкцию резолва subtask→criteria при тонком description (маркеры: упоминание `subtask`/«подзадач», детектор-критериев, ссылка на плейбук `task-context-`).
+- **(b)** ассерт, что `SKILL.md` несёт дедуп related-источников (маркеры: «dedup»/«deduplicate», `linked`, `similar`).
+
+Стиль — как существующие `test_solve_task_*` (grep по стабильным подстрокам). Прогон: `.venv/bin/pytest tests/skills/test_solve_task_brief.py -q`.
+
+## Инварианты / ограничения
+
+- **Сохранить YAGNI инлайн-критериев:** при наличии секции критериев в `description` поведение не меняется (`criteria=[]`).
+- **Fail-open везде:** нет доски / нет подзадач / сбой board-MCP / Neo4j down → бриф собирается без criteria-обогащения и без дедупа-падений; скил никогда не абортит (политика шага 3).
+- **Никаких записей в движок:** часть (a) не вызывает `index_task` и не трогает стор/доску на запись.
+- **Server-side criteria-колонка — вне скоупа** (см. «Решение»).
+
+## Файлы
+
+- `plugin/skills/solve-task/SKILL.md` — шаги 2–4 (обе части).
+- `tests/skills/test_solve_task_brief.py` — guard-ассерты (a) и (b).
+- (без изменений: `reviewer/tasks/*`, плейбук `task-context-yougile.md` уже содержит механику резолва subtasks).

--- a/plugin/skills/solve-task/SKILL.md
+++ b/plugin/skills/solve-task/SKILL.md
@@ -79,6 +79,15 @@ brief to `superpowers:brainstorming` (which leads to writing-plans → subagent-
         - **Hit** (a task object with a `key`): use it directly as the `TaskBrief`. The task is
           already indexed (the preflight sync persisted it) — do NOT call `index_task`. Note in the
           brief that the task data came from the reviewer store (after sync).
+          - **Thin-criteria enrichment (optional, fail-open).** The store returns `criteria=[]` —
+            requirements normally live in `description`. If `description` has NO acceptance-criteria
+            heading (no section matching `(?i)(критери|приёмк|acceptance)`) AND a board is connected,
+            resolve the task's subtasks into `criteria[]` via the board-MCP playbook
+            `../review-pr/references/task-context-<task_board.type>.md` (its «Criteria note»):
+            one board `get_task(key)` → for each `subtasks[]` id resolve its title. Fold the resolved
+            criteria into the brief's `## Task` section only — do NOT call `index_task`. When the
+            heading IS present, criteria are inline in `description` → skip (leave `[]`). No board /
+            no subtasks / any error → leave `criteria` empty.
         - **Miss** (`null` / no `key`) AND a board is configured/connected: read the task via the
           playbook `../review-pr/references/task-context-<task_board.type>.md`, build a `TaskBrief`
           `{key, aliases[], title, description, criteria[], status, url, links[]}`, then call

--- a/plugin/skills/solve-task/SKILL.md
+++ b/plugin/skills/solve-task/SKILL.md
@@ -107,6 +107,9 @@ brief to `superpowers:brainstorming` (which leads to writing-plans → subagent-
      touched.
    - `search_tasks("<title>. <first lines of description>", project=<task_board.project>)` → semantically similar tasks. If a board
      is connected, you may read the most relevant similar tasks from the board for fuller detail.
+   - **Related work = linked ∪ similar.** The «Related work» brief section draws from two sources —
+     `get_task_context` (linked) and `search_tasks` (similar). They overlap; the Step 4 filter
+     deduplicates them by key before the cap.
    - `search_codebase("<task description>")` → relevant existing code (files/symbols to touch or
      mimic).
    - **Deepen via the code graph (optional — when `search_codebase` surfaced concrete symbols).**
@@ -155,6 +158,11 @@ Use the session-less tools above.
        you won't touch or copy; background you won't act on.
    - **Report what you dropped:** end the Related work and Relevant code sections with
      `(dropped N: reason)`.
+   - **Dedup related sources by key (linked ∪ similar).** «Related work» draws from
+     `get_task_context` (linked) and `search_tasks` (similar). Deduplicate by canonical task key
+     BEFORE the ≤3 cap, matching `PRI-N`↔`ID-N` via `aliases` (one task, two codes). On collision
+     keep the linked entry (richer — carries PR/graph context) and drop the similar duplicate, so a
+     task never appears twice in the brief.
 
    **Brief skeleton — fill it, keep each item to one line:**
 

--- a/tests/skills/test_solve_task_brief.py
+++ b/tests/skills/test_solve_task_brief.py
@@ -32,3 +32,11 @@ def test_solve_task_persists_brief():
     assert "Persist the brief" in text          # шаг персиста присутствует
     assert "file path" in text                  # хендофф ссылается на путь к файлу
     assert "Board-less" in text                 # сохранение и без ключа (slug)
+
+
+def test_solve_task_dedupes_related_sources():
+    """PRI-164(b): «Related work» дедупится по ключу между linked и similar."""
+    text = SOLVE.read_text(encoding="utf-8")
+    assert "Dedup related sources by key" in text   # явный шаг дедупа
+    assert "linked ∪ similar" in text               # оба источника, слитые
+    assert "canonical task key" in text             # дедуп по каноническому ключу

--- a/tests/skills/test_solve_task_brief.py
+++ b/tests/skills/test_solve_task_brief.py
@@ -40,3 +40,12 @@ def test_solve_task_dedupes_related_sources():
     assert "Dedup related sources by key" in text   # явный шаг дедупа
     assert "linked ∪ similar" in text               # оба источника, слитые
     assert "canonical task key" in text             # дедуп по каноническому ключу
+
+
+def test_solve_task_resolves_subtask_criteria_when_thin():
+    """PRI-164(a): при тонком description критерии дорезолвятся из подзадач (fail-open, без index_task)."""
+    text = SOLVE.read_text(encoding="utf-8")
+    assert "Thin-criteria enrichment" in text                 # шаг присутствует
+    assert "(?i)(критери|приёмк|acceptance)" in text          # детектор «тонкого» description
+    assert "subtasks" in text                                  # источник критериев — подзадачи
+    assert "do NOT call `index_task`" in text                  # обогащение только в бриф


### PR DESCRIPTION
## Задача
PRI-164 — гигиена брифа скилла `solve-task`. https://ru.yougile.com/team/686c049c8af8/#PRI-164

Две doc-правки в `plugin/skills/solve-task/SKILL.md` (+ guard-тесты), без изменений движка/БД.

## Что сделано
- **(a) Резолв subtask-criteria при тонком description** (шаг 2, ветка Hit): если `description` тонкий на критерии (нет заголовка `(?i)(критери|приёмк|acceptance)`) и доска подключена — дорезолвить подзадачи в `criteria[]` через board-MCP-плейбук `review-pr`. Только в бриф, **без `index_task`**, fail-open. Инлайн-критерии (заголовок есть) → `criteria` остаётся `[]` (YAGNI сохранён).
- **(b) Дедуп related-источников** (шаги 3–4): «Related work» дедупится по каноническому ключу между `get_task_context` (linked) ∪ `search_tasks` (similar) до капа ≤3, с учётом `PRI-N`↔`ID-N` через `aliases`; linked при коллизии в приоритете.

## Вне скоупа
Серверный путь (колонка `criteria` в `TaskRow`) — это DB-миграция, несоразмерно размеру S; отложено (`get_task`/`normalize` по-прежнему отдают `criteria=[]`).

## Тесты
Guard-тесты в `tests/skills/test_solve_task_brief.py` (grep маркеров инструкций). Полный unit-набор: 807 passed (исключая пред-существующий `tests/web` без `fastapi`).

## Трасса
бриф → спека → план в `docs/superpowers/{briefs,specs,plans}/2026-06-26-…pri-164…`.