### PR TITLE
fix(tasks): вложения YouGile из ссылок описания, не только из чата (PRI-196)

### DIFF
--- a/reviewer/tasks/boards/yougile.py
+++ b/reviewer/tasks/boards/yougile.py
@@ -9,6 +9,7 @@ REST API v2: base https://yougile.com/api-v2, заголовок Authorization: 
 """
 from __future__ import annotations
 
+import html
 import logging
 import re
 from collections.abc import Iterable
@@ -23,20 +24,32 @@ log = logging.getLogger(__name__)
 
 _PAGE = 1000
 
-# YouGile кодирует прикреплённый к чату файл маркером /root/#file:<url> в text сообщения
-# (POST /upload-file → {url}; см. send_task_file). Структурного списка файлов в API нет.
+# Структурного списка файлов YouGile в API не отдаёт. Файл попадает в задачу двумя путями:
+#  1) прикреплённый к задаче — HTML-ссылкой <a href="…/user-data/…"> в description
+#     (реальная модель, подтверждена на живой доске — PRI-196/PRI-197);
+#  2) прикреплённый в чате — маркером /root/#file:<url> в text/textHtml сообщения
+#     (POST /upload-file → {url}; см. send_task_file).
 _FILE_MARKER = re.compile(r"/root/#file:(\S+)")
+_HREF = re.compile(r"""href=["']([^"']+)["']""")
+_USER_DATA = "/user-data/"  # путь хранилища загруженных файлов YouGile
 
 
 def _file_urls_from_text(text: str | None) -> list[str]:
-    """Абсолютные URL файлов из YouGile-маркера /root/#file:<url> в тексте сообщения.
+    """URL загруженных в YouGile файлов из текста/HTML сообщения или описания задачи.
 
-    Если маркер пришёл из textHtml — обрезаем возможный HTML/кавычки-хвост.
+    Два источника: маркер ``/root/#file:<url>`` (доверяем — это всегда файл) и HTML-ссылка
+    ``<a href="…">``, ограниченная путём ``/user-data/`` (хранилище файлов), чтобы не качать
+    произвольные ссылки описания — на связанные задачи и т.п. ``&amp;`` в href разэкранируется.
     """
+    text = text or ""
     out: list[str] = []
-    for m in _FILE_MARKER.finditer(text or ""):
+    for m in _FILE_MARKER.finditer(text):
         url = re.split(r"[\"'<>\s]", m.group(1))[0]
         if url:
+            out.append(url)
+    for m in _HREF.finditer(text):
+        url = html.unescape(m.group(1)).strip()
+        if url and _USER_DATA in urlsplit(url).path:
             out.append(url)
     return out
 
@@ -166,13 +179,10 @@ class YougileBoard:
                         if limit and count >= limit:
                             return
 
-    def _attachments_from_chat(self, task_uuid: str) -> list[dict]:
-        """Вложения из сообщений чата задачи (best-effort, fail-soft).
+    def _chat_texts(self, task_uuid: str) -> list[str]:
+        """text + textHtml всех сообщений чата задачи (best-effort, fail-soft → []).
 
-        YouGile не отдаёт структурного списка файлов — они вшиты маркером
-        /root/#file:<url> в text/textHtml сообщений. chatId == внутренний UUID задачи.
-        Пустой/недоступный чат → []. fetch_attachment сам fail-soft (битый файл →
-        только метаданные). Имя файла — basename URL; mime неизвестен (диспатч по расширению).
+        chatId == внутренний UUID задачи. Пустой/недоступный чат → [].
         """
         if not task_uuid:
             return []
@@ -183,22 +193,43 @@ class YougileBoard:
         except Exception:
             log.warning("yougile: чат задачи %s недоступен", task_uuid, exc_info=True)
             return []
-        seen: set[str] = set()
-        out: list[dict] = []
+        texts: list[str] = []
         for msg in msgs:
             props = msg.get("properties") or {}
-            for field_text in (msg.get("text"), props.get("textHtml")):
-                for url in _file_urls_from_text(field_text):
-                    if url in seen:
-                        continue
-                    seen.add(url)
-                    if not host_allowed(url, self._att_domains):
-                        log.warning("yougile: файл чата %s вне домена доски — пропуск", url)
-                        continue
-                    out.append(fetch_attachment(
-                        self._client, name=_filename_from_url(url), mime=None,
-                        size=None, url=url, timeout=self._att_timeout,
-                        max_bytes=self._att_max_bytes, store_chars=self._att_store_chars))
+            texts.append(msg.get("text") or "")
+            texts.append(props.get("textHtml") or "")
+        return texts
+
+    def _fetch_urls(self, urls: list[str], seen: set[str], out: list[dict]) -> None:
+        """Скачать+распарсить новые (вне seen) URL; off-host пропустить (токен/SSRF).
+
+        fetch_attachment сам fail-soft (битый файл → только метаданные). Имя файла —
+        basename URL; mime неизвестен (диспатч парсинга по расширению).
+        """
+        for url in urls:
+            if url in seen:
+                continue
+            seen.add(url)
+            if not host_allowed(url, self._att_domains):
+                log.warning("yougile: файл %s вне домена доски — пропуск", url)
+                continue
+            out.append(fetch_attachment(
+                self._client, name=_filename_from_url(url), mime=None,
+                size=None, url=url, timeout=self._att_timeout,
+                max_bytes=self._att_max_bytes, store_chars=self._att_store_chars))
+
+    def _collect_attachments(self, description: str | None, task_uuid: str) -> list[dict]:
+        """Вложения задачи: файл-ссылки на /user-data/ из description + файлы из чата.
+
+        Источники объединяются и дедупятся по URL. best-effort: сбой любого слоя не валит
+        normalize (см. _chat_texts/_fetch_urls). Описание сканируется первым — это основной
+        путь прикрепления файла к задаче в YouGile (PRI-196).
+        """
+        seen: set[str] = set()
+        out: list[dict] = []
+        self._fetch_urls(_file_urls_from_text(description), seen, out)
+        for text in self._chat_texts(task_uuid):
+            self._fetch_urls(_file_urls_from_text(text), seen, out)
         return out
 
     def normalize(self, raw: RawTask) -> dict:
@@ -212,6 +243,6 @@ class YougileBoard:
                 subtask_titles[sid] = f"{code}:{st.get('title', '')}"
             except Exception:
                 log.warning("yougile: не резолвится подзадача %s", sid, exc_info=True)
-        attachments = self._attachments_from_chat(raw.board_id)
+        attachments = self._collect_attachments(raw.description, raw.board_id)
         return normalize_yougile(raw, self._key_pattern, self._url_template,
                                  subtask_titles, attachments=attachments)

--- a/tests/tasks/boards/test_yougile_normalize.py
+++ b/tests/tasks/boards/test_yougile_normalize.py
@@ -173,3 +173,53 @@ def test_yougile_normalize_skips_offhost_chat_file():
     brief = board.normalize(_raw(board_id=UUID, subtask_ids=[]))
     assert brief["attachments"] == []
     assert "https://evil.example.com/x.md" not in board._client.requested
+
+
+def test_yougile_normalize_pulls_file_from_description_href():
+    """Файл-вложение приходит HTML-ссылкой на /user-data/ в description (реальная модель PRI-196).
+
+    Так YouGile рендерит прикреплённый к задаче файл — не маркером /root/#file: в чате
+    (чат при этом пуст), а <a href="…/user-data/…"> в описании задачи.
+    """
+    href = ('<p><br><a target="_blank" rel="noopener noreferrer" '
+            'href="https://yougile.com/user-data/abc/Te.md">Te.md</a></p>')
+    routes = {
+        f"/chats/{UUID}/messages": _FakeYResp(json_data={"content": []}),
+        "https://yougile.com/user-data/abc/Te.md": _FakeYResp(content="Тестовая".encode()),
+    }
+    board = _board_with(routes)
+    brief = board.normalize(_raw(key="ID-10", board_id=UUID, description=href, subtask_ids=[]))
+    att = next(a for a in brief["attachments"] if a["name"] == "Te.md")
+    assert att["content_text"] == "Тестовая"
+
+
+def test_yougile_normalize_unescapes_amp_in_href():
+    """&amp; в href восстанавливается в & перед скачиванием (URL с query-подписью)."""
+    href = '<a href="https://yougile.com/user-data/x/d.txt?a=1&amp;b=2">d.txt</a>'
+    routes = {
+        f"/chats/{UUID}/messages": _FakeYResp(json_data={"content": []}),
+        "https://yougile.com/user-data/x/d.txt?a=1&b=2": _FakeYResp(content="D".encode()),
+    }
+    board = _board_with(routes)
+    brief = board.normalize(_raw(board_id=UUID, description=href, subtask_ids=[]))
+    assert any(a["name"] == "d.txt" and a["content_text"] == "D" for a in brief["attachments"])
+
+
+def test_yougile_normalize_ignores_nonfile_description_links():
+    """Обычная ссылка в описании (не на /user-data/) не качается — только файлы-вложения."""
+    desc = '<a href="https://yougile.com/team/T/#PRI-5">PRI-5</a>'
+    routes = {f"/chats/{UUID}/messages": _FakeYResp(json_data={"content": []})}
+    board = _board_with(routes)
+    brief = board.normalize(_raw(board_id=UUID, description=desc, subtask_ids=[]))
+    assert brief["attachments"] == []
+    assert "https://yougile.com/team/T/#PRI-5" not in board._client.requested
+
+
+def test_yougile_normalize_skips_offhost_description_href():
+    """Off-host файл-ссылка в описании не скачивается (защита токена/SSRF, PRI-196)."""
+    desc = '<a href="https://evil.example.com/user-data/x/leak.md">leak.md</a>'
+    routes = {f"/chats/{UUID}/messages": _FakeYResp(json_data={"content": []})}
+    board = _board_with(routes)
+    brief = board.normalize(_raw(board_id=UUID, description=desc, subtask_ids=[]))
+    assert brief["attachments"] == []
+    assert "https://evil.example.com/user-data/x/leak.md" not in board._client.requested


### PR DESCRIPTION
## Проблема (найдена на живой доске)

PR #78 доставал вложения YouGile **только из чата** по маркеру `/root/#file:<url>` — по community-модели, которую не удалось провалидировать на живых данных (доска была пустой).

На реальной задаче `PRI-197` модель оказалась другой:
- файл, прикреплённый к задаче, попадает в **`description`** обычной HTML-ссылкой:
  `<a href="https://yougile.com/user-data/.../Te.md">Te.md</a>`;
- **чат при этом пуст** (`count: 0`).

Старый код такие вложения не находил вовсе.

## Фикс

- `_file_urls_from_text` дополнительно извлекает `href` на путь `/user-data/` (хранилище файлов YouGile), с `html.unescape` для `&amp;` в URL с query-подписью. Ветка `href` ограничена `/user-data/`, чтобы не качать произвольные ссылки описания (на связанные задачи и т.п.).
- Сбор вложений (`_collect_attachments`) сканирует **`description` и чат**, дедупает по URL.
- Маркеры `/root/#file:` в чате продолжают работать (fallback для файлов из чата).

## Безопасность

Гейт по домену доски (allowlist из C1 PR #78) сохранён — off-host-ссылка из описания **не запрашивается** (защита Bearer-токена и SSRF), как и для чата.

## Тесты

`878 passed` (4 новых, моделируют реальный `PRI-197`):
- файл из `href` описания распарсен;
- `&amp;` в href разэкранирован;
- обычная (не `/user-data/`) ссылка описания **не** качается;
- off-host файл-ссылка описания **не** качается.

ruff чист.

## Не входит в PR

- **YouTrack** не затронут — его модель (структурное поле `attachments`) корректна по разбору, но **вживую не перепроверена** (нет доступа к инстансу из среды разработки); валидируется ре-синком после передеплоя.
- Для перепроверки уже синкнутых задач помните про watermark: обычный `sync_board` их пропустит (`timestamp <= cursor`) — нужно тронуть задачу или сбросить курсор (`DELETE FROM index_meta WHERE repo='' AND ref LIKE 'tasks:%'`).