### PR TITLE
feat: server-side discovery done-цели доски (get_board_targets) — PRI-205

### DIFF
--- a/docs/superpowers/briefs/2026-07-02-PRI-205-server-side-done-target-discovery.md
+++ b/docs/superpowers/briefs/2026-07-02-PRI-205-server-side-done-target-discovery.md
@@ -1,0 +1,60 @@
+# Brief — PRI-205 Server-side discovery done-цели доски (колонки YouGile + поля/значения YouTrack) для configure-review — без стороннего MCP
+url: https://ru.yougile.com/team/686c049c8af8/#PRI-205
+
+_Источник данных задачи: reviewer-store (после preflight `sync_board`). Индекс свеж (drift==0), сводки тёплые._
+
+## Task
+- **PRI-205** (alias ID-205, статус «Бэклог»). Продолжение фичи *configurable-done-target* (`finish_task`).
+- **Проблема:** done-цель (`done_column` для YouGile; `status_field`+`done_state` для YouTrack) в `.review.yml` сейчас заполняется вручную, подсматривая точные названия в UI. Для YouTrack особенно больно: на клиенте нет YouTrack-MCP, а у сервера нет тула отдать поля/значения. configure-review в YouGile-ветке к тому же опирается на сторонний `mcp__yougile__get_columns`.
+- **Цель:** новый server-side reviewer MCP-тул `get_board_targets(board_type, project)` (имя обсуждаемо: `describe_board_targets`) — по типу доски+проекту возвращает кандидатов done-цели, используя REST-креды сервера (env). configure-review показывает pick-list вместо ручного ввода — и для YouGile, и для YouTrack, БЕЗ board-MCP на клиенте (симметрично `sync_board`/`finish_task`).
+- **Scope:** (1) provider-методы: YouGile `list_columns(project)` → колонки досок проекта `{title,id,boardId}`; YouTrack `list_status_fields(project)` → поля-состояния/enum + значения бандла `[{field, values:[…]}]` (admin customFields API; фолбэк — агрегировать `value(name)`+`$type` из выборки задач). (2) MCP-тул `get_board_targets` — fail-soft, репо-агностичен, креды НЕ возвращает. (3) configure-review: pick-list вместо ручного ввода `done_column`/`status_field`/`done_state`, ask-фолбэк; убрать клиентский `get_columns`. (4) finish-task step 4: явно называть резолвнутую цель. (5) unit-тесты (мок httpx) + guard-тесты + опц. интеграция. (6) деплой: бамп версии + PyPI → reviewer update → live-приёмка на обеих досках.
+- **Acceptance:** configure-review на YouGile-репо БЕЗ клиентского MCP предлагает реальные колонки → выбор `done_column`; на YouTrack-репо предлагает поля статуса + значения → выбор `status_field`/`done_state` (напр. `Stage`/`Готово`); finish-task в подтверждении явно называет цель переноса/статуса.
+- **Инварианты:** креды только в env (не в `.review.yml`, не в возврате тула); fail-soft (недоступна доска/права → пустой список → скилл откатывается на вопрос); repo-агностичность сервера (`.review.yml` сервер не парсит); discovery — только ЧТЕНИЕ (перенос/completed по-прежнему через `finish_task` с подтверждением).
+
+## Related work
+- **configurable-done-target** — `docs/superpowers/specs/2026-07-02-configurable-done-target-design.md` — прямой предшественник (0.2.23): добавил `done_column`/`status_field`/`done_state` в `finish_task` + `provider.finish`. PRI-205 = discovery-надстройка (читать доступные значения вместо ручного ввода). **Паттерн к переиспользованию:** server-side, креды в env, репо-агностичный тул принимает `board_type`+`project` параметрами, клиент читает `.review.yml` и передаёт.
+- **configure-review context-limits** — `docs/superpowers/specs/2026-07-01-configure-review-context-limits.md` — свежий образец расширения configure-review: `count_tasks(project)` best-effort → **фолбэк на вопрос** при отсутствии тула/пустом корпусе. Точный шаблон «pick-list из server-тула ИЛИ ask».
+- **PRI-168 configure-review skill** — `docs/superpowers/specs/2026-06-24-pri-168-configure-review-skill.md` — базовая структура скилла (step 5b task_board / done-target — точка правки).
+- **youtrack-board-provider** — `docs/superpowers/specs/2026-06-24-youtrack-board-provider.md` — `customFields`/`_FIELDS`/`_state_of`, источник значений для `list_status_fields`.
+- **PRI-170 task-board-project-scope** — `docs/superpowers/specs/2026-06-24-pri-170-task-board-project-scope.md` — `project_prefix` скоуп (для `list_columns(project)`, как `iter_raw`).
+- (dropped 2: `get_task_context` пуст — у PRI-205 нет связанных задач/PR; `search_tasks` вернул только ID-204 TEST-мусор и PRI-203 grounding — иной механизм, не информируют реализацию.)
+
+## Subsystems
+- **reviewer/tasks** — REST-провайдеры досок (yougile/youtrack), нормализация, `finish`. Место для новых discovery-методов провайдера.
+- **reviewer/mcp** — сервисный слой MCP (`finish_task`/`sync_board`/`board_config`). Место для метода-делегата `get_board_targets` в `MCPReviewService`.
+- **reviewer/entrypoints** — CLI + MCP-сервер (регистрация 33+ тулов через FastMCP). Место `@mcp.tool() get_board_targets`.
+- **reviewer/config** — `Settings`: `board_creds`/`configured_board_types` (креды из env, наружу не отдаются через `board_config`).
+
+## Relevant code
+- `reviewer/tasks/boards/yougile.py:251` — `_resolve_column_id`: логику резолва колонок доски (GET `/columns/{cur}`→`boardId`; GET `/columns?boardId` match по `title`) вынести/переиспользовать в публичном `list_columns(project)`.
+- `reviewer/tasks/boards/yougile.py:139` / `:157-160` — `_get_all("/columns", {"boardId"})` внутри `iter_raw` (обход projects→boards→columns) — готовый паттерн перечисления колонок, скоупить по `project_prefix`.
+- `reviewer/tasks/boards/yougile.py:270` — `finish` (использует `_resolve_column_id`, возвращает `column_moved`) — контракт done-колонки, который discovery наполняет.
+- `reviewer/tasks/boards/youtrack.py:24` — `_FIELDS` (`customFields(name,value(name))`) и `:43` `_state_of` — источник значений для фолбэк-агрегации `list_status_fields` из выборки задач.
+- `reviewer/tasks/boards/youtrack.py:207` / `:233` / `:261` — `finish`: GET `customFields(name,$type,value($type,name))` + `_FIELD_TO_ELEMENT` — паттерн запроса типов/значений полей для discovery.
+- `reviewer/tasks/boards/base.py:43` — `TaskBoardProvider` (Protocol): добавить сигнатуры `list_columns`/`list_status_fields` (discovery-методы, доска-специфичные); `:17` `project_prefix` — скоуп по проекту.
+- `reviewer/tasks/boards/__init__.py:10` — `make_board_provider(settings, type_, status_field=...)`: фабрика провайдера из `board_creds` (env). **Blast radius:** зовётся в `service.finish_task:342` и `make_board_providers:53` — `get_board_targets` пойдёт тем же путём.
+- `reviewer/mcp/service.py:324` `finish_task` / `:299` `sync_board` / `:281` `board_config` — эталон server-side тула (резолв `configured_board_types`, `make_board_provider`, `provider.close()` в finally, fail-soft try/except). Сюда добавить `get_board_targets(board_type, project)`.
+- `reviewer/entrypoints/mcp_server.py:120` `finish_task` / `:166` `get_board_config` — паттерн `@mcp.tool()`-регистрации (тонкий делегат в `service`).
+- `plugin/skills/configure-review/SKILL.md:125-137` — step 5b done-target: заменить ручной ввод `done_column`/`status_field`/`done_state` на pick-list из нового тула; **`:131-132`** явная ссылка на клиентский `get_columns` — переключить на server-тул.
+- `plugin/skills/finish-task/SKILL.md:32-34` — step 4 «Offer + confirm»: явно называть резолвнутую done-цель («перенесу в колонку „Готово" + completed» / «выставлю Stage=Готово»), НЕ регрессить подтверждение перед записью.
+- (dropped 0)
+
+## Test exemplars
+_(file-level: из дерева `tests/tasks/boards/` + design §8.1; не из retrieval-сниппета → без line-номеров)_
+- `tests/tasks/boards/test_yougile_finish.py` — мок httpx для YouGile finish (резолв колонки GET `/columns`) → шаблон теста `list_columns`.
+- `tests/tasks/boards/test_youtrack_finish.py` — мок httpx для YouTrack finish (`customFields`) → шаблон теста `list_status_fields` (и фолбэк-агрегации).
+- `tests/mcp/test_finish_task.py` — monkeypatch провайдера, проверка проброса параметров в тул → шаблон теста `get_board_targets`.
+- `tests/skills/test_configure_review_skill.py` + `tests/skills/test_finish_task_skill.py` — guard-тесты вординга скиллов (pick-list вместо ручного ввода / явная done-цель).
+
+## Constraints / open questions
+- **Имя тула не финализировано:** `get_board_targets` vs `describe_board_targets` — решить на brainstorming.
+- **YouTrack права токена:** admin `/admin/projects/.../customFields` API может требовать доп. прав → фолбэк на агрегацию `value(name)`+`$type` из выборки задач проекта (`_FIELDS` уже тянет).
+- **Неуникальность YouGile-колонок** между досками одного проекта → discovery должен возвращать `boardId` и/или скоупить (в `finish` резолв в пределах доски задачи; здесь единой задачи нет → перечислять доски проекта).
+- **Деплой не в этой сессии:** server-тул → бамп `0.2.23`→`0.2.24` + PyPI, затем `reviewer update` + live-приёмка на обеих досках (YouGile PRI + YouTrack TES). Live-acceptance вне сессии (нужен передеплой). См. [[finish-task-branch-status]] — предыдущая фича принята на 0.2.23.
+- **Реализация:** subagent-driven, код на **Opus** (по заметке задачи и [[model-code-opus-no-fable]]).
+- **Верификация задачи:** [[verify-board-task-not-already-done]] — задача «Бэклог», в git/PR не найдено следов discovery-тула; предшественник (configurable-done-target) смержен, PRI-205 — реальная надстройка над ним, не дубль.
+
+## Токены (этап solve-task)
+Модель: claude-opus-4-8
+fresh-in 49K · out 64.2K · cache-write 477.4K · cache-read 4.1M
+Всего: 4.7M токенов

--- a/docs/superpowers/plans/2026-07-02-pri-205-server-side-done-target-discovery.md
+++ b/docs/superpowers/plans/2026-07-02-pri-205-server-side-done-target-discovery.md
@@ -1,0 +1,821 @@
+# PRI-205 Server-side discovery done-цели доски — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a read-only server-side reviewer MCP tool `get_board_targets(board_type, project)` that returns done-target candidates (YouGile board columns / YouTrack status fields + values) so `configure-review` shows a pick-list instead of manual entry and drops its dependency on the client-side yougile MCP; `finish-task` then names the resolved done target explicitly.
+
+**Architecture:** One board-agnostic Protocol method `list_done_targets(project)` implemented per board (YouGile walks projects→boards→columns, scoping boards to the project by task code-prefix — equivalent to the spec's task-sampling, reusing `iter_raw`'s walk; YouTrack tries the admin customFields API then falls back to aggregating distinct values from a sample of project issues). A thin `MCPReviewService.get_board_targets` resolves the provider from env creds (mirroring `finish_task`), calls the method fail-soft, and never returns credentials. Two skills consume/mention it.
+
+**Tech Stack:** Python 3.11+, httpx (mocked in unit tests), FastMCP, pytest, ruff. Design spec: `docs/superpowers/specs/2026-07-02-pri-205-server-side-done-target-discovery-design.md`.
+
+## Global Constraints
+
+- **Language:** all new comments/docstrings/CLI text in Russian (project convention). `SKILL.md` bodies stay English, but instruct answering the user in Russian.
+- **Credentials only in env** — never in `.review.yml`, never in `get_board_targets` return.
+- **Discovery is read-only** — no writes to the board; no task moves.
+- **Repo-agnostic server** — the server never parses `.review.yml`; `board_type`+`project` arrive as tool params.
+- **Fail-soft everywhere** — board/creds/permission/network failure → empty list + `warnings`, never raise, never block.
+- **Tests:** unit tests mock httpx (no network); `pytest` excludes `integration` by default.
+- **Ruff:** line-length 100, target py311. Run `.venv/bin/ruff check <touched files>` (repo-wide may be pre-dirty — only new/edited files must be clean).
+- **Commits:** Conventional Commits in Russian, **no self-attribution** (no `Co-Authored-By`/Claude).
+- **Session scope:** units 4.1–4.6 + §7.1 tests + version bump `0.2.23`→`0.2.24`. Out of session: PyPI publish, `reviewer update`, live acceptance (§7.2).
+
+---
+
+### Task 1: YouGile `list_done_targets` + Protocol method
+
+**Files:**
+- Modify: `reviewer/tasks/boards/base.py` (add `list_done_targets` to the `TaskBoardProvider` Protocol, after `finish`)
+- Modify: `reviewer/tasks/boards/yougile.py` (add `list_done_targets` method to `YougileBoard`, after `_resolve_column_id`/`finish`)
+- Test: `tests/tasks/boards/test_yougile_targets.py` (create)
+
+**Interfaces:**
+- Produces: `YougileBoard.list_done_targets(self, project: str | None) -> dict` returning
+  `{"columns": [{"title": str, "id": str, "board_id": str, "board_title": str}], "warnings": [str]}`.
+- Consumes: existing `self._get_all(path, params)` (`yougile.py:139`) and `project_prefix` (`base.py:17`, already imported in yougile.py), module `log`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/tasks/boards/test_yougile_targets.py`:
+
+```python
+from reviewer.tasks.boards.yougile import YougileBoard
+
+
+class _Resp:
+    def __init__(self, status=200, content=None):
+        self.status_code = status
+        self._content = content if content is not None else []
+
+    def raise_for_status(self):
+        if self.status_code >= 400:
+            raise RuntimeError(f"HTTP {self.status_code}")
+
+    def json(self):
+        return {"content": self._content}
+
+
+class _Client:
+    """Фейк httpx: роутит GET по (path + дискриминирующий param). Неизвестный путь → 500
+    (для проверки fail-soft). _get_all читает .json()['content']."""
+
+    def __init__(self, routes):
+        self.routes = routes  # ключ "path" или "path?disc=val" -> list[dict]
+        self.calls = []
+
+    def get(self, path, params=None):
+        params = params or {}
+        self.calls.append((path, dict(params)))
+        for disc in ("projectId", "boardId", "columnId"):
+            if disc in params:
+                key = f"{path}?{disc}={params[disc]}"
+                return _Resp(200, self.routes[key]) if key in self.routes else _Resp(500)
+        return _Resp(200, self.routes[path]) if path in self.routes else _Resp(500)
+
+    def close(self):
+        pass
+
+
+def _board(routes):
+    b = YougileBoard.__new__(YougileBoard)  # обойти httpx.Client в __init__
+    b._client = _Client(routes)
+    return b
+
+
+_TWO_BOARDS = {
+    "/projects": [{"id": "p1", "title": "Proj"}],
+    "/boards?projectId=p1": [{"id": "b1", "title": "Board One"},
+                             {"id": "b2", "title": "Board Two"}],
+    "/columns?boardId=b1": [{"id": "c1", "title": "В работе"},
+                            {"id": "c2", "title": "Готово"}],
+    "/columns?boardId=b2": [{"id": "c3", "title": "Todo"},
+                            {"id": "c4", "title": "Done"}],
+    "/tasks?columnId=c1": [{"idTaskProject": "PRI-1"}],  # b1 хостит PRI
+    "/tasks?columnId=c2": [],
+    "/tasks?columnId=c3": [{"idTaskProject": "TES-1"}],  # b2 хостит только TES
+    "/tasks?columnId=c4": [],
+}
+
+
+def test_yougile_targets_scopes_to_project_boards():
+    res = _board(_TWO_BOARDS).list_done_targets("PRI")
+    titles = {(c["title"], c["board_title"]) for c in res["columns"]}
+    assert titles == {("В работе", "Board One"), ("Готово", "Board One")}
+    assert res["warnings"] == []
+    assert all(c["board_id"] == "b1" for c in res["columns"])
+
+
+def test_yougile_targets_empty_project_returns_all_boards():
+    b = _board(_TWO_BOARDS)
+    res = b.list_done_targets(None)
+    assert {c["title"] for c in res["columns"]} == {"В работе", "Готово", "Todo", "Done"}
+    # без project задачи не сканируются вовсе
+    assert not any(path == "/tasks" for path, _ in b._client.calls)
+
+
+def test_yougile_targets_no_project_boards_warns():
+    res = _board(_TWO_BOARDS).list_done_targets("ZZZ")
+    assert res["columns"] == []
+    assert res["warnings"]  # «колонки для проекта 'ZZZ' не найдены»
+
+
+def test_yougile_targets_failsoft_on_error():
+    # отсутствует роут /boards?projectId=p1 → 500 внутри обхода → warning, без падения
+    routes = {"/projects": [{"id": "p1", "title": "Proj"}]}
+    res = _board(routes).list_done_targets("PRI")
+    assert res["columns"] == []
+    assert res["warnings"]
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `.venv/bin/pytest tests/tasks/boards/test_yougile_targets.py -q`
+Expected: FAIL with `AttributeError: 'YougileBoard' object has no attribute 'list_done_targets'`.
+
+- [ ] **Step 3: Add the Protocol method to `base.py`**
+
+In `reviewer/tasks/boards/base.py`, inside `class TaskBoardProvider(Protocol)`, add after the `finish` method:
+
+```python
+    def list_done_targets(self, project: str | None) -> dict:
+        """Кандидаты done-цели доски (read-only, fail-soft, НИКОГДА не бросает).
+
+        YouGile → {"columns": [{"title", "id", "board_id", "board_title"}], "warnings": [...]}
+        YouTrack → {"status_fields": [{"field", "values": [...], "$type"?}],
+                    "source": "admin"|"sample", "warnings": [...]}
+
+        Ошибка/нет прав/сеть → пустой список + warnings (скилл откатывается на ручной ввод)."""
+        ...
+```
+
+- [ ] **Step 4: Implement `list_done_targets` in `yougile.py`**
+
+In `reviewer/tasks/boards/yougile.py`, add to `class YougileBoard` (after `finish`):
+
+```python
+    def list_done_targets(self, project: str | None) -> dict:
+        """Колонки досок проекта (read-only, fail-soft). project — код-префикс задач
+        (напр. PRI): доска включается, если на ней есть хоть одна задача проекта. Пустой
+        project → все доски всех проектов. НИКОГДА не бросает."""
+        warnings: list[str] = []
+        boards: list[dict] = []           # [{board_id, board_title, columns:[{id,title}]}]
+        hosts: set[str] = set()           # board_id, где встречена задача проекта
+        scanned = 0
+        _CAP = 500                        # предохранитель на число просканированных задач
+        try:
+            for proj in self._get_all("/projects"):
+                for brd in self._get_all("/boards", {"projectId": proj["id"]}):
+                    bid = brd["id"]
+                    cols = [{"id": c["id"], "title": c.get("title", "")}
+                            for c in self._get_all("/columns", {"boardId": bid})]
+                    boards.append({"board_id": bid, "board_title": brd.get("title", ""),
+                                   "columns": cols})
+                    if not project:
+                        continue
+                    for c in cols:
+                        if scanned >= _CAP:
+                            break
+                        hit = False
+                        for t in self._get_all("/tasks", {"columnId": c["id"]}):
+                            scanned += 1
+                            if project_prefix(t.get("idTaskProject", "")) == project:
+                                hit = True
+                                break
+                            if scanned >= _CAP:
+                                break
+                        if hit:
+                            hosts.add(bid)
+                            break
+        except Exception:
+            log.warning("yougile: discovery колонок не удался", exc_info=True)
+            warnings.append("не удалось перечислить колонки доски")
+        kept = boards if not project else [b for b in boards if b["board_id"] in hosts]
+        columns = [{"title": col["title"], "id": col["id"],
+                    "board_id": b["board_id"], "board_title": b["board_title"]}
+                   for b in kept for col in b["columns"]]
+        if project and not hosts and not warnings:
+            warnings.append(f"колонки для проекта {project!r} не найдены")
+        return {"columns": columns, "warnings": warnings}
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `.venv/bin/pytest tests/tasks/boards/test_yougile_targets.py -q`
+Expected: PASS (4 tests).
+
+- [ ] **Step 6: Lint**
+
+Run: `.venv/bin/ruff check reviewer/tasks/boards/yougile.py reviewer/tasks/boards/base.py tests/tasks/boards/test_yougile_targets.py`
+Expected: no errors on these files.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add reviewer/tasks/boards/base.py reviewer/tasks/boards/yougile.py tests/tasks/boards/test_yougile_targets.py
+git commit -m "feat(tasks): YouGile list_done_targets — discovery колонок доски проекта (PRI-205)"
+```
+
+---
+
+### Task 2: YouTrack `list_done_targets` (try-admin → fallback aggregation)
+
+**Files:**
+- Modify: `reviewer/tasks/boards/youtrack.py` (add `_SAMPLE` constant; add `list_done_targets` + two private helpers to `YouTrackBoard`)
+- Test: `tests/tasks/boards/test_youtrack_targets.py` (create)
+
+**Interfaces:**
+- Produces: `YouTrackBoard.list_done_targets(self, project: str | None) -> dict` returning
+  `{"status_fields": [{"field": str, "values": [str], "$type": str | None}], "source": "admin"|"sample", "warnings": [str]}`.
+- Consumes: `self._client.get(path, params)`, `quote` (already imported), module `log`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/tasks/boards/test_youtrack_targets.py`:
+
+```python
+from reviewer.tasks.boards.youtrack import YouTrackBoard
+
+
+class _Resp:
+    def __init__(self, status=200, json_data=None):
+        self.status_code = status
+        self._json = json_data
+
+    def raise_for_status(self):
+        if self.status_code >= 400:
+            raise RuntimeError(f"HTTP {self.status_code}")
+
+    def json(self):
+        return self._json
+
+
+class _Client:
+    """Фейк httpx: роутит GET по path (admin id уже в пути). .json() отдаёт список."""
+
+    def __init__(self, routes):
+        self.routes = routes
+        self.calls = []
+
+    def get(self, path, params=None):
+        self.calls.append((path, dict(params or {})))
+        r = self.routes.get(path)
+        if r is None:
+            return _Resp(500, None)
+        return r
+
+    def close(self):
+        pass
+
+
+def _board(routes):
+    b = YouTrackBoard.__new__(YouTrackBoard)  # обойти httpx.Client в __init__
+    b._client = _Client(routes)
+    b._status_field = "State"
+    return b
+
+
+def test_youtrack_targets_admin_success():
+    routes = {
+        "/admin/projects": _Resp(200, [{"id": "0-5", "shortName": "TES"}]),
+        "/admin/projects/0-5/customFields": _Resp(200, [
+            {"$type": "StateProjectCustomField", "field": {"name": "Stage"},
+             "bundle": {"values": [{"name": "Open"}, {"name": "Готово"}]}},
+            {"$type": "TextProjectCustomField", "field": {"name": "Descr"},
+             "bundle": None},  # не bundle-поле → пропуск
+        ]),
+    }
+    res = _board(routes).list_done_targets("TES")
+    assert res["source"] == "admin"
+    assert res["status_fields"] == [
+        {"field": "Stage", "values": ["Open", "Готово"], "$type": "StateProjectCustomField"}]
+    assert res["warnings"] == []
+
+
+def test_youtrack_targets_fallback_to_sample_on_admin_403():
+    routes = {
+        "/admin/projects": _Resp(403, None),  # нет admin-прав
+        "/issues": _Resp(200, [
+            {"customFields": [{"name": "Stage", "value": {"name": "Open"},
+                               "$type": "StateIssueCustomField"}]},
+            {"customFields": [{"name": "Stage", "value": {"name": "Готово"},
+                               "$type": "StateIssueCustomField"}]},
+        ]),
+    }
+    res = _board(routes).list_done_targets("TES")
+    assert res["source"] == "sample"
+    assert res["status_fields"] == [
+        {"field": "Stage", "values": ["Open", "Готово"], "$type": "StateIssueCustomField"}]
+    assert res["warnings"]  # предупреждение про недоступный admin
+
+
+def test_youtrack_targets_sample_ignores_non_dict_values():
+    routes = {
+        "/admin/projects": _Resp(403, None),
+        "/issues": _Resp(200, [
+            {"customFields": [{"name": "Stage", "value": {"name": "Open"}},
+                              {"name": "Assignee", "value": "текст"},   # не dict → пропуск
+                              {"name": "Sprints", "value": [{"name": "S1"}]}]},  # list → пропуск
+        ]),
+    }
+    res = _board(routes).list_done_targets("TES")
+    assert [f["field"] for f in res["status_fields"]] == ["Stage"]
+
+
+def test_youtrack_targets_total_failure_empty_failsoft():
+    routes = {"/admin/projects": _Resp(403, None), "/issues": _Resp(500, None)}
+    res = _board(routes).list_done_targets("TES")
+    assert res["status_fields"] == []
+    assert res["source"] == "sample"
+    assert len(res["warnings"]) >= 1
+
+
+def test_youtrack_targets_empty_project_uses_sample_no_admin_call():
+    routes = {"/issues": _Resp(200, [
+        {"customFields": [{"name": "State", "value": {"name": "Open"},
+                           "$type": "StateIssueCustomField"}]}])}
+    b = _board(routes)
+    res = b.list_done_targets(None)
+    assert res["source"] == "sample"
+    assert [f["field"] for f in res["status_fields"]] == ["State"]
+    assert not any(path.startswith("/admin") for path, _ in b._client.calls)
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `.venv/bin/pytest tests/tasks/boards/test_youtrack_targets.py -q`
+Expected: FAIL with `AttributeError: 'YouTrackBoard' object has no attribute 'list_done_targets'`.
+
+- [ ] **Step 3: Add the `_SAMPLE` constant**
+
+In `reviewer/tasks/boards/youtrack.py`, next to the existing `_PAGE` module constant, add:
+
+```python
+_SAMPLE = 200  # число задач в выборке для fallback-агрегации значений полей статуса
+```
+
+- [ ] **Step 4: Implement the method + helpers in `youtrack.py`**
+
+Add to `class YouTrackBoard` (after `finish`):
+
+```python
+    def list_done_targets(self, project: str | None) -> dict:
+        """Поля статуса + значения (read-only, fail-soft). Try admin customFields;
+        при недоступности — агрегация distinct значений из выборки задач проекта.
+        НИКОГДА не бросает."""
+        warnings: list[str] = []
+        try:
+            fields = self._admin_status_fields(project)
+            if fields:
+                return {"status_fields": fields, "source": "admin", "warnings": warnings}
+        except Exception:
+            log.warning("youtrack: admin customFields недоступны — fallback", exc_info=True)
+            warnings.append("admin customFields недоступны (нет прав?) — "
+                            "значения собраны из задач")
+        try:
+            fields = self._sampled_status_fields(project)
+        except Exception:
+            log.warning("youtrack: discovery полей из выборки не удался", exc_info=True)
+            warnings.append("не удалось собрать поля статуса из задач")
+            fields = []
+        return {"status_fields": fields, "source": "sample", "warnings": warnings}
+
+    def _admin_status_fields(self, project: str | None) -> list[dict]:
+        """Bundle-поля (state/enum) проекта из admin API + их значения. [] если project пуст
+        или проект не найден. Бросает при ошибке HTTP — вызывающий ловит и фолбэкает."""
+        if not project:
+            return []
+        pr = self._client.get("/admin/projects",
+                              params={"fields": "id,shortName", "query": project})
+        pr.raise_for_status()
+        pid = next((p["id"] for p in (pr.json() or [])
+                    if p.get("shortName") == project), None)
+        if not pid:
+            return []
+        r = self._client.get(
+            f"/admin/projects/{quote(str(pid), safe='')}/customFields",
+            params={"fields": "field(name),$type,bundle(values(name,$type))"})
+        r.raise_for_status()
+        out: list[dict] = []
+        for pcf in (r.json() or []):
+            bundle = pcf.get("bundle") or {}
+            values = [v.get("name") for v in (bundle.get("values") or []) if v.get("name")]
+            if not values:
+                continue  # не bundle-поле — не кандидат статуса
+            name = (pcf.get("field") or {}).get("name")
+            if name:
+                out.append({"field": name, "values": values, "$type": pcf.get("$type")})
+        return out
+
+    def _sampled_status_fields(self, project: str | None) -> list[dict]:
+        """Distinct значения single-value кастом-полей из выборки задач проекта.
+        Бросает при ошибке HTTP — вызывающий ловит."""
+        params: dict = {"fields": "customFields(name,value(name),$type)", "$top": _SAMPLE}
+        if project:
+            params["query"] = f"project: {project}"
+        r = self._client.get("/issues", params=params)
+        r.raise_for_status()
+        agg: dict[str, dict] = {}  # field name -> {"values": [...], "$type": ...}
+        for issue in (r.json() or []):
+            for cf in issue.get("customFields") or []:
+                name = cf.get("name")
+                val = cf.get("value")
+                vname = val.get("name") if isinstance(val, dict) else None
+                if not name or not vname:
+                    continue
+                slot = agg.setdefault(name, {"values": [], "$type": cf.get("$type")})
+                if vname not in slot["values"]:
+                    slot["values"].append(vname)
+        return [{"field": n, "values": s["values"], "$type": s["$type"]}
+                for n, s in agg.items()]
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `.venv/bin/pytest tests/tasks/boards/test_youtrack_targets.py -q`
+Expected: PASS (5 tests).
+
+- [ ] **Step 6: Lint**
+
+Run: `.venv/bin/ruff check reviewer/tasks/boards/youtrack.py tests/tasks/boards/test_youtrack_targets.py`
+Expected: no errors.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add reviewer/tasks/boards/youtrack.py tests/tasks/boards/test_youtrack_targets.py
+git commit -m "feat(tasks): YouTrack list_done_targets — admin customFields + fallback-агрегация (PRI-205)"
+```
+
+---
+
+### Task 3: MCP tool `get_board_targets` (service + server)
+
+**Files:**
+- Modify: `reviewer/mcp/service.py` (add `get_board_targets` method after `finish_task`, ~line 356)
+- Modify: `reviewer/entrypoints/mcp_server.py` (register `@mcp.tool() get_board_targets`, near `get_board_config` at ~line 166, before `return mcp` at line 317)
+- Test: `tests/mcp/test_get_board_targets.py` (create)
+
+**Interfaces:**
+- Consumes: `make_board_provider(self.settings, board_type)` (already imported, `service.py:31`), `self.settings.configured_board_types()`, `provider.list_done_targets(project)` (Tasks 1–2).
+- Produces: `MCPReviewService.get_board_targets(self, board_type: str | None = None, project: str | None = None) -> dict` → `{"board_type", "project", **targets}` on success, or `{"status": "error", "reason": …}`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/mcp/test_get_board_targets.py`:
+
+```python
+import reviewer.mcp.service as svc_mod
+from reviewer.mcp.service import MCPReviewService
+
+
+class _Provider:
+    def __init__(self, targets):
+        self.targets = targets
+        self.project = "UNSET"
+        self.closed = False
+
+    def list_done_targets(self, project):
+        self.project = project
+        return self.targets
+
+    def close(self):
+        self.closed = True
+
+
+class _Svc(MCPReviewService):
+    """Обходим тяжёлый __init__: только settings с configured_board_types."""
+    def __init__(self, configured):
+        self.settings = type("S", (), {
+            "configured_board_types": staticmethod(lambda: configured)})()
+
+
+def test_get_board_targets_single_board_threads_project(monkeypatch):
+    prov = _Provider({"columns": [{"title": "Готово", "id": "c1",
+                                   "board_id": "b1", "board_title": "B"}], "warnings": []})
+    monkeypatch.setattr(svc_mod, "make_board_provider", lambda s, t: prov)
+    out = _Svc(["yougile"]).get_board_targets(project="PRI")
+    assert out["board_type"] == "yougile"
+    assert out["project"] == "PRI"
+    assert out["columns"][0]["title"] == "Готово"
+    assert prov.project == "PRI"
+    assert prov.closed is True
+    # креды наружу не отдаются
+    assert "api_key" not in out and "token" not in out
+
+
+def test_get_board_targets_ambiguous_requires_type():
+    out = _Svc(["yougile", "youtrack"]).get_board_targets()
+    assert out["status"] == "error"
+    assert "board_type" in out["reason"]
+
+
+def test_get_board_targets_not_configured():
+    out = _Svc([]).get_board_targets(board_type="youtrack")
+    assert out["status"] == "error"
+
+
+def test_get_board_targets_explicit_type(monkeypatch):
+    prov = _Provider({"status_fields": [{"field": "Stage", "values": ["Готово"],
+                                         "$type": "X"}], "source": "admin", "warnings": []})
+    monkeypatch.setattr(svc_mod, "make_board_provider", lambda s, t: prov)
+    out = _Svc(["yougile", "youtrack"]).get_board_targets(board_type="youtrack",
+                                                          project="TES")
+    assert out["board_type"] == "youtrack"
+    assert out["source"] == "admin"
+    assert prov.project == "TES"
+
+
+def test_get_board_targets_failsoft(monkeypatch):
+    class Boom:
+        def list_done_targets(self, project):
+            raise RuntimeError("kaboom")
+
+        def close(self):
+            pass
+
+    monkeypatch.setattr(svc_mod, "make_board_provider", lambda s, t: Boom())
+    out = _Svc(["yougile"]).get_board_targets()
+    assert out["status"] == "error"
+    assert "kaboom" in out["reason"]
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `.venv/bin/pytest tests/mcp/test_get_board_targets.py -q`
+Expected: FAIL with `AttributeError: 'MCPReviewService' object has no attribute 'get_board_targets'`.
+
+- [ ] **Step 3: Implement `get_board_targets` in `service.py`**
+
+In `reviewer/mcp/service.py`, add after the `finish_task` method (after line 356, before `_resolve_repo_branch`):
+
+```python
+    def get_board_targets(self, board_type: str | None = None,
+                          project: str | None = None) -> dict:
+        """Кандидаты done-цели доски для configure-review (read-only, server-side).
+
+        Резолвит провайдера по board_type (или единственному настроенному), зовёт
+        list_done_targets(project) fail-soft. YouGile → columns; YouTrack → status_fields
+        (+source). Креды из env; наружу НЕ отдаются."""
+        types = self.settings.configured_board_types()
+        if board_type is None:
+            if len(types) == 1:
+                board_type = types[0]
+            else:
+                return {"status": "error",
+                        "reason": f"board_type required (configured: {types or 'none'})"}
+        if board_type not in types:
+            return {"status": "error",
+                    "reason": f"board '{board_type}' not configured (have: {types or 'none'})"}
+        provider = make_board_provider(self.settings, board_type)
+        if provider is None:
+            return {"status": "error", "reason": f"board '{board_type}' not configured"}
+        try:
+            targets = provider.list_done_targets(project)
+        except Exception as e:  # fail-soft: discovery — вторичная функция
+            log.warning("get_board_targets: сбой discovery", exc_info=True)
+            return {"status": "error", "reason": f"{type(e).__name__}: {e}"}
+        finally:
+            try:
+                provider.close()
+            except Exception:
+                pass
+        return {"board_type": board_type, "project": project, **targets}
+```
+
+- [ ] **Step 4: Register the MCP tool in `mcp_server.py`**
+
+In `reviewer/entrypoints/mcp_server.py`, add after the `get_board_config` tool (after line 173), before `return mcp`:
+
+```python
+    @mcp.tool()
+    def get_board_targets(board_type: str | None = None,
+                          project: str | None = None) -> dict:
+        """Discover done-target candidates for a repo's board, server-side (read-only).
+        YouGile → board columns; YouTrack → status fields + their values (bundle via the
+        admin API, else aggregated from a sample of project issues). board_type and
+        project come from the repo's .review.yml task_board block. Credentials are NEVER
+        returned; fail-soft — empty list + warnings when the board/creds/permissions are
+        unavailable, so configure-review can fall back to asking."""
+        return service.get_board_targets(board_type, project)
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `.venv/bin/pytest tests/mcp/test_get_board_targets.py -q`
+Expected: PASS (5 tests).
+
+- [ ] **Step 6: Lint**
+
+Run: `.venv/bin/ruff check reviewer/mcp/service.py reviewer/entrypoints/mcp_server.py tests/mcp/test_get_board_targets.py`
+Expected: no errors.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add reviewer/mcp/service.py reviewer/entrypoints/mcp_server.py tests/mcp/test_get_board_targets.py
+git commit -m "feat(mcp): server-side тул get_board_targets — discovery done-цели доски (PRI-205)"
+```
+
+---
+
+### Task 4: `configure-review` skill — pick-list via `get_board_targets`, drop client `get_columns`
+
+**Files:**
+- Modify: `plugin/skills/configure-review/SKILL.md` (step 5b done-target block, lines ~125–137)
+- Test: `tests/skills/test_configure_review_skill.py` (add two guard tests)
+
+**Interfaces:**
+- Consumes: MCP tool `get_board_targets(board_type, project)` (Task 3).
+- Produces: skill text that mentions `get_board_targets`, presents a pick-list, falls back to asking, and no longer references `get_columns`.
+
+- [ ] **Step 1: Write the failing guard tests**
+
+Append to `tests/skills/test_configure_review_skill.py`:
+
+```python
+def test_skill_uses_server_side_done_target_discovery():
+    text = SKILL.read_text(encoding="utf-8")
+    assert "get_board_targets" in text            # server-side discovery тул
+    assert "pick-list" in text                    # предъявляет список кандидатов
+    # больше не зависит от клиентского yougile-MCP
+    assert "get_columns" not in text
+
+
+def test_skill_done_target_discovery_falls_back_to_asking():
+    text = SKILL.read_text(encoding="utf-8")
+    # тул отсутствует/пусто/ошибка → спросить пользователя (fail-open)
+    assert "fall back to asking" in text
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `.venv/bin/pytest tests/skills/test_configure_review_skill.py -q`
+Expected: FAIL — `get_board_targets`/`pick-list` absent; `get_columns` currently present.
+
+- [ ] **Step 3: Edit the skill**
+
+In `plugin/skills/configure-review/SKILL.md`, replace the done-target block (the paragraph starting `**Then ask the finish-task done target**` through the end of the **youtrack** bullet, lines ~125–137) with:
+
+```markdown
+   **Then ask the finish-task done target** (closing a task after its PR — skill `/reviewer_finish-task`
+   moves the finished task into the board's "done" cell). First **discover candidates server-side**: call
+   the reviewer MCP tool `get_board_targets(board_type=<type>, project=<project>)` (read-only; creds live in
+   the reviewer env — nothing to configure on the client, and **no yougile/youtrack board-MCP is needed**).
+   Show the result as a **pick-list**; if the tool is absent (older deploy), returns an empty list, or
+   errors, **fall back to asking** the user for the value. Write only the key(s) matching the board type;
+   comment out the other board's keys with a one-line note (mirror the root `.review.yml`). All are optional
+   and fail-soft — a wrong/absent column or value only warns, the PR link is still written:
+   - **yougile** → `done_column`: the exact column **title** finish-task moves the finished task into (plus
+     `completed:true`). `get_board_targets` returns `columns: [{title, board_title, …}]` — present them as a
+     pick-list and disambiguate same-named columns by `board_title`; the user picks the done column by title.
+     Empty / tool absent → ask for the title. Not set → finish-task only flips `completed:true` without
+     moving the card.
+   - **youtrack** → `status_field` (name of the custom field the board is built on — default `State`; it
+     **also** governs status reading on sync, so set it when the board runs on a custom field like `Stage`)
+     and `done_state` (target value of that field — default `Fixed`). `get_board_targets` returns
+     `status_fields: [{field, values: […]}]` — let the user pick the field, then a value from that field's
+     `values` as `done_state`. Empty / tool absent → ask for both. YouTrack-only; a yougile board ignores them.
+```
+
+Then update the intro «Standalone baseline» sentence (around lines 12–15) to note the new optional tool without removing the existing `count_tasks` guarded phrases — change the sentence:
+
+> The single optional exception is sizing `context_limits.search_tasks`: the skill may call the reviewer MCP tool `count_tasks(project)` when it is connected; if not (fresh repo / no reviewer MCP / older deploy / empty graph) it **falls back to asking** the user. Everything else needs **no reviewer MCP / Postgres / Neo4j**.
+
+to:
+
+> Two optional exceptions use the reviewer MCP when connected: sizing `context_limits.search_tasks` via `count_tasks(project)`, and the finish-task done-target pick-list via `get_board_targets(board_type, project)`; if the reviewer MCP is absent (fresh repo / older deploy) or a tool errors, the skill **falls back to asking** the user. Everything else needs **no reviewer MCP / Postgres / Neo4j**.
+
+(Verify `no reviewer MCP`, `count_tasks`, and `falls back to asking` all remain present — the existing guard `test_skill_standalone_baseline_with_optional_count_tasks` depends on them.)
+
+- [ ] **Step 4: Run the full configure-review guard suite**
+
+Run: `.venv/bin/pytest tests/skills/test_configure_review_skill.py -q`
+Expected: PASS (all existing tests + 2 new).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add plugin/skills/configure-review/SKILL.md tests/skills/test_configure_review_skill.py
+git commit -m "feat(skills): configure-review — pick-list done-цели через get_board_targets, без клиентского get_columns (PRI-205)"
+```
+
+---
+
+### Task 5: `finish-task` skill — name the resolved done target in the confirmation
+
+**Files:**
+- Modify: `plugin/skills/finish-task/SKILL.md` (step 4 «Offer + confirm», lines ~32–34)
+- Test: `tests/skills/test_finish_task_skill.py` (add one guard test)
+
+**Interfaces:**
+- Produces: skill text where step 4 names the resolved done target explicitly and preserves the confirm-before-write gate.
+
+- [ ] **Step 1: Write the failing guard test**
+
+Append to `tests/skills/test_finish_task_skill.py`:
+
+```python
+def test_finish_task_names_resolved_done_target():
+    t = SKILL.read_text(encoding="utf-8")
+    assert "resolved done target" in t   # шаг 4 явно называет цель, не обобщённое mark done
+    # гейт подтверждения не регрессирует
+    assert "only after explicit confirmation" in t
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `.venv/bin/pytest tests/skills/test_finish_task_skill.py -q`
+Expected: FAIL — phrases absent.
+
+- [ ] **Step 3: Edit the skill**
+
+In `plugin/skills/finish-task/SKILL.md`, replace step 4 (lines ~32–34) with:
+
+```markdown
+4. **Offer + confirm.** Show what will be written — the PR link + the **resolved done target, named
+   explicitly** (not a generic "mark done"): for yougile «перенесу задачу в колонку „<done_column>" +
+   отмечу completed» (or just «отмечу completed» when `done_column` is unset); for youtrack «выставлю
+   <status_field> = <done_state>» — plus any optional note. Ask the user to **confirm** before writing,
+   and whether they want to add an optional note (details under the task). **Never write to the board
+   silently** — the move / mark-done happens **only after explicit confirmation**, even when the values
+   are already set in `.review.yml`.
+```
+
+- [ ] **Step 4: Run the full finish-task guard suite**
+
+Run: `.venv/bin/pytest tests/skills/test_finish_task_skill.py -q`
+Expected: PASS (all existing tests + 1 new).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add plugin/skills/finish-task/SKILL.md tests/skills/test_finish_task_skill.py
+git commit -m "feat(skills): finish-task — явно называть резолвнутую done-цель в подтверждении (PRI-205)"
+```
+
+---
+
+### Task 6: Version bump + full verification
+
+**Files:**
+- Modify: `pyproject.toml:3`
+
+- [ ] **Step 1: Bump the version**
+
+In `pyproject.toml`, change line 3 from `version = "0.2.23"` to `version = "0.2.24"`.
+
+- [ ] **Step 2: Run the full unit suite**
+
+Run: `.venv/bin/pytest -q`
+Expected: PASS (all tests; `integration` excluded by default per `pyproject.toml addopts`).
+
+- [ ] **Step 3: Lint all touched files**
+
+Run:
+```bash
+.venv/bin/ruff check reviewer/tasks/boards/base.py reviewer/tasks/boards/yougile.py \
+  reviewer/tasks/boards/youtrack.py reviewer/mcp/service.py \
+  reviewer/entrypoints/mcp_server.py tests/tasks/boards/test_yougile_targets.py \
+  tests/tasks/boards/test_youtrack_targets.py tests/mcp/test_get_board_targets.py
+```
+Expected: no errors on these files (repo-wide ruff may be pre-dirty — do not chase unrelated warnings).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add pyproject.toml
+git commit -m "chore: bump 0.2.23 → 0.2.24"
+```
+
+---
+
+## Out-of-session follow-ups (§7.2 / §8 of the spec)
+
+Not part of this plan's session; require a redeploy:
+1. Publish `0.2.24` to PyPI.
+2. `reviewer update` on the deploy.
+3. Live acceptance on both boards:
+   - **YouGile PRI:** `get_board_targets("yougile","PRI")` → real columns; configure-review без клиентского yougile-MCP предлагает список → выбор `done_column`.
+   - **YouTrack TES:** `get_board_targets("youtrack","TES")` → поля статуса (напр. `Stage`) + значения (напр. `Готово`); проверить оба пути (admin и fallback).
+4. After the PR is created, offer `/reviewer_finish-task` to close PRI-205.
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- §3 Protocol `list_done_targets` → Task 1 Step 3. ✅
+- §4.1 YouGile discovery (scope by project, board_id/board_title, fail-soft) → Task 1. ✅
+- §4.2 YouTrack try-admin → fallback (source, distinct values, fail-soft) → Task 2. ✅
+- §4.3 `make_board_provider` reuse (no status_field) → Task 3 service code. ✅
+- §4.4 MCP tool (resolve type, creds not returned, fail-soft) → Task 3. ✅
+- §4.5 configure-review pick-list + ask-fallback, drop `get_columns` → Task 4. ✅
+- §4.6 finish-task explicit target, gate preserved → Task 5. ✅
+- §7.1 unit tests (yougile/youtrack/init-via-provider/mcp/skills) → Tasks 1–5 tests. ✅
+  (boards/__init__ path is exercised indirectly via the mcp monkeypatch of `make_board_provider`; the factory signature is unchanged, so no separate test is added.)
+- §8 version bump → Task 6. ✅
+- §7.2 live acceptance → out-of-session follow-ups (per session scope). ✅
+
+**Placeholder scan:** No TBD/TODO; every code step shows full code. No "handle edge cases"/"add validation" hand-waves.
+
+**Type consistency:** `list_done_targets(project)` signature identical across base.py Protocol, YougileBoard, YouTrackBoard, and the `_Provider` test doubles. Return keys consistent: YouGile `{columns, warnings}`, YouTrack `{status_fields, source, warnings}`; service wraps with `{board_type, project, **targets}`. `make_board_provider(self.settings, board_type)` called without `status_field` in Task 3 (matches the `lambda s, t:` monkeypatch), distinct from `finish_task`'s `status_field=` call — intentional (discovery returns candidates for status_field, so it needn't be set).

--- a/docs/superpowers/specs/2026-07-02-pri-205-server-side-done-target-discovery-design.md
+++ b/docs/superpowers/specs/2026-07-02-pri-205-server-side-done-target-discovery-design.md
@@ -1,0 +1,206 @@
+# Дизайн — Server-side discovery done-цели доски (PRI-205)
+
+- **Дата:** 2026-07-02
+- **Статус:** утверждён
+- **Задача:** PRI-205 (alias ID-205)
+- **Поверх:** фичи *configurable-done-target* (rag-reviewer 0.2.23) — расширяет её.
+- **Бриф:** `docs/superpowers/briefs/2026-07-02-PRI-205-server-side-done-target-discovery.md`
+
+## 1. Цель
+
+Done-цель для `finish_task` (`done_column` у YouGile; `status_field`+`done_state` у YouTrack) сейчас
+заполняется в `.review.yml` **вручную**, подсматривая точные названия в UI доски. Для YouTrack
+особенно больно: на клиенте нет YouTrack-MCP, а у reviewer-сервера нет тула отдать поля/значения.
+`configure-review` в YouGile-ветке к тому же опирается на **сторонний** `mcp__yougile__get_columns`.
+
+Новый **read-only server-side** reviewer MCP-тул `get_board_targets(board_type, project)` возвращает
+кандидатов done-цели, используя REST-креды сервера из env. `configure-review` показывает pick-list
+вместо ручного ввода; `finish-task` явно называет резолвнутую цель в подтверждении. Работает и для
+YouGile, и для YouTrack — **без** board-MCP на клиенте (симметрично `sync_board`/`finish_task`).
+
+## 2. Не-цели (YAGNI)
+
+- Не двигаем задачу и не резолвим промежуточные («в работе») колонки/состояния — только discovery
+  кандидатов done-цели. Перенос/`completed` по-прежнему делает `finish_task` с подтверждением.
+- Сервер `.review.yml` не парсит: `board_type`+`project` приходят параметрами тула (репо-агностичность).
+- Секретов в `.review.yml` нет; тул креды не возвращает.
+- Не кэшируем discovery на сервере (finish/configure — не hot-path).
+
+## 3. Интерфейс провайдера (`reviewer/tasks/boards/base.py`)
+
+**Решение А — один board-агностичный метод Protocol** (вместо раздельных `list_columns`/
+`list_status_fields` из текста задачи). Сервисный слой остаётся board-агностичным
+(`provider.list_done_targets(project)`, без `isinstance`); каждый провайдер владеет своей
+нормализацией — ровно философия `base.py`, и точно повторяет приём `finish()` (единая сигнатура,
+доска-специфичное поведение внутри).
+
+```python
+def list_done_targets(self, project: str | None) -> dict:
+    """Кандидаты done-цели доски (read-only, fail-soft, НИКОГДА не бросает).
+
+    YouGile → {"columns": [{"title", "id", "board_id", "board_title"}], "warnings": [...]}
+    YouTrack → {"status_fields": [{"field", "values": [...], "$type"?}],
+                "source": "admin"|"sample", "warnings": [...]}
+
+    Ошибка/нет прав/сеть → пустой список + warnings (скилл откатывается на ручной ввод)."""
+    ...
+```
+
+Добавляется в `TaskBoardProvider` (Protocol) рядом с `finish`. Оба провайдера реализуют метод.
+
+## 4. Компоненты (units)
+
+### 4.1 YouGile — `YougileBoard.list_done_targets(project)`
+
+Скоуп по `project` (код-префикс, напр. `PRI`) решается через фактически используемые доски:
+
+1. Выбрать небольшую пачку задач проекта — как `iter_raw` с фильтром `project_prefix` (`base.py:17`),
+   с внутренним лимитом (напр. `limit=200`, достаточно чтобы покрыть доски проекта); собрать
+   `columnId` этих задач.
+2. Резолв `columnId → boardId`: `GET /columns/{id}` (переиспользует приём `_resolve_column_id`,
+   `yougile.py:251`) — собрать distinct `board_id` (+ `board_title` через `GET /boards/{id}` или из
+   уже полученных данных).
+3. Перечислить **все** колонки этих досок: `_get_all("/columns", {"boardId": …})` (`yougile.py:139`).
+   Вернуть `columns: [{title, id, board_id, board_title}]` — `board_id`+`board_title` дают pick-list'у
+   различить одноимённые колонки между досками (риск неуникальности).
+
+Пустой `project` → перечислить колонки всех досок всех проектов (`/projects` → `/boards` → `/columns`,
+как `iter_raw:157-160`). Любой сбой любого шага → warning в список, продолжаем с тем, что собрали.
+
+### 4.2 YouTrack — `YouTrackBoard.list_done_targets(project)` (try-admin → fallback)
+
+**Решение по discovery — «Try-admin → fallback агрегация»** (максимум полноты, не ломается на
+урезанном токене; fail-soft на обоих уровнях):
+
+1. **Try (admin):** резолв внутреннего id проекта по shortName —
+   `GET /admin/projects?fields=id,shortName,name` (или `query=<project>`), match по `shortName == project`.
+   Затем `GET /admin/projects/{id}/customFields?fields=field(name,$type),bundle(values(name,$type))`
+   — вернуть поля-состояния/enum (те, у кого есть `bundle`) + значения. `source="admin"`.
+2. **Fallback (403 / нет прав / любая ошибка admin-уровня):**
+   `GET /issues?query=project:{project}&fields=customFields(name,value(name),$type)` (тот же `_FIELDS`-путь,
+   что у синка — `youtrack.py:24`, `_state_of` семантика), с внутренним `$top`-лимитом; собрать
+   **distinct** `value.name` по каждому имени поля (+ `$type` элемента). `source="sample"`.
+3. Полный провал обоих → `{status_fields: [], source: "sample", warnings: [...]}`.
+
+Пустой `project` → admin: все проекты пропустить нельзя дёшево → fallback на выборку задач без
+`project:`-фильтра (или warning + пусто). Возвращаем только поля с bundle-значениями (кандидаты
+статуса), не все кастом-поля.
+
+### 4.3 Фабрика провайдера (`reviewer/tasks/boards/__init__.py`)
+
+Без изменений сигнатуры: `make_board_provider(settings, board_type, status_field=...)` уже строит
+провайдер из `board_creds` (env). `get_board_targets` идёт тем же путём, что `finish_task:342`.
+`status_field` для discovery не нужен (тул возвращает **кандидатов** для выбора `status_field`) →
+зовём `make_board_provider(settings, board_type)` с дефолтом.
+
+### 4.4 MCP-тул `get_board_targets`
+
+**Решение Б — имя `get_board_targets`** (не `describe_board_targets`) — консистентно с
+`get_board_config`/`get_task`/`get_task_context` (read-тулы = `get_`).
+
+- `reviewer/mcp/service.py`: метод `get_board_targets(self, board_type, project=None) -> dict`:
+  - резолв `board_type` через `configured_board_types()` (паттерн `finish_task:332-341`: если один
+    тип — берём его; ноль/несколько без явного — error-summary);
+  - `provider = make_board_provider(self.settings, board_type)`; `None` → error-summary;
+  - `provider.list_done_targets(project)` в try/except (fail-soft), `provider.close()` в finally;
+  - возврат `{"board_type", "project", **targets}` (targets = `columns`/`status_fields`+`source`+`warnings`).
+    **Креды никогда не в возврате.**
+- `reviewer/entrypoints/mcp_server.py`: тонкий `@mcp.tool() get_board_targets(board_type, project=None)`
+  → делегат в `service.get_board_targets` (паттерн `:120`/`:166`). Docstring — назначение, форма
+  возврата, «credentials never returned; fail-soft».
+
+### 4.5 Скилл `configure-review`
+
+`plugin/skills/configure-review/SKILL.md`, step 5b «finish-task done target» (`:125-137`):
+- Перед вводом done-цели — вызвать `get_board_targets(type, project)` (reviewer MCP, best-effort).
+- **yougile:** показать pick-list колонок (`title`, при неоднозначности — `board_title`); пользователь
+  выбирает `done_column`. Пусто/ошибка/тул отсутствует (старый деплой) → **ask-фолбэк** (текущий ручной
+  ввод) — шаблон best-effort+fallback из `count_tasks` (context-limits, `SKILL.md:178-181`).
+- **youtrack:** показать pick-list полей статуса + их значений; пользователь выбирает `status_field`
+  и `done_state`. Пусто/ошибка → ask-фолбэк.
+- **Убрать** зависимость от клиентского `mcp__yougile__get_columns` (`:131-132`) — заменить на server-тул.
+- Всё остальное поведение скилла (merge, «never write credentials», ask-per-candidate) не трогаем.
+
+### 4.6 Скилл `finish-task`
+
+`plugin/skills/finish-task/SKILL.md`, step 4 «Offer + confirm» (`:32-34`):
+- В подтверждении **явно называть** резолвнутую done-цель: «перенесу задачу в колонку „Готово"
+  + отмечу completed» (yougile) / «выставлю Stage = Готово» (youtrack) — из прочитанных
+  `done_column`/`status_field`+`done_state`. Обобщённое «mark done» → конкретика.
+- **НЕ регрессить** гейт подтверждения: перенос/отметка выполненной — только после явного согласия
+  пользователя, даже если значения заданы в `.review.yml` (инвариант «Never write silently»).
+- `finish-task` **не** зовёт `get_board_targets` (цель уже в `.review.yml`); тул нужен только
+  configure-review на этапе заполнения `.review.yml`.
+
+## 5. Поток данных
+
+```
+DISCOVERY (configure-review, этап заполнения .review.yml):
+  configure-review читает task_board.{type, project} из .review.yml
+  → get_board_targets(board_type, project)
+      make_board_provider(settings, board_type)            # креды из env
+      YouGile:  sample задач проекта → columnId → boardId → все колонки досок
+                → {columns:[{title,id,board_id,board_title}]}
+      YouTrack: try GET /admin/projects/{id}/customFields  → {status_fields, source:"admin"}
+                except → GET /issues?query=project:… → distinct values → source:"sample"
+  → pick-list → пользователь выбирает → запись done_column / status_field+done_state в .review.yml
+                (ask-фолбэк при пустом/ошибке/отсутствии тула)
+
+WRITE (finish-task, без изменений в проводке — только вординг подтверждения):
+  .review.yml {done_column | status_field+done_state}
+  → confirm: «перенесу в „Готово"+completed» / «выставлю Stage=Готово»  → finish_task(...)
+```
+
+## 6. Инварианты и fail-soft
+
+- **Креды только в env** — не в `.review.yml`, не в возврате `get_board_targets`.
+- **Discovery — только ЧТЕНИЕ** доски; перенос/`completed` по-прежнему через `finish_task` с
+  подтверждением пользователя.
+- **Repo-агностичность сервера** — `.review.yml` не парсится сервером; `board_type`+`project`
+  приходят параметрами; клиент (configure-review) читает `.review.yml` и передаёт.
+- **Fail-soft везде** — недоступна доска/креды/права/сеть → пустой список + warnings; скилл
+  откатывается на ручной ввод (никогда не блокирует конфигурацию репо).
+- **Обратная совместимость** — новый тул аддитивен; старый деплой без него → configure-review
+  фолбэкает на ручной ввод (как сейчас).
+
+## 7. Тестирование
+
+### 7.1 Unit (моки httpx, без сети)
+- **yougile** (`tests/tasks/boards/test_yougile_*`): `list_done_targets` резолвит доски из выборки
+  задач и перечисляет их колонки (GET `/columns/{cur}`→board, `/columns?boardId`→список); скоуп по
+  `project`; сбой шага → warning, частичный результат; пустой `project` → все доски.
+- **youtrack** (`tests/tasks/boards/test_youtrack_*`): try-admin успех (`source="admin"`, все значения
+  бандла); admin 403 → fallback-агрегация из выборки задач (`source="sample"`, distinct values);
+  полный провал → `status_fields=[]`+warnings.
+- **boards/__init__**: `make_board_provider(...)` → провайдер с методом `list_done_targets`.
+- **mcp** (`tests/mcp/`): `get_board_targets` резолвит board_type, пробрасывает `project` в провайдер
+  (monkeypatch), возврат НЕ содержит кредов; неизвестный/ненастроенный тип → error-summary.
+- **skills** (`tests/skills/`): guard — `configure-review` упоминает `get_board_targets`/pick-list и
+  НЕ ссылается на `mcp__yougile__get_columns`; `finish-task` step 4 называет конкретную done-цель.
+
+### 7.2 Live acceptance (обе доски) — **вне сессии, после передеплоя**
+- **YouGile PRI:** `get_board_targets("yougile","PRI")` → реальные колонки доски; configure-review
+  без клиентского yougile-MCP предлагает список → выбор `done_column`.
+- **YouTrack TES:** `get_board_targets("youtrack","TES")` → поля статуса (напр. `Stage`) + значения
+  (напр. `Готово`); выбор `status_field`/`done_state`. Проверить оба пути (admin и fallback).
+
+## 8. Границы (scope сессии)
+
+**Решение В — в сессии: код+тесты (units 4.1–4.6, §7.1) + бамп версии `0.2.23`→`0.2.24`.**
+Вне сессии (нужен передеплой, как с фичей-предшественником):
+- PyPI-публикация `0.2.24`;
+- `reviewer update` на деплое;
+- live-приёмка §7.2 на обеих досках.
+
+## 9. Риски / открытые вопросы
+
+- **YouTrack admin API права** — токен может не иметь admin-доступа → покрыто fallback-агрегацией
+  (§4.2); поле done может не всплыть в fallback, если ещё ни одна задача не в done-статусе (приемлемо —
+  пользователь введёт вручную; отражено в warning).
+- **Неуникальность YouGile-колонок** между досками проекта → возвращаем `board_id`+`board_title`,
+  pick-list уточняет.
+- **YouGile «project» ≠ объект YouGile-проекта** — `project` из `.review.yml` это код-префикс задач
+  (`idTaskProject`), не id YouGile-проекта; поэтому доски находим через выборку задач проекта, а не
+  через `/projects` по имени (§4.1).
+- **Проброс в несколько мест** — тул трогает только configure-review; finish-task меняет лишь вординг.
+  Риск забыть скилл минимален (покрывается guard-тестами §7.1).

--- a/plugin/skills/configure-review/SKILL.md
+++ b/plugin/skills/configure-review/SKILL.md
@@ -9,9 +9,10 @@ Scan the repo's **tracked** tree (plus churn), generate a recommended `.review.y
 (cluster depth, per-prefix depth overrides, summary top-k threshold, ignore for noisy tracked
 paths), show it as a draft + diff, let the user adjust, then write it — preserving every other key.
 Standalone baseline: uses `git` and file editing — works on a fresh repo before the first index.
-The single optional exception is sizing `context_limits.search_tasks`: the skill may call the
-reviewer MCP tool `count_tasks(project)` when it is connected; if not (fresh repo / no reviewer MCP /
-older deploy / empty graph) it **falls back to asking** the user. Everything else needs
+Two optional exceptions use the reviewer MCP when connected: sizing `context_limits.search_tasks`
+via `count_tasks(project)`, and the finish-task done-target pick-list via
+`get_board_targets(board_type, project)`; if the reviewer MCP is absent (fresh repo / older deploy)
+or a tool errors, the skill **falls back to asking** the user. Everything else needs
 **no reviewer MCP / Postgres / Neo4j**.
 
 **Always answer the user in Russian** (the project language), regardless of this file's language.
@@ -123,17 +124,23 @@ Parse from $ARGUMENTS (all optional):
    `project` смешивает их. Пустой `task_board.project` = текущее глобальное поведение.
 
    **Then ask the finish-task done target** (closing a task after its PR — skill `/reviewer_finish-task`
-   moves the finished task into the board's "done" cell). Write only the key(s) matching the board type;
+   moves the finished task into the board's "done" cell). First **discover candidates server-side**: call
+   the reviewer MCP tool `get_board_targets(board_type=<type>, project=<project>)` (read-only; creds live in
+   the reviewer env — nothing to configure on the client, and **no yougile/youtrack board-MCP is needed**).
+   Show the result as a **pick-list**; if the tool is absent (older deploy), returns an empty list, or
+   errors, **fall back to asking** the user for the value. Write only the key(s) matching the board type;
    comment out the other board's keys with a one-line note (mirror the root `.review.yml`). All are optional
    and fail-soft — a wrong/absent column or value only warns, the PR link is still written:
    - **yougile** → `done_column`: the exact column **title** finish-task moves the finished task into (plus
-     `completed:true`). If the reviewer/yougile MCP is connected you MAY list the board's columns
-     (`get_columns`) and let the user pick the done column by title; otherwise ask for the title. Not set →
-     finish-task only flips `completed:true` without moving the card.
+     `completed:true`). `get_board_targets` returns `columns: [{title, board_title, …}]` — present them as a
+     pick-list and disambiguate same-named columns by `board_title`; the user picks the done column by title.
+     Empty / tool absent → ask for the title. Not set → finish-task only flips `completed:true` without
+     moving the card.
    - **youtrack** → `status_field` (name of the custom field the board is built on — default `State`; it
      **also** governs status reading on sync, so set it when the board runs on a custom field like `Stage`)
-     and `done_state` (target value of that field — default `Fixed`). YouTrack-only; a yougile board ignores
-     them.
+     and `done_state` (target value of that field — default `Fixed`). `get_board_targets` returns
+     `status_fields: [{field, values: […]}]` — let the user pick the field, then a value from that field's
+     `values` as `done_state`. Empty / tool absent → ask for both. YouTrack-only; a yougile board ignores them.
 
    **Never write credentials.** Remind the user (in Russian): ключи доски (`YOUTRACK_TOKEN`/
    `YOUTRACK_BASE_URL` для youtrack, `YOUGILE_API_KEY` для yougile) задаются в env деплоя reviewer-mcp,

--- a/plugin/skills/finish-task/SKILL.md
+++ b/plugin/skills/finish-task/SKILL.md
@@ -30,7 +30,7 @@ in Russian.
    If none is found, ask the user for the PR URL.
 
 4. **Offer + confirm.** Show what will be written — the PR link + the **resolved done target, named
-   explicitly** (not a generic "mark done"): for yougile «перенесу задачу в колонку „<done_column>" +
+   explicitly** (not a generic "mark done"): for yougile «перенесу задачу в колонку „<done_column>“ +
    отмечу completed» (or just «отмечу completed» when `done_column` is unset); for youtrack «выставлю
    <status_field> = <done_state>» — plus any optional note. Ask the user to **confirm** before writing,
    and whether they want to add an optional note (details under the task). **Never write to the board

--- a/plugin/skills/finish-task/SKILL.md
+++ b/plugin/skills/finish-task/SKILL.md
@@ -29,9 +29,13 @@ in Russian.
 3. **Resolve the PR URL.** `gh pr view --json url -q .url` (GitHub) or `glab mr view` (GitLab).
    If none is found, ask the user for the PR URL.
 
-4. **Offer + confirm.** Show what will be written — the PR link + "mark done" + any optional note —
-   and ask the user to **confirm** before writing. Ask whether they want to add an optional note
-   (details under the task). **Never write to the board silently.**
+4. **Offer + confirm.** Show what will be written — the PR link + the **resolved done target, named
+   explicitly** (not a generic "mark done"): for yougile «перенесу задачу в колонку „<done_column>" +
+   отмечу completed» (or just «отмечу completed» when `done_column` is unset); for youtrack «выставлю
+   <status_field> = <done_state>» — plus any optional note. Ask the user to **confirm** before writing,
+   and whether they want to add an optional note (details under the task). **Never write to the board
+   silently** — the move / mark-done happens **only after explicit confirmation**, even when the values
+   are already set in `.review.yml`.
 
 5. **Write.** Call `finish_task(key=<key>, pr_url=<url>, note=<note or null>, board_type=<type>,
    done_state=<done_state or null>, status_field=<status_field or null>,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "rag-reviewer"
-version = "0.2.23"
+version = "0.2.24"
 description = "AI pull-request reviewer: hybrid RAG + a code graph + Claude Code. Whole-repo context, inline GitHub comments grounded on exact code."
 readme = "README.md"
 license = { text = "MIT" }

--- a/reviewer/entrypoints/mcp_server.py
+++ b/reviewer/entrypoints/mcp_server.py
@@ -173,6 +173,17 @@ def create_server(service: MCPReviewService) -> FastMCP:
         return service.board_config()
 
     @mcp.tool()
+    def get_board_targets(board_type: str | None = None,
+                          project: str | None = None) -> dict:
+        """Discover done-target candidates for a repo's board, server-side (read-only).
+        YouGile → board columns; YouTrack → status fields + their values (bundle via the
+        admin API, else aggregated from a sample of project issues). board_type and
+        project come from the repo's .review.yml task_board block. Credentials are NEVER
+        returned; fail-soft — empty list + warnings when the board/creds/permissions are
+        unavailable, so configure-review can fall back to asking."""
+        return service.get_board_targets(board_type, project)
+
+    @mcp.tool()
     def search_codebase(repo: str, query: str, top_k: int | None = None,
                         branch: str | None = None,
                         include_tests: bool = False) -> str:

--- a/reviewer/entrypoints/mcp_server.py
+++ b/reviewer/entrypoints/mcp_server.py
@@ -16,7 +16,7 @@ log = logging.getLogger(__name__)
 
 
 def create_server(service: MCPReviewService) -> FastMCP:
-    """Создать и вернуть сконфигурированный FastMCP-сервер с 33 тулами.
+    """Создать и вернуть сконфигурированный FastMCP-сервер с 34 тулами.
 
     Все тулы — обычные def (sync), а не async: сервис не потокобезопасен
     и рассчитан на последовательное исполнение sync-тулов FastMCP в event loop.

--- a/reviewer/mcp/service.py
+++ b/reviewer/mcp/service.py
@@ -355,6 +355,38 @@ class MCPReviewService:
                 pass
         return {"status": "ok", "board_type": board_type, **result}
 
+    def get_board_targets(self, board_type: str | None = None,
+                          project: str | None = None) -> dict:
+        """Кандидаты done-цели доски для configure-review (read-only, server-side).
+
+        Резолвит провайдера по board_type (или единственному настроенному), зовёт
+        list_done_targets(project) fail-soft. YouGile → columns; YouTrack → status_fields
+        (+source). Креды из env; наружу НЕ отдаются."""
+        types = self.settings.configured_board_types()
+        if board_type is None:
+            if len(types) == 1:
+                board_type = types[0]
+            else:
+                return {"status": "error",
+                        "reason": f"board_type required (configured: {types or 'none'})"}
+        if board_type not in types:
+            return {"status": "error",
+                    "reason": f"board '{board_type}' not configured (have: {types or 'none'})"}
+        provider = make_board_provider(self.settings, board_type)
+        if provider is None:
+            return {"status": "error", "reason": f"board '{board_type}' not configured"}
+        try:
+            targets = provider.list_done_targets(project)
+        except Exception as e:  # fail-soft: discovery — вторичная функция
+            log.warning("get_board_targets: сбой discovery", exc_info=True)
+            return {"status": "error", "reason": f"{type(e).__name__}: {e}"}
+        finally:
+            try:
+                provider.close()
+            except Exception:
+                pass
+        return {"board_type": board_type, "project": project, **targets}
+
     def _resolve_repo_branch(self, repo: str, branch: str | None) -> tuple[str, str] | str:
         """Резолв (repo, ветка) для session-less тулов.
 

--- a/reviewer/mcp/service.py
+++ b/reviewer/mcp/service.py
@@ -342,9 +342,21 @@ class MCPReviewService:
         provider = make_board_provider(self.settings, board_type, status_field=status_field)
         if provider is None:
             return {"status": "error", "reason": f"board '{board_type}' not configured"}
+        reindexed = False
         try:
             result = provider.finish(key, pr_url, note=note, mark_done=mark_done,
                                      done_state=done_state, done_column=done_column)
+            # Write-through: сразу переиндексировать закрытую задачу в стор reviewer
+            # (fetch_one → normalize → index_task), чтобы get_task/search_tasks/граф
+            # отразили done+PR без гонки с watermark инкрементального sync_board
+            # (тот пропускает задачи с timestamp <= курсор). Best-effort, fail-soft.
+            try:
+                raw = provider.fetch_one(key)
+                if raw is not None:
+                    self.components.task_service.index_task(provider.normalize(raw))
+                    reindexed = True
+            except Exception:
+                log.warning("finish_task: write-through реиндекс не удался", exc_info=True)
         except Exception as e:  # fail-soft: PR уже создан, доска — вторичный эффект
             log.warning("finish_task: сбой записи в доску", exc_info=True)
             return {"status": "error", "reason": f"{type(e).__name__}: {e}"}
@@ -353,7 +365,8 @@ class MCPReviewService:
                 provider.close()
             except Exception:
                 pass
-        return {"status": "ok", "board_type": board_type, **result}
+        return {"status": "ok", "board_type": board_type, "reindexed": reindexed,
+                **result}
 
     def get_board_targets(self, board_type: str | None = None,
                           project: str | None = None) -> dict:

--- a/reviewer/tasks/boards/base.py
+++ b/reviewer/tasks/boards/base.py
@@ -69,6 +69,15 @@ class TaskBoardProvider(Protocol):
         YouGile дополнительно кладёт `column_moved: bool` (доска-специфичное поле)."""
         ...
 
+    def fetch_one(self, key: str) -> RawTask | None:
+        """Один RawTask по ключу задачи — для write-through после finish.
+
+        После finish закрытую задачу надо сразу переиндексировать в стор reviewer,
+        не дожидаясь инкрементального sync_board (тот отсекает задачи с
+        timestamp <= watermark-курсор). fail-soft: сетевой сбой / 404 / нет задачи
+        → None (write-through пропускается, стор догонит обычным синком)."""
+        ...
+
     def list_done_targets(self, project: str | None) -> dict:
         """Кандидаты done-цели доски (read-only, fail-soft, НИКОГДА не бросает).
 

--- a/reviewer/tasks/boards/base.py
+++ b/reviewer/tasks/boards/base.py
@@ -68,3 +68,13 @@ class TaskBoardProvider(Protocol):
         {key, board_id, done_set, pr_link_added, already_closed, warnings};
         YouGile дополнительно кладёт `column_moved: bool` (доска-специфичное поле)."""
         ...
+
+    def list_done_targets(self, project: str | None) -> dict:
+        """Кандидаты done-цели доски (read-only, fail-soft, НИКОГДА не бросает).
+
+        YouGile → {"columns": [{"title", "id", "board_id", "board_title"}], "warnings": [...]}
+        YouTrack → {"status_fields": [{"field", "values": [...], "$type"?}],
+                    "source": "admin"|"sample", "warnings": [...]}
+
+        Ошибка/нет прав/сеть → пустой список + warnings (скилл откатывается на ручной ввод)."""
+        ...

--- a/reviewer/tasks/boards/yougile.py
+++ b/reviewer/tasks/boards/yougile.py
@@ -318,3 +318,47 @@ class YougileBoard:
         return {"key": key, "board_id": uuid, "done_set": done_set,
                 "pr_link_added": pr_link_added, "column_moved": column_moved,
                 "already_closed": not payload, "warnings": warnings}
+
+    def list_done_targets(self, project: str | None) -> dict:
+        """Колонки досок проекта (read-only, fail-soft). project — код-префикс задач
+        (напр. PRI): доска включается, если на ней есть хоть одна задача проекта. Пустой
+        project → все доски всех проектов. НИКОГДА не бросает."""
+        warnings: list[str] = []
+        boards: list[dict] = []           # [{board_id, board_title, columns:[{id,title}]}]
+        hosts: set[str] = set()           # board_id, где встречена задача проекта
+        scanned = 0
+        _CAP = 500                        # предохранитель на число просканированных задач
+        try:
+            for proj in self._get_all("/projects"):
+                for brd in self._get_all("/boards", {"projectId": proj["id"]}):
+                    bid = brd["id"]
+                    cols = [{"id": c["id"], "title": c.get("title", "")}
+                            for c in self._get_all("/columns", {"boardId": bid})]
+                    boards.append({"board_id": bid, "board_title": brd.get("title", ""),
+                                   "columns": cols})
+                    if not project:
+                        continue
+                    for c in cols:
+                        if scanned >= _CAP:
+                            break
+                        hit = False
+                        for t in self._get_all("/tasks", {"columnId": c["id"]}):
+                            scanned += 1
+                            if project_prefix(t.get("idTaskProject", "")) == project:
+                                hit = True
+                                break
+                            if scanned >= _CAP:
+                                break
+                        if hit:
+                            hosts.add(bid)
+                            break
+        except Exception:
+            log.warning("yougile: discovery колонок не удался", exc_info=True)
+            warnings.append("не удалось перечислить колонки доски")
+        kept = boards if not project else [b for b in boards if b["board_id"] in hosts]
+        columns = [{"title": col["title"], "id": col["id"],
+                    "board_id": b["board_id"], "board_title": b["board_title"]}
+                   for b in kept for col in b["columns"]]
+        if project and not hosts and not warnings:
+            warnings.append(f"колонки для проекта {project!r} не найдены")
+        return {"columns": columns, "warnings": warnings}

--- a/reviewer/tasks/boards/yougile.py
+++ b/reviewer/tasks/boards/yougile.py
@@ -248,6 +248,40 @@ class YougileBoard:
         return normalize_yougile(raw, self._key_pattern, self._url_template,
                                  subtask_titles, attachments=attachments)
 
+    def fetch_one(self, key: str) -> RawTask | None:
+        """Один RawTask по ключу (проектный/компанийный код) — write-through после finish.
+
+        GET /tasks/{key} (тот же вызов, что и в finish); title колонки резолвится
+        best-effort через GET /columns/{columnId}. fail-soft: сбой/404 → None."""
+        try:
+            r = self._client.get(f"/tasks/{quote(key, safe='')}")
+            r.raise_for_status()
+            t = r.json()
+        except Exception:
+            log.warning("yougile: fetch_one(%s) не удался", key, exc_info=True)
+            return None
+        status = None
+        col_id = t.get("columnId")
+        if col_id:
+            try:
+                rc = self._client.get(f"/columns/{quote(str(col_id), safe='')}")
+                rc.raise_for_status()
+                status = rc.json().get("title")
+            except Exception:
+                log.warning("yougile: колонка задачи %s недоступна — status=None",
+                            key, exc_info=True)
+        return RawTask(
+            key=t.get("idTaskCommon") or t.get("id") or key,
+            project_code=t.get("idTaskProject", "") or "",
+            title=t.get("title", "") or "",
+            description=t.get("description", "") or "",
+            status=status,
+            subtask_ids=list(t.get("subtasks", []) or []),
+            timestamp=int(t.get("timestamp", 0) or 0),
+            board_id=t.get("id") or key,
+            completed=bool(t.get("completed", False)),
+        )
+
     def _resolve_column_id(self, current_col_id: str, title: str) -> str | None:
         """id колонки с заданным title на той же доске, что и current_col_id.
 

--- a/reviewer/tasks/boards/youtrack.py
+++ b/reviewer/tasks/boards/youtrack.py
@@ -20,6 +20,7 @@ from reviewer.tasks.boards.base import RawTask, project_prefix
 log = logging.getLogger(__name__)
 
 _PAGE = 200
+_SAMPLE = 200  # число задач в выборке для fallback-агрегации значений полей статуса
 
 _FIELDS = (
     "idReadable,summary,description,updated,"
@@ -277,3 +278,73 @@ class YouTrackBoard:
                 "pr_link_added": pr_link_added,
                 "already_closed": not pr_link_added and not done_set,
                 "warnings": warnings}
+
+    def list_done_targets(self, project: str | None) -> dict:
+        """Поля статуса + значения (read-only, fail-soft). Try admin customFields;
+        при недоступности — агрегация distinct значений из выборки задач проекта.
+        НИКОГДА не бросает."""
+        warnings: list[str] = []
+        try:
+            fields = self._admin_status_fields(project)
+            if fields:
+                return {"status_fields": fields, "source": "admin", "warnings": warnings}
+        except Exception:
+            log.warning("youtrack: admin customFields недоступны — fallback", exc_info=True)
+            warnings.append("admin customFields недоступны (нет прав?) — "
+                            "значения собраны из задач")
+        try:
+            fields = self._sampled_status_fields(project)
+        except Exception:
+            log.warning("youtrack: discovery полей из выборки не удался", exc_info=True)
+            warnings.append("не удалось собрать поля статуса из задач")
+            fields = []
+        return {"status_fields": fields, "source": "sample", "warnings": warnings}
+
+    def _admin_status_fields(self, project: str | None) -> list[dict]:
+        """Bundle-поля (state/enum) проекта из admin API + их значения. [] если project пуст
+        или проект не найден. Бросает при ошибке HTTP — вызывающий ловит и фолбэкает."""
+        if not project:
+            return []
+        pr = self._client.get("/admin/projects",
+                              params={"fields": "id,shortName", "query": project})
+        pr.raise_for_status()
+        pid = next((p["id"] for p in (pr.json() or [])
+                    if p.get("shortName") == project), None)
+        if not pid:
+            return []
+        r = self._client.get(
+            f"/admin/projects/{quote(str(pid), safe='')}/customFields",
+            params={"fields": "field(name),$type,bundle(values(name,$type))"})
+        r.raise_for_status()
+        out: list[dict] = []
+        for pcf in (r.json() or []):
+            bundle = pcf.get("bundle") or {}
+            values = [v.get("name") for v in (bundle.get("values") or []) if v.get("name")]
+            if not values:
+                continue  # не bundle-поле — не кандидат статуса
+            name = (pcf.get("field") or {}).get("name")
+            if name:
+                out.append({"field": name, "values": values, "$type": pcf.get("$type")})
+        return out
+
+    def _sampled_status_fields(self, project: str | None) -> list[dict]:
+        """Distinct значения single-value кастом-полей из выборки задач проекта.
+        Бросает при ошибке HTTP — вызывающий ловит."""
+        params: dict = {"fields": "customFields(name,value(name),$type)", "$top": _SAMPLE}
+        if project:
+            params["query"] = f"project: {project}"
+        r = self._client.get("/issues", params=params)
+        r.raise_for_status()
+        agg: dict[str, dict] = {}  # field name -> {"values": [...], "$type": ...}
+        for issue in (r.json() or []):
+            for cf in issue.get("customFields") or []:
+                name = cf.get("name")
+                val = cf.get("value")
+                vname = val.get("name") if isinstance(val, dict) else None
+                if not name or not vname:
+                    continue
+                slot = agg.setdefault(name, {"values": [], "$type": cf.get("$type")})
+                if vname not in slot["values"]:
+                    slot["values"].append(vname)
+        return [{"field": n, "values": s["values"], "$type": s["$type"]}
+                for n, s in agg.items()]

--- a/reviewer/tasks/boards/youtrack.py
+++ b/reviewer/tasks/boards/youtrack.py
@@ -279,6 +279,23 @@ class YouTrackBoard:
                 "already_closed": not pr_link_added and not done_set,
                 "warnings": warnings}
 
+    def fetch_one(self, key: str) -> RawTask | None:
+        """Один RawTask по idReadable — write-through после finish.
+
+        GET /issues/{key} с богатым `fields` (_FIELDS) → _issue_to_raw. Имя поля
+        статуса — self._status_field (per-repo). fail-soft: сбой/пусто → None."""
+        try:
+            r = self._client.get(f"/issues/{quote(key, safe='')}",
+                                  params={"fields": _FIELDS})
+            r.raise_for_status()
+            issue = r.json()
+        except Exception:
+            log.warning("youtrack: fetch_one(%s) не удался", key, exc_info=True)
+            return None
+        if not issue:
+            return None
+        return _issue_to_raw(issue, self._status_field)
+
     def list_done_targets(self, project: str | None) -> dict:
         """Поля статуса + значения (read-only, fail-soft). Try admin customFields;
         при недоступности — агрегация distinct значений из выборки задач проекта.

--- a/tests/mcp/test_finish_task.py
+++ b/tests/mcp/test_finish_task.py
@@ -1,11 +1,25 @@
 import reviewer.mcp.service as svc_mod
 from reviewer.mcp.service import MCPReviewService
+from reviewer.tasks.boards.base import RawTask
+
+
+class _FakeTaskService:
+    def __init__(self):
+        self.indexed = []
+
+    def index_task(self, brief):
+        self.indexed.append(brief)
+        return {"key": brief.get("key"), "embedded": True, "warnings": []}
 
 
 class _Provider:
-    def __init__(self):
+    def __init__(self, raw=None):
         self.finished = None
         self.closed = False
+        self.fetched = None
+        self._raw = raw if raw is not None else RawTask(
+            key="ID-10", project_code="PRI-10", title="T", description="d",
+            status=None, subtask_ids=[], timestamp=1, completed=True)
 
     def finish(self, key, pr_url, *, note=None, mark_done=True, done_state=None,
                done_column=None):
@@ -13,15 +27,25 @@ class _Provider:
         return {"key": key, "board_id": "u1", "done_set": True,
                 "pr_link_added": True, "already_closed": False, "warnings": []}
 
+    def fetch_one(self, key):
+        self.fetched = key
+        return self._raw
+
+    def normalize(self, raw):
+        return {"key": raw.key, "title": raw.title, "status": "done",
+                "project": "PRI", "description": raw.description}
+
     def close(self):
         self.closed = True
 
 
 class _Svc(MCPReviewService):
-    """Обходим тяжёлый __init__: только settings с configured_board_types."""
-    def __init__(self, configured):
+    """Обходим тяжёлый __init__: только settings + components.task_service."""
+    def __init__(self, configured, task_service=None):
         self.settings = type("S", (), {
             "configured_board_types": staticmethod(lambda: configured)})()
+        self.components = type("C", (), {
+            "task_service": task_service or _FakeTaskService()})()
 
 
 def test_finish_task_resolves_single_board(monkeypatch):
@@ -81,3 +105,36 @@ def test_finish_task_failsoft(monkeypatch):
     out = _Svc(["yougile"]).finish_task("PRI-10", "url")
     assert out["status"] == "error"
     assert "kaboom" in out["reason"]
+
+
+def test_finish_task_writes_through_to_store(monkeypatch):
+    # После записи в доску закрытая задача сразу переиндексируется в стор reviewer
+    # (без гонки с watermark инкрементального sync_board).
+    prov = _Provider()
+    ts = _FakeTaskService()
+    monkeypatch.setattr(svc_mod, "make_board_provider", lambda s, t, status_field=None: prov)
+    out = _Svc(["yougile"], task_service=ts).finish_task(
+        "PRI-10", "https://github.com/o/r/pull/7")
+    assert out["status"] == "ok"
+    assert out["reindexed"] is True
+    assert prov.fetched == "PRI-10"
+    assert len(ts.indexed) == 1
+    assert ts.indexed[0]["key"] == "ID-10"
+    assert ts.indexed[0]["status"] == "done"
+
+
+def test_finish_task_writethrough_failsoft_when_fetch_none(monkeypatch):
+    # fetch_one вернул None (сбой доски) → finish всё равно ok, reindexed=False,
+    # стор не трогается (fallback — обычный sync_board).
+    class _NoRaw(_Provider):
+        def fetch_one(self, key):
+            self.fetched = key
+            return None
+
+    prov = _NoRaw()
+    ts = _FakeTaskService()
+    monkeypatch.setattr(svc_mod, "make_board_provider", lambda s, t, status_field=None: prov)
+    out = _Svc(["yougile"], task_service=ts).finish_task("PRI-10", "url")
+    assert out["status"] == "ok"
+    assert out["reindexed"] is False
+    assert ts.indexed == []

--- a/tests/mcp/test_get_board_targets.py
+++ b/tests/mcp/test_get_board_targets.py
@@ -1,0 +1,73 @@
+import reviewer.mcp.service as svc_mod
+from reviewer.mcp.service import MCPReviewService
+
+
+class _Provider:
+    def __init__(self, targets):
+        self.targets = targets
+        self.project = "UNSET"
+        self.closed = False
+
+    def list_done_targets(self, project):
+        self.project = project
+        return self.targets
+
+    def close(self):
+        self.closed = True
+
+
+class _Svc(MCPReviewService):
+    """Обходим тяжёлый __init__: только settings с configured_board_types."""
+    def __init__(self, configured):
+        self.settings = type("S", (), {
+            "configured_board_types": staticmethod(lambda: configured)})()
+
+
+def test_get_board_targets_single_board_threads_project(monkeypatch):
+    prov = _Provider({"columns": [{"title": "Готово", "id": "c1",
+                                   "board_id": "b1", "board_title": "B"}], "warnings": []})
+    monkeypatch.setattr(svc_mod, "make_board_provider", lambda s, t: prov)
+    out = _Svc(["yougile"]).get_board_targets(project="PRI")
+    assert out["board_type"] == "yougile"
+    assert out["project"] == "PRI"
+    assert out["columns"][0]["title"] == "Готово"
+    assert prov.project == "PRI"
+    assert prov.closed is True
+    # креды наружу не отдаются
+    assert "api_key" not in out and "token" not in out
+
+
+def test_get_board_targets_ambiguous_requires_type():
+    out = _Svc(["yougile", "youtrack"]).get_board_targets()
+    assert out["status"] == "error"
+    assert "board_type" in out["reason"]
+
+
+def test_get_board_targets_not_configured():
+    out = _Svc([]).get_board_targets(board_type="youtrack")
+    assert out["status"] == "error"
+
+
+def test_get_board_targets_explicit_type(monkeypatch):
+    prov = _Provider({"status_fields": [{"field": "Stage", "values": ["Готово"],
+                                         "$type": "X"}], "source": "admin", "warnings": []})
+    monkeypatch.setattr(svc_mod, "make_board_provider", lambda s, t: prov)
+    out = _Svc(["yougile", "youtrack"]).get_board_targets(board_type="youtrack",
+                                                          project="TES")
+    assert out["board_type"] == "youtrack"
+    assert out["source"] == "admin"
+    assert prov.project == "TES"
+
+
+def test_get_board_targets_failsoft(monkeypatch):
+    class Boom:
+        def list_done_targets(self, project):
+            raise RuntimeError("kaboom")
+
+        def close(self):
+            pass
+
+    monkeypatch.setattr(svc_mod, "make_board_provider", lambda s, t: Boom())
+    out = _Svc(["yougile"]).get_board_targets()
+    assert out["status"] == "error"
+    assert "kaboom" in out["reason"]

--- a/tests/mcp/test_server.py
+++ b/tests/mcp/test_server.py
@@ -88,7 +88,7 @@ def _make_mcp_service(number: int = 7) -> MCPReviewService:
 # ---------------------------------------------------------------------------
 
 def test_server_registers_all_tools() -> None:
-    """create_server регистрирует ровно 33 ожидаемых MCP-тула."""
+    """create_server регистрирует ровно 34 ожидаемых MCP-тула."""
     from reviewer.entrypoints.mcp_server import create_server
 
     server = create_server(_make_mcp_service())
@@ -113,6 +113,7 @@ def test_server_registers_all_tools() -> None:
         "get_task",
         "count_tasks",
         "get_board_config",
+        "get_board_targets",
         "publish_review",
         "submit_findings",
         "submit_verdicts",

--- a/tests/skills/test_configure_review_skill.py
+++ b/tests/skills/test_configure_review_skill.py
@@ -107,3 +107,17 @@ def test_skill_asks_for_project_scope():
     assert "project" in text
     # предупреждение про пустой project (тянет все проекты)
     assert "все проект" in text.lower() or "all project" in text.lower()
+
+
+def test_skill_uses_server_side_done_target_discovery():
+    text = SKILL.read_text(encoding="utf-8")
+    assert "get_board_targets" in text            # server-side discovery тул
+    assert "pick-list" in text                    # предъявляет список кандидатов
+    # больше не зависит от клиентского yougile-MCP
+    assert "get_columns" not in text
+
+
+def test_skill_done_target_discovery_falls_back_to_asking():
+    text = SKILL.read_text(encoding="utf-8")
+    # тул отсутствует/пусто/ошибка → спросить пользователя (fail-open)
+    assert "fall back to asking" in text

--- a/tests/skills/test_finish_task_skill.py
+++ b/tests/skills/test_finish_task_skill.py
@@ -38,3 +38,10 @@ def test_finish_task_reads_status_field_and_done_column():
     t = SKILL.read_text(encoding="utf-8")
     assert "status_field" in t     # читает имя поля YouTrack из .review.yml
     assert "done_column" in t       # читает done-колонку YouGile из .review.yml
+
+
+def test_finish_task_names_resolved_done_target():
+    t = SKILL.read_text(encoding="utf-8")
+    assert "resolved done target" in t   # шаг 4 явно называет цель, не обобщённое mark done
+    # гейт подтверждения не регрессирует
+    assert "only after explicit confirmation" in t

--- a/tests/tasks/boards/test_yougile_fetch_one.py
+++ b/tests/tasks/boards/test_yougile_fetch_one.py
@@ -1,0 +1,75 @@
+"""fetch_one(key) — единичный RawTask по ключу для write-through после finish."""
+from reviewer.tasks.boards.yougile import YougileBoard
+
+
+class _Resp:
+    def __init__(self, status=200, json_data=None):
+        self.status_code = status
+        self._json = json_data or {}
+
+    def raise_for_status(self):
+        if self.status_code >= 400:
+            raise RuntimeError(f"HTTP {self.status_code}")
+
+    def json(self):
+        return self._json
+
+
+class _Client:
+    def __init__(self, get_routes):
+        self._get = get_routes
+        self.calls = []
+
+    def get(self, path, params=None):
+        self.calls.append(("GET", path))
+        return self._get[path]
+
+    def close(self):
+        pass
+
+
+def _board(get_routes):
+    b = YougileBoard.__new__(YougileBoard)
+    b._client = _Client(get_routes)
+    return b
+
+
+def test_fetch_one_builds_rawtask_like_iter_raw():
+    b = _board({
+        "/tasks/PRI-10": _Resp(200, {
+            "id": "u1", "idTaskCommon": "ID-10", "idTaskProject": "PRI-10",
+            "title": "Заголовок", "description": "тело", "columnId": "c1",
+            "subtasks": ["s1", "s2"], "timestamp": 123, "completed": True}),
+        "/columns/c1": _Resp(200, {"title": "Готово"}),
+    })
+    raw = b.fetch_one("PRI-10")
+    assert raw is not None
+    assert raw.key == "ID-10"                 # idTaskCommon предпочтительнее id
+    assert raw.project_code == "PRI-10"
+    assert raw.title == "Заголовок"
+    assert raw.description == "тело"
+    assert raw.status == "Готово"             # резолв колонки
+    assert raw.subtask_ids == ["s1", "s2"]
+    assert raw.timestamp == 123
+    assert raw.board_id == "u1"
+    assert raw.completed is True
+
+
+def test_fetch_one_none_on_http_error():
+    # 404/сеть → None (write-through пропускается, не валит finish).
+    b = _board({"/tasks/PRI-404": _Resp(404, {})})
+    assert b.fetch_one("PRI-404") is None
+
+
+def test_fetch_one_survives_column_resolve_failure():
+    # колонка не резолвится → status=None, но RawTask собран (completed даст done).
+    b = _board({
+        "/tasks/PRI-10": _Resp(200, {
+            "id": "u1", "idTaskProject": "PRI-10", "title": "T",
+            "description": "d", "columnId": "c1", "completed": True}),
+        "/columns/c1": _Resp(500, {}),
+    })
+    raw = b.fetch_one("PRI-10")
+    assert raw is not None
+    assert raw.status is None
+    assert raw.completed is True

--- a/tests/tasks/boards/test_yougile_targets.py
+++ b/tests/tasks/boards/test_yougile_targets.py
@@ -1,0 +1,86 @@
+from reviewer.tasks.boards.yougile import YougileBoard
+
+
+class _Resp:
+    def __init__(self, status=200, content=None):
+        self.status_code = status
+        self._content = content if content is not None else []
+
+    def raise_for_status(self):
+        if self.status_code >= 400:
+            raise RuntimeError(f"HTTP {self.status_code}")
+
+    def json(self):
+        return {"content": self._content}
+
+
+class _Client:
+    """Фейк httpx: роутит GET по (path + дискриминирующий param). Неизвестный путь → 500
+    (для проверки fail-soft). _get_all читает .json()['content']."""
+
+    def __init__(self, routes):
+        self.routes = routes  # ключ "path" или "path?disc=val" -> list[dict]
+        self.calls = []
+
+    def get(self, path, params=None):
+        params = params or {}
+        self.calls.append((path, dict(params)))
+        for disc in ("projectId", "boardId", "columnId"):
+            if disc in params:
+                key = f"{path}?{disc}={params[disc]}"
+                return _Resp(200, self.routes[key]) if key in self.routes else _Resp(500)
+        return _Resp(200, self.routes[path]) if path in self.routes else _Resp(500)
+
+    def close(self):
+        pass
+
+
+def _board(routes):
+    b = YougileBoard.__new__(YougileBoard)  # обойти httpx.Client в __init__
+    b._client = _Client(routes)
+    return b
+
+
+_TWO_BOARDS = {
+    "/projects": [{"id": "p1", "title": "Proj"}],
+    "/boards?projectId=p1": [{"id": "b1", "title": "Board One"},
+                             {"id": "b2", "title": "Board Two"}],
+    "/columns?boardId=b1": [{"id": "c1", "title": "В работе"},
+                            {"id": "c2", "title": "Готово"}],
+    "/columns?boardId=b2": [{"id": "c3", "title": "Todo"},
+                            {"id": "c4", "title": "Done"}],
+    "/tasks?columnId=c1": [{"idTaskProject": "PRI-1"}],  # b1 хостит PRI
+    "/tasks?columnId=c2": [],
+    "/tasks?columnId=c3": [{"idTaskProject": "TES-1"}],  # b2 хостит только TES
+    "/tasks?columnId=c4": [],
+}
+
+
+def test_yougile_targets_scopes_to_project_boards():
+    res = _board(_TWO_BOARDS).list_done_targets("PRI")
+    titles = {(c["title"], c["board_title"]) for c in res["columns"]}
+    assert titles == {("В работе", "Board One"), ("Готово", "Board One")}
+    assert res["warnings"] == []
+    assert all(c["board_id"] == "b1" for c in res["columns"])
+
+
+def test_yougile_targets_empty_project_returns_all_boards():
+    b = _board(_TWO_BOARDS)
+    res = b.list_done_targets(None)
+    assert {c["title"] for c in res["columns"]} == {"В работе", "Готово", "Todo", "Done"}
+    # без project задачи не сканируются вовсе
+    assert not any(path == "/tasks" for path, _ in b._client.calls)
+
+
+def test_yougile_targets_no_project_boards_warns():
+    res = _board(_TWO_BOARDS).list_done_targets("ZZZ")
+    assert res["columns"] == []
+    assert res["warnings"]  # «колонки для проекта 'ZZZ' не найдены»
+
+
+def test_yougile_targets_failsoft_on_error():
+    # отсутствует роут /boards?projectId=p1 → 500 внутри обхода → warning, без падения
+    routes = {"/projects": [{"id": "p1", "title": "Proj"}]}
+    res = _board(routes).list_done_targets("PRI")
+    assert res["columns"] == []
+    assert res["warnings"]

--- a/tests/tasks/boards/test_youtrack_fetch_one.py
+++ b/tests/tasks/boards/test_youtrack_fetch_one.py
@@ -1,0 +1,62 @@
+"""fetch_one(key) — единичный RawTask по idReadable для write-through после finish."""
+from reviewer.tasks.boards.youtrack import YouTrackBoard
+
+
+class _Resp:
+    def __init__(self, status=200, json_data=None):
+        self.status_code = status
+        self._json = json_data if json_data is not None else {}
+
+    def raise_for_status(self):
+        if self.status_code >= 400:
+            raise RuntimeError(f"HTTP {self.status_code}")
+
+    def json(self):
+        return self._json
+
+
+class _Client:
+    def __init__(self, get_routes):
+        self._get = get_routes
+        self.calls = []
+
+    def get(self, path, params=None):
+        self.calls.append(("GET", path, params))
+        return self._get[path]
+
+    def close(self):
+        pass
+
+
+def _board(get_routes, status_field="State"):
+    b = YouTrackBoard.__new__(YouTrackBoard)
+    b._client = _Client(get_routes)
+    b._status_field = status_field
+    return b
+
+
+def test_fetch_one_builds_rawtask():
+    issue = {"idReadable": "TES-5", "summary": "Саммари", "description": "тело",
+             "updated": 999,
+             "customFields": [{"name": "State", "value": {"name": "Fixed"}}]}
+    b = _board({"/issues/TES-5": _Resp(200, issue)})
+    raw = b.fetch_one("TES-5")
+    assert raw is not None
+    assert raw.key == "TES-5"
+    assert raw.title == "Саммари"
+    assert raw.status == "Fixed"
+    assert raw.timestamp == 999
+
+
+def test_fetch_one_honours_custom_status_field():
+    issue = {"idReadable": "TES-6", "summary": "S", "description": "",
+             "updated": 1,
+             "customFields": [{"name": "Stage", "value": {"name": "Готово"}}]}
+    b = _board({"/issues/TES-6": _Resp(200, issue)}, status_field="Stage")
+    raw = b.fetch_one("TES-6")
+    assert raw.status == "Готово"
+
+
+def test_fetch_one_none_on_error():
+    b = _board({"/issues/TES-404": _Resp(500, {})})
+    assert b.fetch_one("TES-404") is None

--- a/tests/tasks/boards/test_youtrack_targets.py
+++ b/tests/tasks/boards/test_youtrack_targets.py
@@ -1,0 +1,105 @@
+from reviewer.tasks.boards.youtrack import YouTrackBoard
+
+
+class _Resp:
+    def __init__(self, status=200, json_data=None):
+        self.status_code = status
+        self._json = json_data
+
+    def raise_for_status(self):
+        if self.status_code >= 400:
+            raise RuntimeError(f"HTTP {self.status_code}")
+
+    def json(self):
+        return self._json
+
+
+class _Client:
+    """Фейк httpx: роутит GET по path (admin id уже в пути). .json() отдаёт список."""
+
+    def __init__(self, routes):
+        self.routes = routes
+        self.calls = []
+
+    def get(self, path, params=None):
+        self.calls.append((path, dict(params or {})))
+        r = self.routes.get(path)
+        if r is None:
+            return _Resp(500, None)
+        return r
+
+    def close(self):
+        pass
+
+
+def _board(routes):
+    b = YouTrackBoard.__new__(YouTrackBoard)  # обойти httpx.Client в __init__
+    b._client = _Client(routes)
+    b._status_field = "State"
+    return b
+
+
+def test_youtrack_targets_admin_success():
+    routes = {
+        "/admin/projects": _Resp(200, [{"id": "0-5", "shortName": "TES"}]),
+        "/admin/projects/0-5/customFields": _Resp(200, [
+            {"$type": "StateProjectCustomField", "field": {"name": "Stage"},
+             "bundle": {"values": [{"name": "Open"}, {"name": "Готово"}]}},
+            {"$type": "TextProjectCustomField", "field": {"name": "Descr"},
+             "bundle": None},  # не bundle-поле → пропуск
+        ]),
+    }
+    res = _board(routes).list_done_targets("TES")
+    assert res["source"] == "admin"
+    assert res["status_fields"] == [
+        {"field": "Stage", "values": ["Open", "Готово"], "$type": "StateProjectCustomField"}]
+    assert res["warnings"] == []
+
+
+def test_youtrack_targets_fallback_to_sample_on_admin_403():
+    routes = {
+        "/admin/projects": _Resp(403, None),  # нет admin-прав
+        "/issues": _Resp(200, [
+            {"customFields": [{"name": "Stage", "value": {"name": "Open"},
+                               "$type": "StateIssueCustomField"}]},
+            {"customFields": [{"name": "Stage", "value": {"name": "Готово"},
+                               "$type": "StateIssueCustomField"}]},
+        ]),
+    }
+    res = _board(routes).list_done_targets("TES")
+    assert res["source"] == "sample"
+    assert res["status_fields"] == [
+        {"field": "Stage", "values": ["Open", "Готово"], "$type": "StateIssueCustomField"}]
+    assert res["warnings"]  # предупреждение про недоступный admin
+
+
+def test_youtrack_targets_sample_ignores_non_dict_values():
+    routes = {
+        "/admin/projects": _Resp(403, None),
+        "/issues": _Resp(200, [
+            {"customFields": [{"name": "Stage", "value": {"name": "Open"}},
+                              {"name": "Assignee", "value": "текст"},   # не dict → пропуск
+                              {"name": "Sprints", "value": [{"name": "S1"}]}]},  # list → пропуск
+        ]),
+    }
+    res = _board(routes).list_done_targets("TES")
+    assert [f["field"] for f in res["status_fields"]] == ["Stage"]
+
+
+def test_youtrack_targets_total_failure_empty_failsoft():
+    routes = {"/admin/projects": _Resp(403, None), "/issues": _Resp(500, None)}
+    res = _board(routes).list_done_targets("TES")
+    assert res["status_fields"] == []
+    assert res["source"] == "sample"
+    assert len(res["warnings"]) >= 1
+
+
+def test_youtrack_targets_empty_project_uses_sample_no_admin_call():
+    routes = {"/issues": _Resp(200, [
+        {"customFields": [{"name": "State", "value": {"name": "Open"},
+                           "$type": "StateIssueCustomField"}]}])}
+    b = _board(routes)
+    res = b.list_done_targets(None)
+    assert res["source"] == "sample"
+    assert [f["field"] for f in res["status_fields"]] == ["State"]
+    assert not any(path.startswith("/admin") for path, _ in b._client.calls)


### PR DESCRIPTION
## PRI-205 — server-side discovery done-цели доски

Надстройка над `configurable-done-target` (0.2.23): вместо ручного ввода `done_column` /
`status_field` / `done_state` в `.review.yml` (подсматривая точные названия в UI доски),
`configure-review` теперь показывает **pick-list** реальных кандидатов, а `finish-task`
явно называет резолвнутую done-цель в подтверждении. Discovery — server-side по REST-кредам
из env, **без** стороннего board-MCP на клиенте (симметрично `sync_board` / `finish_task`).

## Что сделано

- **`reviewer/tasks/boards/base.py`** — новый метод Protocol `list_done_targets(project)`
  (доска-специфичная форма возврата: YouGile `{columns, warnings}` / YouTrack
  `{status_fields, source, warnings}`).
- **YouGile** (`yougile.py`) — обход `projects → boards → columns`, скоуп по `project_prefix`
  членства задач (`_CAP=500`); возвращает `{title, id, board_id, board_title}`.
- **YouTrack** (`youtrack.py`) — `list_done_targets`: try-admin (`/admin/projects/.../customFields`)
  → fallback-агрегация значений из выборки задач (`_SAMPLE=200`); `source: admin|sample`.
- **MCP-тул** `get_board_targets(board_type, project)` (`mcp/service.py` + регистрация в
  `mcp_server.py`) — резолв `configured_board_types`, `make_board_provider` без `status_field`,
  `provider.close()` в finally, fail-soft. Тулов на сервере: 33 → 34.
- **Скиллы:** `configure-review` step 5b — pick-list через `get_board_targets` с ask-фолбэком,
  убран клиентский `mcp__yougile__get_columns`; `finish-task` step 4 — явное имя done-цели.
- **Версия:** 0.2.23 → 0.2.24.

## Инварианты

- Креды только в env — **не** в `.review.yml` и **не** в возврате тула (тул отдаёт только
  метаданные доски + переданные параметры).
- Fail-soft: недоступна доска / нет прав → пустой список → скилл откатывается на вопрос.
- Repo-агностичность сервера (`.review.yml` сервер не парсит); клиент читает и передаёт.
- Discovery — только **чтение**; перенос/`completed` по-прежнему через `finish_task` с подтверждением.

## Тесты

Новые unit (мок httpx): `test_yougile_targets.py` (4), `test_youtrack_targets.py` (5),
`test_get_board_targets.py` (5); guard-тесты вординга скиллов (+3); обновлён registry-guard
(33→34). **979 passed** (кроме `tests/web` — преэкзистинг-разрыв по `fastapi`, не связан с фичей).

## Follow-up вне этой сессии

- Публикация 0.2.24 в PyPI → `reviewer update` на деплое.
- Live-приёмка на обеих досках (YouGile PRI + YouTrack TES).
- После merge — закрыть PRI-205 через `/reviewer_finish-task`.
