### PR TITLE
feat(solve-task): проверка существующих briefs/specs/plans + починка glob (PRI-176)

### DIFF
--- a/docs/superpowers/briefs/2026-06-29-PRI-176-check-existing-briefs-plans-specs.md
+++ b/docs/superpowers/briefs/2026-06-29-PRI-176-check-existing-briefs-plans-specs.md
@@ -1,0 +1,40 @@
+# Brief — PRI-176 solve-task: проверка существующих briefs/plans/specs по ключу
+url: https://ru.yougile.com/team/686c049c8af8/#PRI-176
+
+## Task
+- **Ключ:** PRI-176. **Слой:** плагин/скил `solve-task` (`plugin/skills/solve-task/SKILL.md`) + guard-тест `tests/skills/test_solve_task_brief.py`.
+- **Проблема 1:** glob-паттерн идемпотентности `docs/superpowers/briefs/<date>-<KEY>-*.md` привязан к сегодняшней дате → повторный прогон на другой день создаёт дубликат брифа.
+- **Проблема 2:** solve-task не проверяет downstream-артефакты (spec/plan) перед перезаписью брифа.
+- **Решение:** (1) заменить glob на `*-<KEY>-*.md` (без даты); (2) перед дистилляцией брифа искать `*<KEY>*` в `briefs/`, `*<key>*-design.md` в `specs/`, `*<key>*.md` в `plans/` (case-insensitive); (3) предупреждать пользователя, но не блокировать; (4) найденные артефакты писать в `## Constraints` с тегом `[existing_artifacts]`.
+- **Критерии:** правильный glob, case-insensitive поиск по трём директориям, предупреждение (не блокировка), тег в Constraints, guard-тесты в `test_solve_task_brief.py`.
+
+## Related work
+- **PRI-163 (ID-163)** — персист брифа и idempotency-логика, которую чиним (`plugin/skills/solve-task/SKILL.md` шаг 4, PR #69). ✓ reuse
+- **PRI-164 (ID-164)** — brief hygiene, guard-тесты `test_solve_task_brief.py` (PR #72). ✓ reuse стиль guard-тестов.
+- **PRI-146 (ID-146)** — спека brief + relevance-фильтр, задаёт скелет брифа и секцию Constraints.
+- (dropped 2: PRI-177 — трассируемость brief→spec, смежная но отдельная; PRI-187 — верификация перед hand-off, задача явно исключает.)
+
+## Subsystems
+- **tests/skills** — guardrail-тесты скиллов; здесь живут маркер-проверки `SKILL.md`.
+- **plugin/hooks** — хук `brief_cost` следит за папкой `docs/superpowers/briefs/`, но не в скоупе правки.
+- (dropped 1: reviewer/tasks — store-first/get_task не трогаем.)
+
+## Relevant code
+- `plugin/skills/solve-task/SKILL.md:207` — **цель правки**: `glob \`docs/superpowers/briefs/<date>-<KEY>-*.md\`` → заменить на паттерн без даты; добавить pre-brief check и warning.
+- `tests/skills/test_solve_task_brief.py:13-54` — **расширить guard-тесты**: маркеры glob-шаблона, упоминание `docs/superpowers/specs/` и `docs/superpowers/plans/`, case-insensitive search, предупреждение-не-блокировка.
+- `docs/superpowers/briefs/2026-06-26-PRI-164-solve-task-brief-hygiene.md` — пример имени брифа (дата-KEY-slug).
+- `docs/superpowers/plans/2026-06-26-pri-164-solve-task-brief-hygiene.md` — пример плана (дата-pri-N-slug, lowercase).
+- `docs/superpowers/specs/2026-06-26-pri-164-solve-task-brief-hygiene-design.md` — пример спеки (суффикс `-design.md`, lowercase).
+- (dropped 1: `plugin/hooks/brief_cost.py:156-158` — использует `/docs/superpowers/briefs/`, но не правим.)
+
+## Test exemplars
+- `tests/skills/test_solve_task_brief.py:28-34` — `test_solve_task_persists_brief()`: стиль guard-теста `SKILL.md` (PRI-163).
+- `tests/skills/test_solve_task_brief.py:37-43` — `test_solve_task_dedupes_related_sources()`: пример guard'а для новой логики solve-task.
+- (dropped 1: `tests/skills/test_solve_task_brief.py:46-51` — criteria enrichment, не относится к этой задаче.)
+
+## Constraints / open questions
+- **Case-insensitive glob:** на Linux/macOS glob чувствителен к регистру; инструкция должна требовать case-insensitive матчинг (например, два globs `*PRI-176*` + `*pri-176*` или fnmatch с lowercased именами).
+- **Не блокировать:** warning → `[Y/n]`; при продолжении — тег `[existing_artifacts]` в Constraints.
+- **Spec-суффикс:** спеки ищем по `*--*-design.md`? Нет, задача говорит `*--*design.md` (суффикс `-design.md`).
+- **Board-less:** для задачи без ключа искать по slug (out of scope этой задачи? Текущий скоуп — по ключу).
+- **Индекс свежий:** drift=0, summaries warm, corpus warm (PRI).

--- a/docs/superpowers/plans/2026-06-29-pri-176-check-existing-artifacts.md
+++ b/docs/superpowers/plans/2026-06-29-pri-176-check-existing-artifacts.md
@@ -1,0 +1,164 @@
+# PRI-176 check existing artifacts — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** В скиле `solve-task` починить glob-паттерн идемпотентности брифа и добавить предупреждение о существующих brief/spec/plan перед перезаписью.
+
+**Architecture:** Изменения исключительно в `plugin/skills/solve-task/SKILL.md` (параграф **Persist the brief**) + guard-тест в `tests/skills/test_solve_task_brief.py`. TDD: сначала падающий guard-тест, потом правка SKILL.md.
+
+**Tech Stack:** Markdown (SKILL.md), Python 3.11+, pytest.
+
+---
+
+## Global Constraints
+
+- Тело `SKILL.md` пишется **по-английски** (соответствие существующему скилу); тест-докстринги — на русском.
+- Без правок движка/БД/миграций.
+- Коммиты: Conventional Commits на русском, **без self-attribution**.
+- Линт: `ruff check tests/skills/test_solve_task_brief.py`.
+- Guard-тесты — маркер-проверки текста SKILL.md, не пинят точные формулировки.
+
+---
+
+### Task 1: Guard-тест для новой логики
+
+**Files:**
+- Modify: `tests/skills/test_solve_task_brief.py`
+
+**Interfaces:**
+- Consumes: текущий `plugin/skills/solve-task/SKILL.md`.
+- Produces: падающий guard-тест `test_solve_task_warns_on_existing_artifacts`.
+
+- [ ] **Step 1: Добавить падающий guard-тест**
+
+В конец `tests/skills/test_solve_task_brief.py` добавить:
+
+```python
+
+def test_solve_task_warns_on_existing_artifacts():
+    """PRI-176: solve-task проверяет существующие briefs/specs/plans и предупреждает, не блокируя."""
+    text = SOLVE.read_text(encoding="utf-8")
+    assert "*-<KEY>-*.md" in text               # glob без даты
+    assert "docs/superpowers/specs/" in text    # проверка спек
+    assert "docs/superpowers/plans/" in text    # проверка планов
+    assert "case-insensitive" in text            # insensitive matching
+    assert "[Y/n]" in text                       # предупреждение с выбором
+    assert "[existing_artifacts]" in text        # тег в Constraints
+    assert "Do NOT block" in text or "not block" in text  # не блокировка
+```
+
+- [ ] **Step 2: Запустить тест — убедиться, что падает**
+
+Run: `.venv/bin/pytest tests/skills/test_solve_task_brief.py::test_solve_task_warns_on_existing_artifacts -q`
+
+Expected: FAIL — первый ассерт `assert "*-<KEY>-*.md" in text` не проходит, т.к. в SKILL.md ещё старый паттерн `<date>-<KEY>-*.md`.
+
+---
+
+### Task 2: Правка SKILL.md
+
+**Files:**
+- Modify: `plugin/skills/solve-task/SKILL.md` (параграф **Persist the brief**, строки ~199–212)
+
+**Interfaces:**
+- Consumes: текущий параграф **Persist the brief**.
+- Produces: исправленный glob + новый подпункт **Check for existing artifacts**.
+
+- [ ] **Step 3: Починить glob-паттерн**
+
+В `plugin/skills/solve-task/SKILL.md` заменить:
+
+```markdown
+   - **Idempotency:** before writing, glob `docs/superpowers/briefs/<date>-<KEY>-*.md` and overwrite
+     the match if any (slug drift between runs must not spawn duplicates); board-less → exact name.
+```
+
+на:
+
+```markdown
+   - **Idempotency:** before writing, glob `docs/superpowers/briefs/*-<KEY>-*.md` and overwrite
+     the match if any (slug drift between runs must not spawn duplicates); board-less → exact name.
+```
+
+- [ ] **Step 4: Добавить подпункт проверки существующих артефактов**
+
+В `plugin/skills/solve-task/SKILL.md`, **перед** подпунктом **Idempotency** (т.е. между **Content** и **Idempotency**, или в начале списка после введения параграфа), вставить:
+
+```markdown
+   - **Check for existing artifacts (warn, don't block).** Before writing the brief, scan the
+     three artifact directories for files matching this task key (case-insensitive):
+     - `docs/superpowers/briefs/*<KEY>*`
+     - `docs/superpowers/specs/*<key>*-design.md`
+     - `docs/superpowers/plans/*<key>*.md`
+     Use case-insensitive matching (e.g., try both `PRI-176` and `pri-176` globs, or lowercase
+     file names before matching). If any artifacts are found, warn the user (in Russian):
+     > "⚠️ Похожие артефакты уже существуют: briefs/PRI-176-..., specs/pri-176-...-design.md,
+     > plans/pri-176-....md. Продолжить? [Y/n]"
+     Do **not** block — continue unless the user explicitly says no. If the user continues (or
+     auto-permission mode leaves no choice), list the found artifacts under `## Constraints` with
+     the tag `[existing_artifacts]`.
+```
+
+**Placement note:** этот подпункт должен находиться внутри параграфа **Persist the brief**, желательно перед **Idempotency**, чтобы логика была: проверить → предупредить → перезаписать.
+
+- [ ] **Step 5: Запустить guard-тест — убедиться, что проходит**
+
+Run: `.venv/bin/pytest tests/skills/test_solve_task_brief.py::test_solve_task_warns_on_existing_artifacts -q`
+
+Expected: PASS.
+
+---
+
+### Task 3: Регрессионный прогон и линт
+
+**Files:**
+- Test: `tests/skills/test_solve_task_brief.py`
+- Test: `tests/skills/` (весь каталог)
+
+- [ ] **Step 6: Прогнать весь `tests/skills/` — нет регрессий**
+
+Run: `.venv/bin/pytest tests/skills/ -q`
+
+Expected: PASS (все guard-тесты скиллов зелёные).
+
+- [ ] **Step 7: Линт**
+
+Run: `.venv/bin/ruff check tests/skills/test_solve_task_brief.py`
+
+Expected: без ошибок в изменённом файле.
+
+---
+
+### Task 4: Коммит
+
+**Files:**
+- Modify: `plugin/skills/solve-task/SKILL.md`
+- Modify: `tests/skills/test_solve_task_brief.py`
+
+- [ ] **Step 8: Коммит**
+
+```bash
+git add plugin/skills/solve-task/SKILL.md tests/skills/test_solve_task_brief.py
+git commit -m "feat(solve-task): проверка существующих briefs/specs/plans + починка glob (PRI-176)"
+```
+
+---
+
+## Self-Review
+
+**1. Spec coverage:**
+- Исправление glob на `*-<KEY>-*.md` → Task 2 Step 3. ✓
+- Проверка `briefs/`/`specs/`/`plans/` → Task 2 Step 4. ✓
+- Case-insensitive matching → Task 2 Step 4. ✓
+- Предупреждение `[Y/n]` и не-блокировка → Task 2 Step 4. ✓
+- Тег `[existing_artifacts]` в Constraints → Task 2 Step 4. ✓
+- Guard-тест → Task 1. ✓
+- Регрессионный прогон + линт → Task 3. ✓
+
+**2. Placeholder scan:**
+- Нет TBD/TODO.
+- Все шаги содержат конкретные команды и код.
+- Пути файлов точные.
+
+**3. Type/marker consistency:**
+- Маркеры теста (`*-<KEY>-*.md`, `docs/superpowers/specs/`, `docs/superpowers/plans/`, `case-insensitive`, `[Y/n]`, `[existing_artifacts]`, `not block`) совпадают с текстом, добавляемым в SKILL.md Task 2 Step 4.

--- a/docs/superpowers/specs/2026-06-29-PRI-176-check-existing-artifacts-design.md
+++ b/docs/superpowers/specs/2026-06-29-PRI-176-check-existing-artifacts-design.md
@@ -1,0 +1,107 @@
+# PRI-176 — solve-task: проверка существующих briefs/plans/specs по ключу
+
+**Задача:** https://ru.yougile.com/team/686c049c8af8/#PRI-176  
+**Бриф:** `docs/superpowers/briefs/2026-06-29-PRI-176-check-existing-briefs-plans-specs.md`  
+**Размер:** S. **Слой:** плагин/скил `solve-task`.
+
+## Проблема
+
+Скил `solve-task` (PRI-163) персистит solution brief в `docs/superpowers/briefs/`. Две проблемы:
+
+1. **Баг в glob-паттерне идемпотентности.** Текущий паттерн `docs/superpowers/briefs/<date>-<KEY>-*.md` привязан к сегодняшней дате. Если бриф создан вчера (`2026-06-28-PRI-164-...`), а сегодня (`2026-06-29`) запустить `solve-task PRI-164` — поиск `2026-06-29-PRI-164-*.md` ничего не найдёт и создаст дубликат.
+2. **Нет проверки downstream-артефактов.** Для задачи, уже прошедшей полный цикл (бриф → спека → план), повторный `solve-task` молча перезаписывает бриф, не предупреждая, что спека и план уже существуют.
+
+## Решение
+
+Правки только в `plugin/skills/solve-task/SKILL.md` (параграф **Persist the brief**) + guard-тест в `tests/skills/test_solve_task_brief.py`. Никакой исполняемой логики — инструкции для LLM-агента, который выполняет скил.
+
+### 1. Починить glob-паттерн
+
+Заменить:
+
+```markdown
+- **Idempotency:** before writing, glob `docs/superpowers/briefs/<date>-<KEY>-*.md` and overwrite
+  the match if any (slug drift between runs must not spawn duplicates); board-less → exact name.
+```
+
+на:
+
+```markdown
+- **Idempotency:** before writing, glob `docs/superpowers/briefs/*-<KEY>-*.md` and overwrite
+  the match if any (slug drift between runs must not spawn duplicates); board-less → exact name.
+```
+
+Паттерн `*-<KEY>-*.md` не привязан к дате и находит любой бриф для этого ключа независимо от даты создания.
+
+### 2. Pre-brief artifact check
+
+Добавить подпункт в параграф **Persist the brief**, **сразу перед** подпунктом **Idempotency**:
+
+```markdown
+   - **Check for existing artifacts (warn, don't block).** Before writing the brief, scan the
+     three artifact directories for files matching this task key (case-insensitive):
+     - `docs/superpowers/briefs/*<KEY>*`
+     - `docs/superpowers/specs/*<key>*-design.md`
+     - `docs/superpowers/plans/*<key>*.md`
+     Use case-insensitive matching (e.g., try both `PRI-176` and `pri-176` globs, or lowercase
+     file names before matching). If any artifacts are found, warn the user (in Russian):
+     > "⚠️ Похожие артефакты уже существуют: briefs/PRI-176-..., specs/pri-176-...-design.md,
+     > plans/pri-176-....md. Продолжить? [Y/n]"
+     Do **not** block — continue unless the user explicitly says no. If the user continues (or
+     auto-permission mode leaves no choice), list the found artifacts under `## Constraints` with
+     the tag `[existing_artifacts]`.
+```
+
+**Case-insensitive matching:** на macOS/Linux glob чувствителен к регистру. Инструкция требует явно приводить имена файлов к нижнему регистру (или перебирать оба варианта `PRI-N`/`pri-N`) перед сопоставлением.
+
+### 3. Тег в Constraints
+
+Если артефакты найдены и пользователь продолжил, в `## Constraints / open questions` брифа добавлять строку:
+
+```markdown
+- `[existing_artifacts] Найдены: briefs/PRI-176-..., specs/pri-176-...-design.md`
+```
+
+### 4. Guard-тест
+
+В `tests/skills/test_solve_task_brief.py` добавить:
+
+```python
+def test_solve_task_warns_on_existing_artifacts():
+    """PRI-176: solve-task проверяет существующие briefs/specs/plans и предупреждает, не блокируя."""
+    text = SOLVE.read_text(encoding="utf-8")
+    assert "*-<KEY>-*.md" in text               # glob без даты
+    assert "docs/superpowers/specs/" in text    # проверка спек
+    assert "docs/superpowers/plans/" in text    # проверка планов
+    assert "case-insensitive" in text            # insensitive matching
+    assert "[Y/n]" in text                       # предупреждение с выбором
+    assert "[existing_artifacts]" in text        # тег в Constraints
+    assert "Do NOT block" in text or "not block" in text  # не блокировка
+```
+
+## Что НЕ делаем
+
+- **Не модифицируем** `superpowers:brainstorming` / `superpowers:writing-plans` — они human-gated.
+- **Не добавляем новый риск-тег в список #8** Constraints — `[existing_artifacts]` это информационный тег.
+- **Не меняем** формат имён файлов (`YYYY-MM-DD-<KEY>-<slug>.md`) — только glob для их поиска.
+- **Не делаем** server-side логику: это markdown-скил, исполняемый LLM-агентом.
+
+## Критерии приёмки
+
+- В `SKILL.md` glob-паттерн идемпотентности использует `*-<KEY>-*.md` (без даты).
+- В `SKILL.md` описан case-insensitive поиск по `briefs/`, `specs/`, `plans/`.
+- В `SKILL.md` есть текст предупреждения `[Y/n]` и явное требование не блокировать.
+- В `SKILL.md` есть требование писать `[existing_artifacts]` в Constraints при продолжении.
+- `tests/skills/test_solve_task_brief.py` содержит guard-тест на все маркеры выше.
+- Все существующие guard-тесты `tests/skills/` продолжают проходить.
+
+## Затрагиваемые файлы
+
+- `plugin/skills/solve-task/SKILL.md` — параграф **Persist the brief**.
+- `tests/skills/test_solve_task_brief.py` — новый guard-тест.
+
+## Вне скоупа
+
+- Автоматическая ротация/чистка старых брифов.
+- Жёсткие перекрёстные ссылки между brief/spec/plan.
+- Board-less режим (может быть затронут опционально, но не является критерием).

--- a/plugin/skills/solve-task/SKILL.md
+++ b/plugin/skills/solve-task/SKILL.md
@@ -204,7 +204,19 @@ Use the session-less tools above.
      matching `key_pattern` (e.g. `PRI-163`, NOT the normalized store key `ID-163`) and `slug` is a
      short ASCII kebab of the title. **Board-less** (no key): `YYYY-MM-DD-<slug>.md` (slug from the
      user's formulation). `YYYY-MM-DD` = today's date.
-   - **Idempotency:** before writing, glob `docs/superpowers/briefs/<date>-<KEY>-*.md` and overwrite
+   - **Check for existing artifacts (warn, don't block).** Before writing the brief, scan the
+     three artifact directories for files matching this task key (case-insensitive):
+     - `docs/superpowers/briefs/*<KEY>*`
+     - `docs/superpowers/specs/*<key>*-design.md`
+     - `docs/superpowers/plans/*<key>*.md`
+     Use case-insensitive matching (e.g., try both `PRI-176` and `pri-176` globs, or lowercase
+     file names before matching). If any artifacts are found, warn the user (in Russian):
+     > "⚠️ Похожие артефакты уже существуют: briefs/PRI-176-..., specs/pri-176-...-design.md,
+     > plans/pri-176-....md. Продолжить? [Y/n]"
+     Do **not** block — continue unless the user explicitly says no. If the user continues (or
+     auto-permission mode leaves no choice), list the found artifacts under `## Constraints` with
+     the tag `[existing_artifacts]`.
+   - **Idempotency:** before writing, glob `docs/superpowers/briefs/*-<KEY>-*.md` and overwrite
      the match if any (slug drift between runs must not spawn duplicates); board-less → exact name.
    - **Content:** the distilled brief verbatim (the `# Brief — <KEY> <title>` skeleton); add the
      task `url` on the line below the heading when available, for grep-by-key.

--- a/tests/skills/test_solve_task_brief.py
+++ b/tests/skills/test_solve_task_brief.py
@@ -56,3 +56,15 @@ def test_solve_task_includes_test_exemplars():
     text = SOLVE.read_text(encoding="utf-8")
     assert "include_tests=True" in text     # тест-ретрив в шаге 3
     assert "Test exemplars" in text         # секция скелета брифа
+
+
+def test_solve_task_warns_on_existing_artifacts():
+    """PRI-176: solve-task проверяет существующие briefs/specs/plans и предупреждает, не блокируя."""
+    text = SOLVE.read_text(encoding="utf-8")
+    assert "*-<KEY>-*.md" in text               # glob без даты
+    assert "docs/superpowers/specs/" in text    # проверка спек
+    assert "docs/superpowers/plans/" in text    # проверка планов
+    assert "case-insensitive" in text            # insensitive matching
+    assert "[Y/n]" in text                       # предупреждение с выбором
+    assert "[existing_artifacts]" in text        # тег в Constraints
+    assert "Do NOT block" in text or "not block" in text  # не блокировка


### PR DESCRIPTION
## Summary

- Исправлен glob-паттерн идемпотентности solve-task: `<date>-<KEY>-*.md` → `*-<KEY>-*.md`.
- Добавлена pre-brief проверка существующих артефактов в `briefs/`, `specs/` и `plans/` по ключу задачи (case-insensitive).
- При обнаружении артефактов — предупреждение пользователя с `[Y/n]` и продолжение без блокировки.
- Найденные артефакты записываются в `## Constraints` брифа с тегом `[existing_artifacts]`.
- Добавлен guard-тест `test_solve_task_warns_on_existing_artifacts` в `tests/skills/test_solve_task_brief.py`.

## Test Plan

- [x] `.venv/bin/pytest tests/skills/ -q` — 67 passed
- [x] `.venv/bin/ruff check tests/skills/test_solve_task_brief.py` — clean

## Related

- Задача: PRI-176
- Бриф: `docs/superpowers/briefs/2026-06-29-PRI-176-check-existing-briefs-plans-specs.md`
- Спека: `docs/superpowers/specs/2026-06-29-PRI-176-check-existing-artifacts-design.md`
- План: `docs/superpowers/plans/2026-06-29-pri-176-check-existing-artifacts.md`