### PR TITLE
feat(tasks): self-healing meta-refresh синка — backfill project ниже watermark (PRI-207)

### DIFF
--- a/docs/superpowers/briefs/2026-07-03-PRI-207-watermark-sync-no-project-backfill.md
+++ b/docs/superpowers/briefs/2026-07-03-PRI-207-watermark-sync-no-project-backfill.md
@@ -1,0 +1,47 @@
+# Brief — PRI-207 Watermark синка задач не backfill-ит старые задачи → project (PRI-170) пуст у 94/97, scoped search_tasks почти слепой
+url: https://ru.yougile.com/team/686c049c8af8/#PRI-207
+_(данные задачи — из стора reviewer после preflight `sync_board`; индекс dev переиндексирован в этой сессии @ `8dd053c`, SCIP)_
+
+## Task
+- **Симптом.** `search_tasks(project="PRI")` / `get_task(project="PRI")` видят ~3 из ~97 задач. В `tasks`: `project=''` — 94, `PRI` — 3, `TES` — 1. Это НЕ утечка скоупа (SQL верен), а незаполненная колонка `project`.
+- **Корень.** `SyncService._sync_provider` (`sync.py:48`): `if raw.timestamp <= cursor: continue` — старые задачи не доходят до normalize/index. Заполнение `project` (добавлено в путь индексации в PRI-170) никогда не backfill-ится на уже-синканутые задачи. `content_hash` не спасает (в него входит только текст, не `project`).
+- **Обобщение.** Любое обогащение, добавленное в индексацию позже первого синка задачи, не доезжает до старых задач; `project` — первый пойманный случай.
+- **Кандидаты фикса (выбрать на brainstorming):** 1) force/full-режим `sync_board` (обход watermark → полный re-normalize/index); 2) сброс курсора в `index_meta`; 3) одноразовый backfill `project` прямым UPDATE; 4) отдельный «meta-refresh» путь для ВСЕХ enumerate-нутых задач независимо от watermark.
+- **Acceptance:** после фикса `search_tasks(project="PRI")` возвращает десятки PRI-задач (не 3); распределение `project` в `tasks` — ~все валидные задачи имеют непустой `project`, ноль пустых среди задач с валидным кодом.
+
+## Related work
+- **PR #92 / `384fce7`** (`finish_task` write-through) — тот же watermark-баг, решён точечно: `provider.fetch_one(key) → normalize → index_task` в обход курсора (`reviewer/mcp/service.py:342-366`). Кандидаты 1/4 обобщают ровно этот паттерн на все задачи; `fetch_one`/`normalize`/`index_task` уже есть.
+- **PRI-170** (скоуп задач по проекту) — фича, которую этот баг де-факто отключает для основного корпуса: она добавила `project` в путь индексации (`normalize_* → project_prefix` в `reviewer/tasks/boards/`), но только для changed-задач.
+- (dropped 4: ID-205 done-target discovery, ID-203 reviewer-priming, ID-206 blast-radius discipline — та же область task-инфры, но иной механизм; ID-204 «TEST … удалить» — шум.)
+
+## Subsystems
+- `reviewer/tasks` — синк/сервис/граф/стор задач; ETL-синк (`SyncService`) с watermark-курсором, батчевый `index_tasks_batch`, дедуп по `content_hash` — ядро правки.
+- `reviewer/index` — аналогичный паттерн инкрементальной свежести (watermark/`content_hash`); прецедент дедупа переэмбеда, полезен как ориентир.
+- `reviewer/mcp` — сервисный слой MCP; здесь живёт `finish_task` write-through (прецедент обхода watermark).
+- `reviewer/entrypoints` — регистрация MCP-тула `sync_board` (сюда тянется новый `force`/`full` параметр).
+
+## Relevant code
+- `reviewer/tasks/sync.py:48` — **корень**: watermark-гейт `if raw.timestamp <= cursor: unchanged; continue`. Точка правки для кандидатов 1/4 (обойти skip, но не курсор).
+- `reviewer/tasks/sync.py:81-96` — `SyncService.run(board, limit, purge_orphaned, keep_with_prs, board_type, status_field)` — сюда тянется новый параметр force/full до `_sync_provider`.
+- `reviewer/tasks/sync.py:65-73` — продвижение курсора (`max_ts > cursor → set_index_meta`); force-проход должен продвигать курсор штатно, не регрессировать (иначе следующий синк перестанет быть инкрементальным).
+- `reviewer/tasks/service.py:50-60` — `index_task`: meta-only путь (`store.update_meta(..., project)` @ `:53`) **уже штампует `project` без переэмбеда`; embed-путь `:55-60`. Т.е. project пишется, если задача просто ДОШЛА сюда.
+- `reviewer/tasks/service.py:124-138` — `index_batch`: разделение `to_embed`/`meta_only` по `content_hash` (`:138`). При force-проходе почти всё → `meta_only` → штамп project ~бесплатно по Voyage.
+- `reviewer/tasks/store.py:160-169` — `update_meta`: `UPDATE tasks SET … project=%s WHERE key=%s` — дешёвый backfill-примитив (кандидаты 3/4), без Voyage.
+- `reviewer/tasks/store.py:193-207` — `search` scoped `AND project = %(project)s` (@ `:197/:201/:206`); `store.py:111-124` — `get_task` scoped `AND project = %s` (@`:123`); `store.py:171-180` — `list_keys(project)`. SQL корректен — видит лишь пустую колонку (баг не здесь).
+- **Blast radius:** цепочка замкнута — MCP-тул `sync_board` (`reviewer/entrypoints/mcp_server.py`) → `SyncService.run` → `_sync_provider` → `TaskService.index_batch` → `TaskStore`. Новый параметр тянется линейно по этой цепочке.
+
+## Test exemplars
+- `tests/tasks/test_sync.py:58-76` — `FakeProvider`/`FakeTaskService`/`FakeMeta`; `test_first_sync_indexes_all_and_advances_cursor`, `test_watermark_skips_unchanged` — паттерн для нового теста «force обходит watermark, но курсор продвигается штатно».
+- `tests/tasks/test_service_batch.py:208-215` — `test_index_batch_stamps_project_on_meta_only`: доказывает, что meta-only путь штампует `project` в стор (`meta_updates[-1] == "PRI"`) и граф (`task_projects[0] == "PRI"`) — эталон ассертов «project доехал».
+
+## Constraints / open questions
+- **Verify before fix (из задачи):** пишет ли **задеплоенный** reviewer-mcp `project` вообще. Локальный код — да (`index_task` зовёт `update_meta(..., project)` на meta-only, подтверждено тестом), но деплой мог быть старше PRI-170 (0.2.24/PyPI + приёмка были вне сессии — см. память `pri-205-status`). Если деплой старше — сначала передеплой, иначе backfill не поможет.
+- **Voyage (3 RPM / 10K TPM):** кандидат 2 (сброс курсора) форсит полный переэмбед ~96 задач → упрётся в лимит. Кандидат 1 с существующим `content_hash`-дедупом гонит почти всё через `meta_only` (без embed) → дёшево. Предпочитать дизайны, переиспользующие дедуп.
+- **Обобщаемость:** задача явно хочет фикс, покрывающий «любое обогащение, добавленное позже» (не только `project`) → системные кандидаты 1/4 предпочтительнее одноразового SQL-кандидата 3. Кандидат 3 к тому же требует вывести `project` без re-enumerate доски (напр. из префикса алиаса `PRI-N → PRI`) — открытый вопрос дизайна.
+- **Живое подтверждение бага:** scoped `search_tasks(project="PRI")` в этой сессии вернул лишь 5 задач (203–207) — только недавние, выше watermark. Корпус тёплый (96 задач, `changed:0`).
+- **brief_token_cost** включён (`.review.yml → solve_task.brief_token_cost: true`) → блок расхода токенов допишется к этому брифу автоматически.
+
+## Токены (этап solve-task)
+Модель: claude-opus-4-8
+fresh-in 48.8K · out 46.6K · cache-write 407.1K · cache-read 2.6M
+Всего: 3.1M токенов

--- a/docs/superpowers/plans/2026-07-03-pri-207-sync-meta-refresh.md
+++ b/docs/superpowers/plans/2026-07-03-pri-207-sync-meta-refresh.md
@@ -1,0 +1,542 @@
+# PRI-207 Self-healing meta-refresh синка — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** На каждом синке задач дёшево backfill-ить колонку `project` (и прочие плоские метаданные) у задач ниже watermark-курсора, чтобы scoped `search_tasks(project=…)` видел весь корпус, а не 3/97.
+
+**Architecture:** Синк расщепляется на два тракта. Дорогой (changed-only) — как сейчас: `provider.normalize()` (REST-резолв подзадач/вложений) + embed. Новый дешёвый meta-refresh (all-enumerated) — для задач ниже курсора извлекает плоские поля из `RawTask` через **чистый** `normalize_meta()` (без I/O) и обновляет `tasks` (executemany) + графовый узел `:Task`. Watermark-курсор двигается по-прежнему только по `max_ts` — инкрементальность и экономия Voyage дорогого тракта сохранены.
+
+**Tech Stack:** Python 3.11, psycopg3 (Postgres/ParadeDB на :5433), Neo4j, pytest. Провайдеры досок за `TaskBoardProvider` Protocol (yougile — референс, youtrack).
+
+## Global Constraints
+
+- Язык кода — **русский**: комментарии, докстринги, сообщения (сохранять стиль соседнего кода).
+- Коммиты: Conventional Commits на русском (`feat(tasks): …`, `fix(tasks): …`); **без self-attribution** (никаких `Co-Authored-By`/упоминаний Claude).
+- ruff: line-length 100, target py311. Прогонять `.venv/bin/ruff check .` — но не гнаться за repo-wide clean, только не вносить новых нарушений в трогаемых файлах.
+- Внешние сервисы (Postgres/Neo4j) изолированы за интерфейсами и **мокаются в unit-тестах**; реальные вызовы — только в тестах с маркером `@pytest.mark.integration` (исключены из дефолтного `pytest -q`).
+- Unit-цикл: `.venv/bin/pytest -q` (без DB). Integration-цикл: `.venv/bin/pytest -m integration` (нужны `docker compose up -d`).
+- Инвариант дизайна: meta-refresh **никогда** не эмбедит и не роутится через `index_task`/`upsert_task` (иначе задача-не-в-сторе ушла бы в embed-путь). Только `update_meta_batch` + граф `upsert_task`.
+
+---
+
+### Task 1: `normalize_meta` — дешёвый (без I/O) TaskBrief из RawTask
+
+Добавляет провайдерам метод, возвращающий плоские метаданные задачи (key, aliases, title, status, url, project) **без сетевых вызовов**, делегируя в уже существующие чистые module-level `normalize_yougile` / `normalize_youtrack`. Дорогой `normalize()` (резолв подзадач/вложений) не трогаем.
+
+**Files:**
+- Modify: `reviewer/tasks/boards/base.py` (Protocol `TaskBoardProvider` — добавить сигнатуру `normalize_meta`)
+- Modify: `reviewer/tasks/boards/yougile.py` (класс `YougileBoard` — добавить `normalize_meta`)
+- Modify: `reviewer/tasks/boards/youtrack.py` (класс `YouTrackBoard` — добавить `normalize_meta`)
+- Test: `tests/tasks/boards/test_yougile_normalize.py`, `tests/tasks/boards/test_youtrack_normalize.py`
+
+**Interfaces:**
+- Consumes: чистые функции `normalize_yougile(raw, key_pattern, url_template)` и `normalize_youtrack(raw, key_pattern, base_url)` (обе задокументированы «Чистая: без I/O»); атрибуты провайдеров `self._key_pattern`, `self._url_template` (yougile), `self._base` (youtrack).
+- Produces: `TaskBoardProvider.normalize_meta(self, raw: RawTask) -> dict` — возвращает полный чистый TaskBrief dict (ключи `key, aliases, title, description, criteria, status, url, links, project, attachments`), но БЕЗ I/O (`criteria=[]`, `attachments=[]`, у yougile — links без title подзадач). Потребители используют только плоские поля `key/aliases/title/status/url/project`.
+
+- [ ] **Step 1: Написать падающие тесты (оба провайдера)**
+
+В `tests/tasks/boards/test_yougile_normalize.py` добавить в конец файла:
+
+```python
+class _BoomClient:
+    """httpx-заглушка: любой сетевой вызов = ошибка (доказывает отсутствие I/O)."""
+
+    def get(self, *a, **k):
+        raise AssertionError("normalize_meta не должен делать сетевые вызовы")
+
+    def close(self):
+        pass
+
+
+def test_normalize_meta_no_io_yougile():
+    b = YougileBoard(api_key="k", api_base="https://yougile.com/api-v2",
+                     key_pattern=KP, url_template=URL)
+    b._client = _BoomClient()
+    # подзадачи и related-ссылки есть — дорогой normalize полез бы в сеть, meta — нет
+    raw = _raw(subtask_ids=["u1"], description="связано с PRI-96")
+    meta = b.normalize_meta(raw)
+    assert meta["key"] == "ID-10"
+    assert meta["aliases"] == ["PRI-10"]
+    assert meta["status"] == "Backlog"
+    assert meta["url"] == "https://ru.yougile.com/team/T/#PRI-10"
+    assert meta["project"] == "PRI"
+    assert meta["criteria"] == [] and meta["attachments"] == []
+```
+
+В `tests/tasks/boards/test_youtrack_normalize.py` добавить в конец файла:
+
+```python
+class _BoomClient:
+    """httpx-заглушка: любой сетевой вызов = ошибка (доказывает отсутствие I/O)."""
+
+    def get(self, *a, **k):
+        raise AssertionError("normalize_meta не должен делать сетевые вызовы")
+
+    def close(self):
+        pass
+
+
+def test_normalize_meta_no_io_youtrack():
+    b = YouTrackBoard(token="perm:x", base_url=BASE, key_pattern=KP)
+    b._client = _BoomClient()
+    raw = _issue_to_raw(_issue(idReadable="PRJ-7", description="связано с ABC-1"))
+    meta = b.normalize_meta(raw)
+    assert meta["key"] == "PRJ-7"
+    assert meta["status"] == "In Progress"
+    assert meta["url"] == "https://c.youtrack.cloud/issue/PRJ-7"
+    assert meta["project"] == "PRJ"
+    assert meta["criteria"] == [] and meta["attachments"] == []
+```
+
+- [ ] **Step 2: Прогнать — убедиться, что падают**
+
+Run: `.venv/bin/pytest tests/tasks/boards/test_yougile_normalize.py::test_normalize_meta_no_io_yougile tests/tasks/boards/test_youtrack_normalize.py::test_normalize_meta_no_io_youtrack -q`
+Expected: FAIL — `AttributeError: 'YougileBoard' object has no attribute 'normalize_meta'` (и аналогично для YouTrack).
+
+- [ ] **Step 3: Добавить сигнатуру в Protocol**
+
+В `reviewer/tasks/boards/base.py`, в классе `TaskBoardProvider`, сразу после метода `normalize` (перед `finish`):
+
+```python
+    def normalize_meta(self, raw: RawTask) -> dict:
+        """Дешёвый TaskBrief из RawTask БЕЗ I/O (PRI-207): только плоские
+        метаданные (key, aliases, title, status, url, project). Подзадачи и
+        вложения НЕ резолвятся (criteria=[], attachments=[]). Для self-healing
+        meta-refresh задач ниже watermark — не дёргает сеть на задачу."""
+        ...
+```
+
+- [ ] **Step 4: Реализовать в YougileBoard**
+
+В `reviewer/tasks/boards/yougile.py`, в классе `YougileBoard`, сразу после метода `normalize` (перед `fetch_one`):
+
+```python
+    def normalize_meta(self, raw: RawTask) -> dict:
+        """Дешёвая нормализация без I/O (PRI-207): чистый normalize_yougile без
+        резолва подзадач/вложений. Плоские поля (project/url/status) корректны."""
+        return normalize_yougile(raw, self._key_pattern, self._url_template)
+```
+
+- [ ] **Step 5: Реализовать в YouTrackBoard**
+
+В `reviewer/tasks/boards/youtrack.py`, в классе `YouTrackBoard`, сразу после метода `normalize`:
+
+```python
+    def normalize_meta(self, raw: RawTask) -> dict:
+        """Дешёвая нормализация без I/O (PRI-207): чистый normalize_youtrack без
+        резолва вложений. Плоские поля (project/url/status) корректны."""
+        return normalize_youtrack(raw, self._key_pattern, self._base)
+```
+
+- [ ] **Step 6: Прогнать — убедиться, что проходят**
+
+Run: `.venv/bin/pytest tests/tasks/boards/test_yougile_normalize.py tests/tasks/boards/test_youtrack_normalize.py -q`
+Expected: PASS (все тесты файлов, включая два новых).
+
+- [ ] **Step 7: Линт + коммит**
+
+Run: `.venv/bin/ruff check reviewer/tasks/boards/base.py reviewer/tasks/boards/yougile.py reviewer/tasks/boards/youtrack.py`
+Expected: без новых нарушений.
+
+```bash
+git add reviewer/tasks/boards/base.py reviewer/tasks/boards/yougile.py \
+        reviewer/tasks/boards/youtrack.py tests/tasks/boards/test_yougile_normalize.py \
+        tests/tasks/boards/test_youtrack_normalize.py
+git commit -m "feat(tasks): normalize_meta — дешёвый TaskBrief из RawTask без I/O (PRI-207)"
+```
+
+---
+
+### Task 2: `TaskStore.update_meta_batch` — батч-обновление плоских метаданных
+
+Один executemany-UPDATE для всех задач батча (масштабируется на большие доски). Задача не в сторе → 0 строк (безопасный no-op: не создаёт неполных строк, не трогает embedding). Единичный `update_meta` остаётся для `index_batch`.
+
+**Files:**
+- Modify: `reviewer/tasks/store.py` (класс `TaskStore` — добавить `update_meta_batch` после `update_meta`)
+- Test: `tests/tasks/test_integration.py` (маркер `integration` — реальный Postgres)
+
+**Interfaces:**
+- Consumes: существующие `TaskStore._connect()`, таблица `tasks` (колонки `title, status, url, aliases, project, key`); `get_task(key)` для проверки.
+- Produces: `TaskStore.update_meta_batch(self, metas: list[dict]) -> None` — каждый dict `{key, title?, status?, url?, aliases?, project?}`; UPDATE по `key`; отсутствующие ключи → `.get`-дефолты; пустой список / dict без `key` → no-op.
+
+- [ ] **Step 1: Написать падающий интеграционный тест**
+
+В `tests/tasks/test_integration.py` добавить (файл уже под `pytestmark = pytest.mark.integration`, фикстура `store` и `_FakeEmbedder` есть):
+
+```python
+def test_update_meta_batch_backfills_project(store):
+    emb = _FakeEmbedder()
+    text = build_task_text("T1", "d1", [])
+    store.upsert_task(TaskRow(
+        key="ID-1", aliases=["PRI-1"], title="T1", description="d1",
+        status="Open", url=None, content_hash=task_content_hash(text),
+        text=text, embedding=emb.embed_documents([text])[0], project=""))
+    assert store.get_task("ID-1").project == ""
+
+    store.update_meta_batch([{"key": "ID-1", "title": "T1", "status": "Done",
+                              "url": "u", "aliases": ["PRI-1"], "project": "PRI"}])
+    row = store.get_task("ID-1")
+    assert row.project == "PRI"
+    assert row.status == "Done"
+
+    # задача не в сторе → no-op, ничего не создаётся
+    store.update_meta_batch([{"key": "ID-404", "project": "PRI"}])
+    assert store.get_task("ID-404") is None
+
+    # пустой батч → без ошибок
+    store.update_meta_batch([])
+```
+
+- [ ] **Step 2: Прогнать — убедиться, что падает**
+
+Run: `.venv/bin/pytest -m integration tests/tasks/test_integration.py::test_update_meta_batch_backfills_project -q`
+Expected: FAIL — `AttributeError: 'TaskStore' object has no attribute 'update_meta_batch'`.
+(Если Postgres не поднят — сначала `docker compose up -d`.)
+
+- [ ] **Step 3: Реализовать `update_meta_batch`**
+
+В `reviewer/tasks/store.py`, в классе `TaskStore`, сразу после метода `update_meta`:
+
+```python
+    def update_meta_batch(self, metas: list[dict]) -> None:
+        """Батч-обновление плоских метаданных (PRI-207 meta-refresh): один
+        executemany-UPDATE. Задача не в сторе → 0 строк (no-op, не создаёт
+        неполных строк, не трогает embedding). Пустой батч → no-op."""
+        rows = [(m.get("title") or "", m.get("status"), m.get("url"),
+                 m.get("aliases") or [], m.get("project") or "", m["key"])
+                for m in metas if isinstance(m, dict) and m.get("key")]
+        if not rows:
+            return
+        with self._connect() as conn, conn.cursor() as cur:
+            cur.executemany(
+                "UPDATE tasks SET title=%s, status=%s, url=%s, aliases=%s, "
+                "project=%s WHERE key=%s",
+                rows,
+            )
+            conn.commit()
+```
+
+- [ ] **Step 4: Прогнать — убедиться, что проходит**
+
+Run: `.venv/bin/pytest -m integration tests/tasks/test_integration.py::test_update_meta_batch_backfills_project -q`
+Expected: PASS.
+
+- [ ] **Step 5: Линт + коммит**
+
+Run: `.venv/bin/ruff check reviewer/tasks/store.py`
+Expected: без новых нарушений.
+
+```bash
+git add reviewer/tasks/store.py tests/tasks/test_integration.py
+git commit -m "feat(tasks): TaskStore.update_meta_batch — батч-backfill метаданных (PRI-207)"
+```
+
+---
+
+### Task 3: `TaskService.refresh_meta_batch` — оркестрация дешёвого meta-refresh
+
+Обновляет плоские метаданные партии задач в сторе (`update_meta_batch`) и на графе (`upsert_task` per-task, fail-soft). Никогда не эмбедит, не upsert-ит полную строку и не линкует PR.
+
+**Files:**
+- Modify: `reviewer/tasks/service.py` (класс `TaskService` — добавить `refresh_meta_batch` после `index_batch`)
+- Test: `tests/tasks/test_service_batch.py`
+
+**Interfaces:**
+- Consumes: `TaskStore.update_meta_batch(metas)` (Task 2); `self._graph.upsert_task(key, aliases, title, status, url, project)`; `self._graph is None` → граф недоступен; `log` (уже импортирован в модуле).
+- Produces: `TaskService.refresh_meta_batch(self, metas: list[dict]) -> dict` → `{"meta_refreshed": int, "warnings": list[str]}`. Каждый meta-dict — как из `provider.normalize_meta` (нужен только `key`, остальное `.get`-дефолтится).
+
+- [ ] **Step 1: Написать падающие тесты**
+
+В `tests/tasks/test_service_batch.py` — сперва добавить в класс `_FakeStore` поддержку батча. В `_FakeStore.__init__` добавить строку `self.meta_batch = None`, и добавить метод:
+
+```python
+    def update_meta_batch(self, metas):
+        self.meta_batch = list(metas)
+```
+
+Затем добавить тесты в конец файла:
+
+```python
+def test_refresh_meta_batch_stamps_project_store_and_graph():
+    store, graph = _FakeStore(), _FakeGraph()
+    metas = [{"key": "ID-1", "aliases": ["PRI-1"], "title": "T", "status": "Open",
+              "url": "u", "project": "PRI"}]
+    res = TaskService(store, graph, _FakeEmbedder()).refresh_meta_batch(metas)
+    assert res["meta_refreshed"] == 1
+    assert store.meta_batch == metas               # батч ушёл в стор
+    assert graph.tasks == ["ID-1"]
+    assert graph.task_projects == ["PRI"]          # project достиг графа
+
+
+def test_refresh_meta_batch_never_embeds_or_upserts():
+    store, graph, emb = _FakeStore(), _FakeGraph(), _FakeEmbedder()
+    TaskService(store, graph, emb).refresh_meta_batch([{"key": "ID-1", "project": "PRI"}])
+    assert emb.doc_calls == []                     # НИКОГДА не эмбедит
+    assert store.upserted == []                    # и не upsert-ит (не воскрешает задачу)
+
+
+def test_refresh_meta_batch_empty():
+    store = _FakeStore()
+    res = TaskService(store, _FakeGraph(), _FakeEmbedder()).refresh_meta_batch([])
+    assert res == {"meta_refreshed": 0, "warnings": []}
+    assert store.meta_batch is None
+
+
+def test_refresh_meta_batch_graph_none_warns():
+    store = _FakeStore()
+    res = TaskService(store, None, _FakeEmbedder()).refresh_meta_batch(
+        [{"key": "ID-1", "project": "PRI"}])
+    assert res["meta_refreshed"] == 1
+    assert any("graph unavailable" in w for w in res["warnings"])
+
+
+def test_refresh_meta_batch_graph_failsoft():
+    store, graph = _FakeStore(), _FakeGraph(raise_on=("upsert_task",))
+    res = TaskService(store, graph, _FakeEmbedder()).refresh_meta_batch(
+        [{"key": "ID-1", "project": "PRI"}])
+    assert res["meta_refreshed"] == 1              # store прошёл, граф — fail-soft
+    assert any("graph" in w for w in res["warnings"])
+```
+
+- [ ] **Step 2: Прогнать — убедиться, что падают**
+
+Run: `.venv/bin/pytest tests/tasks/test_service_batch.py -q -k refresh_meta_batch`
+Expected: FAIL — `AttributeError: 'TaskService' object has no attribute 'refresh_meta_batch'`.
+
+- [ ] **Step 3: Реализовать `refresh_meta_batch`**
+
+В `reviewer/tasks/service.py`, в классе `TaskService`, сразу после метода `index_batch` (перед `search_tasks`):
+
+```python
+    def refresh_meta_batch(self, metas: list[dict]) -> dict:
+        """Дешёвый self-healing meta-refresh (PRI-207): backfill плоских
+        метаданных (project/title/status/url/aliases) для задач ниже watermark.
+        Стор — один батч update_meta_batch; граф — upsert_task per-task (fail-soft).
+        НИКОГДА не эмбедит и не upsert-ит полную строку (не воскрешает задачу,
+        отсутствующую в сторе) и не линкует PR. metas — как из normalize_meta."""
+        metas = [m for m in metas if isinstance(m, dict) and m.get("key")]
+        if not metas:
+            return {"meta_refreshed": 0, "warnings": []}
+        warnings: list[str] = []
+        try:
+            self._store.update_meta_batch(metas)
+        except Exception as e:
+            log.warning("refresh_meta_batch: сбой update_meta_batch", exc_info=True)
+            warnings.append(f"store: {type(e).__name__}: {e}")
+        if self._graph is None:
+            warnings.append("graph unavailable: task projects not refreshed in graph")
+        else:
+            for m in metas:
+                try:
+                    self._graph.upsert_task(
+                        m["key"], m.get("aliases") or [], m.get("title") or "",
+                        m.get("status"), m.get("url"), m.get("project") or "")
+                except Exception as e:
+                    log.warning("refresh_meta_batch: сбой графа для %s",
+                                m["key"], exc_info=True)
+                    warnings.append(f"graph {m['key']}: {type(e).__name__}: {e}")
+        return {"meta_refreshed": len(metas), "warnings": warnings}
+```
+
+- [ ] **Step 4: Прогнать — убедиться, что проходят**
+
+Run: `.venv/bin/pytest tests/tasks/test_service_batch.py -q`
+Expected: PASS (новые refresh_meta_batch-тесты + существующие index_batch-тесты не сломаны).
+
+- [ ] **Step 5: Линт + коммит**
+
+Run: `.venv/bin/ruff check reviewer/tasks/service.py`
+Expected: без новых нарушений.
+
+```bash
+git add reviewer/tasks/service.py tests/tasks/test_service_batch.py
+git commit -m "feat(tasks): TaskService.refresh_meta_batch — оркестрация meta-refresh (PRI-207)"
+```
+
+---
+
+### Task 4: Встроить meta-refresh в SyncService
+
+Для задач ниже курсора (`raw.timestamp <= cursor`) собирать `provider.normalize_meta(raw)` и после цикла вызывать `refresh_meta_batch`. Курсор двигать по-прежнему только по `max_ts`. В summary добавить `meta_refreshed` (per-provider + агрегат + by_board). MCP-тул `sync_board` прокидывает summary as-is — правок в MCP-слое не нужно.
+
+**Files:**
+- Modify: `reviewer/tasks/sync.py` (методы `SyncService._sync_provider` и `SyncService.run`)
+- Test: `tests/tasks/test_sync.py`
+
+**Interfaces:**
+- Consumes: `provider.normalize_meta(raw) -> dict` (Task 1); `TaskService.refresh_meta_batch(metas) -> {"meta_refreshed", "warnings"}` (Task 3).
+- Produces: per-provider summary и агрегат `run(...)` получают ключ `"meta_refreshed": int`; каждый элемент `by_board` — тоже `"meta_refreshed"`.
+
+- [ ] **Step 1: Обновить фейки и написать/поправить тесты**
+
+В `tests/tasks/test_sync.py`:
+
+(a) В класс `FakeProvider` добавить метод (рядом с `normalize`):
+
+```python
+    def normalize_meta(self, raw):
+        return {"key": raw.key, "aliases": [raw.project_code], "title": raw.title,
+                "status": raw.status, "url": None,
+                "project": raw.project_code.split("-")[0]}
+```
+
+(b) В класс `FakeTaskService`: в `__init__` добавить `self.meta_refreshed = []`, и добавить метод:
+
+```python
+    def refresh_meta_batch(self, metas):
+        self.meta_refreshed.append([m["key"] for m in metas])
+        return {"meta_refreshed": len(metas), "warnings": []}
+```
+
+(c) Обновить существующий `test_first_sync_indexes_all_and_advances_cursor` — добавить в конец:
+
+```python
+    assert summary["meta_refreshed"] == 0        # все changed, unchanged нет
+    assert ts.meta_refreshed == []
+```
+
+(d) Обновить существующий `test_watermark_skips_unchanged` — добавить в конец:
+
+```python
+    assert summary["meta_refreshed"] == 1        # ID-1 (ниже курсора) meta-refreshнут
+    assert ts.meta_refreshed == [["ID-1"]]
+```
+
+(e) Обновить существующий `test_no_changes_does_not_advance_cursor` — добавить в конец:
+
+```python
+    assert summary["meta_refreshed"] == 2        # обе задачи ниже курсора
+    assert ts.meta_refreshed == [["ID-1", "ID-2"]]
+    assert summary["cursor_advanced"] is False   # meta-refresh курсор НЕ двигает
+```
+
+(f) Добавить новый тест (meta_refreshed в by_board):
+
+```python
+def test_by_board_includes_meta_refreshed():
+    prov = FakeProvider([_raw("ID-1", 100), _raw("ID-2", 200)], board_type="yougile")
+    meta = FakeMeta({("", "tasks:yougile:*"): "150"})   # ID-1 ниже курсора
+    ts = FakeTaskService()
+    result = SyncService([prov], ts, meta).run()
+    assert result["meta_refreshed"] == 1
+    assert result["by_board"][0]["meta_refreshed"] == 1
+```
+
+- [ ] **Step 2: Прогнать — убедиться, что падают**
+
+Run: `.venv/bin/pytest tests/tasks/test_sync.py -q`
+Expected: FAIL — `KeyError: 'meta_refreshed'` (summary ещё не содержит ключа) в обновлённых/новом тестах.
+
+- [ ] **Step 3: Правка `_sync_provider`**
+
+В `reviewer/tasks/sync.py`, метод `_sync_provider`. Рядом с инициализацией `changed: list[dict] = []` добавить:
+
+```python
+        meta_refresh: list[dict] = []
+```
+
+Заменить блок watermark-skip:
+
+```python
+            if raw.timestamp <= cursor:
+                unchanged += 1
+                continue
+```
+
+на:
+
+```python
+            if raw.timestamp <= cursor:
+                unchanged += 1
+                try:
+                    meta_refresh.append(provider.normalize_meta(raw))
+                except Exception as e:
+                    log.warning("sync: сбой normalize_meta %s", raw.key, exc_info=True)
+                    warnings.append(f"normalize_meta {raw.key}: {type(e).__name__}: {e}")
+                continue
+```
+
+После блока подсчёта `embedded/refreshed/failed` (после `for r in results: warnings.extend(r.get("warnings") or [])`), перед `cursor_advanced = False`, добавить:
+
+```python
+        meta_refreshed = 0
+        if meta_refresh:
+            mr = self._tasks.refresh_meta_batch(meta_refresh)
+            meta_refreshed = mr.get("meta_refreshed", 0)
+            warnings.extend(mr.get("warnings") or [])
+```
+
+В возвращаемом словаре `_sync_provider` (`return active_keys, {...}`) добавить ключ (например, после `"unchanged": unchanged,`):
+
+```python
+            "meta_refreshed": meta_refreshed,
+```
+
+- [ ] **Step 4: Правка `run` (агрегация + by_board)**
+
+В `reviewer/tasks/sync.py`, метод `run`. В инициализации `agg = {...}` добавить `"meta_refreshed": 0,` (в ту же dict-литералу, рядом с `"unchanged": 0,`).
+
+В цикле агрегации расширить кортеж ключей — было:
+
+```python
+            for k in ("enumerated", "changed", "embedded", "refreshed",
+                      "unchanged", "failed"):
+                agg[k] += one[k]
+```
+
+стало:
+
+```python
+            for k in ("enumerated", "changed", "embedded", "refreshed",
+                      "unchanged", "failed", "meta_refreshed"):
+                agg[k] += one[k]
+```
+
+В сборке `by_board.append({...})` расширить кортеж ключей — было:
+
+```python
+                **{k: one[k] for k in ("enumerated", "changed", "embedded",
+                                        "refreshed", "unchanged", "failed")},
+```
+
+стало:
+
+```python
+                **{k: one[k] for k in ("enumerated", "changed", "embedded",
+                                        "refreshed", "unchanged", "failed",
+                                        "meta_refreshed")},
+```
+
+- [ ] **Step 5: Прогнать — убедиться, что проходят**
+
+Run: `.venv/bin/pytest tests/tasks/test_sync.py -q`
+Expected: PASS (все тесты файла, включая обновлённые и новый).
+
+- [ ] **Step 6: Регресс всего пакета задач + линт**
+
+Run: `.venv/bin/pytest tests/tasks -q`
+Expected: PASS (unit; integration исключены дефолтным маркером).
+
+Run: `.venv/bin/ruff check reviewer/tasks/sync.py`
+Expected: без новых нарушений.
+
+- [ ] **Step 7: Коммит**
+
+```bash
+git add reviewer/tasks/sync.py tests/tasks/test_sync.py
+git commit -m "feat(tasks): self-healing meta-refresh задач ниже watermark при синке (PRI-207)"
+```
+
+---
+
+## Финальная проверка (после всех задач)
+
+- [ ] **Полный unit-прогон:** `.venv/bin/pytest -q` — ожидается PASS (integration исключены).
+- [ ] **Integration-прогон (нужен `docker compose up -d`):** `.venv/bin/pytest -m integration tests/tasks/test_integration.py -q` — ожидается PASS.
+- [ ] **Живая приёмка (после деплоя сервера с этим кодом, вне текущей сессии):** один обычный `sync_board(board="PRI", board_type="yougile")` (changed=0) → в summary `meta_refreshed ≈ 96`; затем `search_tasks(project="PRI")` возвращает десятки PRI-задач (не 3). Это acceptance-критерий задачи. Деплой обязателен — снимает вопрос «пишет ли задеплоенный сервер project вообще».
+
+## Замечания по rollout
+
+- Правок в MCP-слое (`reviewer/entrypoints/mcp_server.py`, `reviewer/mcp/service.py`) не требуется: `sync_board` возвращает summary из `SyncService.run` as-is → `meta_refreshed` появится автоматически.
+- Осознанный gap: задача, отсутствующая в сторе (напр. ранее purged, но всё ещё на доске ниже курсора), meta-refresh НЕ воскрешает (`update_meta_batch` → 0 строк). Re-add — это дорогой тракт при изменении задачи. Вне скоупа PRI-207.
+- Дорогие поля (criteria/attachments/description/embedding) для старых задач не backfill-ятся — восстановятся через дорогой тракт при следующем изменении задачи. Вне скоупа.

--- a/docs/superpowers/specs/2026-07-03-pri-207-sync-meta-refresh-design.md
+++ b/docs/superpowers/specs/2026-07-03-pri-207-sync-meta-refresh-design.md
@@ -1,0 +1,159 @@
+# PRI-207 — Self-healing meta-refresh при синке задач
+
+**Дата:** 2026-07-03
+**Задача:** [PRI-207](https://ru.yougile.com/team/686c049c8af8/#PRI-207)
+**Бриф:** `docs/superpowers/briefs/2026-07-03-PRI-207-watermark-sync-no-project-backfill.md`
+
+## Проблема
+
+`search_tasks(project="PRI")` / `get_task(project="PRI")` видят ~3 из ~97 задач: колонка
+`project` в таблице `tasks` пуста у 94 задач (`project=''` — 94, `PRI` — 3, `TES` — 1). Это **не
+утечка скоупа** (SQL корректен: `store.py:197/123` `AND project = %(project)s`), а **незаполненная
+колонка**.
+
+Корень — watermark-гейт инкрементального синка. `SyncService._sync_provider` (`reviewer/tasks/sync.py:48`):
+
+```python
+if raw.timestamp <= cursor:
+    unchanged += 1
+    continue          # задача не доходит до normalize/index
+```
+
+Заполнение `project` добавлено в путь индексации в PRI-170 (`normalize_* → project_prefix`,
+`index_task`/`index_batch` штампуют его на meta-only пути через `store.update_meta`). Но старые
+задачи (timestamp ниже курсора) **никогда не доходят** до этого пути → `project` не
+backfill-ится. `content_hash` не спасает: в него входит только текст (`task_content_hash(text)`),
+не метаданные.
+
+**Обобщение:** любое обогащение, добавленное в индексацию позже первого синка задачи, не доезжает
+до старых задач. `project` — первый пойманный случай; фикс должен решать класс проблемы, а не
+частный симптом.
+
+## Ключевое наблюдение (обоснование дизайна)
+
+`normalize()` провайдера **дорогой** (per-task REST): YouGile резолвит подзадачи (`GET /tasks/{sid}`)
+и вложения (`GET /chats/.../messages`); YouTrack — аналогично. Поэтому «прогнать `normalize` для
+всех enumerate-нутых на каждом синке» неприемлемо.
+
+Но **дешёвые метаданные `RawTask` не требуют I/O.** Module-level `normalize_yougile` /
+`normalize_youtrack` документированы как **чистые («Чистая: без I/O»)** — весь I/O вынесен в
+обёртку `provider.normalize()`. Все нужные для backfill поля выводятся из `RawTask` без сети:
+
+- `key = raw.key`
+- `aliases = [raw.project_code]`
+- `title = raw.title`
+- `status = "done" if raw.completed else raw.status`
+- `url = url_template.replace("{code}", raw.project_code)`
+- `project = project_prefix(raw.project_code or key)`
+
+Это ровно колонки, которые обновляет `TaskStore.update_meta(key, title, status, url, aliases,
+project)`.
+
+## Решение
+
+Расщепить синк на два тракта:
+
+1. **Дорогой (changed-only)** — без изменений: `timestamp > cursor` → `provider.normalize()` (REST)
+   → `index_batch` (embed по `content_hash`).
+2. **Дешёвый meta-refresh (all-enumerated)** — **новый**: `timestamp <= cursor` → извлечь дешёвые
+   метаданные из `RawTask` (без I/O) → батчем обновить `tasks` (+ граф). Работает на **каждом**
+   синке → `project` и любое дешёвое обогащение самозаполняются, без ручного force-режима.
+
+Курсор продвигается по-прежнему только по `max_ts` — инкрементальность дорогого тракта (и его
+экономия Voyage) сохранена; дешёвый тракт на курсор не влияет.
+
+### Поток данных
+
+```
+iter_raw(board, limit) → per raw:
+    timestamp >  cursor → normalize()      [REST]  → changed  → index_batch      [embed]   (как сейчас)
+    timestamp <= cursor → normalize_meta() [pure]  → metas    → refresh_meta_batch [update_meta + graph]  (НОВОЕ)
+после цикла: cursor ← max_ts (без изменений)
+```
+
+## Компоненты и интерфейсы
+
+### 1. `TaskBoardProvider.normalize_meta(raw) -> dict` — новый метод Protocol
+`reviewer/tasks/boards/base.py` + реализации в `yougile.py` / `youtrack.py`.
+
+Делегирует в чистый module-level `normalize_*(raw, key_pattern, url_template)` с
+`subtask_titles=None, attachments=None` → возвращает **полный** чистый TaskBrief dict, но **без
+I/O** (criteria=[], attachments=[], links без title подзадач). `refresh_meta_batch` потребляет из
+него только дешёвые поля (key, aliases, title, status, url, project) — остальное игнорируется.
+Реализация в каждом провайдере — фактически одна строка (переиспользует существующую чистую
+функцию).
+
+### 2. `TaskStore.update_meta_batch(rows) -> None` — новый (executemany)
+`reviewer/tasks/store.py`. Батч уже существующего `update_meta`:
+`UPDATE tasks SET title=%s, status=%s, url=%s, aliases=%s, project=%s WHERE key=%s` через
+`executemany`. Задача не в сторе → 0 строк (безопасный no-op: не создаёт неполных строк, не трогает
+embedding). `update_meta` (единичный) остаётся для `index_task`.
+
+### 3. `TaskService.refresh_meta_batch(metas) -> dict` — новый
+`reviewer/tasks/service.py`. Для батча дешёвых dict:
+- `store.update_meta_batch(...)` — обновить метаданные (fail-soft на весь батч);
+- для каждой задачи `graph.upsert_task(key, aliases, title, status, url, project)` — заполнить
+  `project` и на графовом узле `:Task` (нужно для scoped `get_task_context`); per-task fail-soft,
+  как в `index_task`; при `graph is None` — пропуск с warning.
+
+**Никогда не эмбедит и не роутится через `index_task`** — иначе задача, отсутствующая в сторе
+(`existing_hash → None`), ушла бы в embed-путь. PR-автолинковка не выполняется (она только для
+`embedded` changed-задач). Возвращает `{"meta_refreshed": n, "warnings": [...]}`.
+
+### 4. `SyncService._sync_provider` — правка `reviewer/tasks/sync.py`
+В цикле для unchanged (`raw.timestamp <= cursor`): вместо голого `continue` — собрать
+`provider.normalize_meta(raw)` в список `meta_refresh`. После цикла (рядом с `index_batch(changed)`):
+`self._tasks.refresh_meta_batch(meta_refresh)`. Добавить в per-provider summary поле
+`meta_refreshed`; агрегировать в `run` и в `by_board`.
+
+## Edge cases и что НЕ меняется
+
+- **Курсор / инкрементальность** дорогого тракта — без изменений; дешёвый тракт курсор не двигает.
+- **`limit` / partial обход** — meta-refresh идемпотентен, работает и на частичном обходе; purge
+  по-прежнему пропускается при `limit`.
+- **Задача не в сторе** (напр. ранее purged, но всё ещё на доске ниже курсора) — `update_meta`
+  no-op (0 строк); meta-refresh её **не воскрешает** (осознанный gap: фикс про метаданные, не про
+  re-add; re-add — это дорогой тракт при изменении задачи).
+- **description / text / embedding** — не трогаются (только колонки `update_meta`); вектор остаётся
+  консистентным тексту.
+- **Стоимость** — N дешёвых `UPDATE` (executemany, один round-trip) + N граф-MERGE на синк
+  (N = enumerated). Для ~96 задач пренебрежимо; ноль Voyage, ноль доп. board-REST.
+
+## Тестирование
+
+Все unit-тесты — на фейках (без реальных БД/сети), согласно соглашениям репозитория.
+
+- **`normalize_meta` (оба провайдера):** корректные `project` / `url` / `status` из `RawTask`
+  **без I/O** — fake-client, падающий на любой GET, доказывает отсутствие сети.
+- **`TaskService.refresh_meta_batch`:** `store.update_meta_batch` вызван с `project`; граф
+  `upsert_task` вызван с `project`; fail-soft (сбой стора/графа не валит); `graph is None` → warning;
+  никакого embed-вызова.
+- **`TaskStore.update_meta_batch`** (integration, `-m integration`): задача в сторе → `project`
+  обновлён; задача не в сторе → 0 строк, ничего не создано.
+- **`_sync_provider` / `SyncService.run`:** unchanged задачи попадают в meta-refresh; курсор ими не
+  двигается; `meta_refreshed` в summary корректен; changed по-прежнему эмбедятся.
+- **Правка существующего `test_watermark_skips_unchanged` (`tests/tasks/test_sync.py:69`):**
+  семантика меняется — unchanged теперь meta-refreshатся (не эмбедятся). Обновить ассерты
+  (`ts.indexed == [["ID-2"]]` сохраняется для embed; добавить проверку meta-refresh для ID-1).
+- **`test_index_batch_stamps_project_on_meta_only` (`tests/tasks/test_service_batch.py:208`)** —
+  остаётся без изменений (дорогой тракт).
+
+## Rollout и acceptance
+
+- **Требует деплоя** сервера с этим кодом. После деплоя следующий обычный `sync_board` (changed=0,
+  все задачи ниже курсора) автоматически backfill-ит `project` у всех 94 задач через meta-refresh.
+  Это снимает вопрос задачи «пишет ли задеплоенный сервер project вообще» — фикс включает PRI-170-
+  логику `project_prefix` и гарантированно прогоняет её для всех enumerate-нутых на первом же синке.
+- **Acceptance (из задачи):**
+  - `search_tasks(project="PRI")` возвращает основной PRI-корпус (десятки задач), не 3.
+  - Распределение `project` в `tasks`: ~все задачи с валидным кодом имеют непустой `project`, ноль
+    пустых среди них.
+
+## Не в скоупе (YAGNI)
+
+- Отдельный force/full-флаг на `sync_board` (систему делает self-healing — ручной force не нужен).
+- Re-add ранее purged задач (см. edge case).
+- Оптимизация «UPDATE только при реальном отличии метаданных» (нужен доп. SELECT; 96 идемпотентных
+  UPDATE и так дёшевы).
+- Backfill дорогих полей (criteria/attachments/description) для старых задач — они восстановятся
+  через дорогой тракт при следующем изменении задачи.

--- a/reviewer/tasks/boards/base.py
+++ b/reviewer/tasks/boards/base.py
@@ -57,6 +57,13 @@ class TaskBoardProvider(Protocol):
         criteria, status, url, links, attachments}."""
         ...
 
+    def normalize_meta(self, raw: RawTask) -> dict:
+        """Дешёвый TaskBrief из RawTask БЕЗ I/O (PRI-207): только плоские
+        метаданные (key, aliases, title, status, url, project). Подзадачи и
+        вложения НЕ резолвятся (criteria=[], attachments=[]). Для self-healing
+        meta-refresh задач ниже watermark — не дёргает сеть на задачу."""
+        ...
+
     def finish(self, key: str, pr_url: str, *, note: str | None = None,
                mark_done: bool = True, done_state: str | None = None,
                done_column: str | None = None) -> dict:

--- a/reviewer/tasks/boards/yougile.py
+++ b/reviewer/tasks/boards/yougile.py
@@ -248,6 +248,11 @@ class YougileBoard:
         return normalize_yougile(raw, self._key_pattern, self._url_template,
                                  subtask_titles, attachments=attachments)
 
+    def normalize_meta(self, raw: RawTask) -> dict:
+        """Дешёвая нормализация без I/O (PRI-207): чистый normalize_yougile без
+        резолва подзадач/вложений. Плоские поля (project/url/status) корректны."""
+        return normalize_yougile(raw, self._key_pattern, self._url_template)
+
     def fetch_one(self, key: str) -> RawTask | None:
         """Один RawTask по ключу (проектный/компанийный код) — write-through после finish.
 

--- a/reviewer/tasks/boards/youtrack.py
+++ b/reviewer/tasks/boards/youtrack.py
@@ -205,6 +205,11 @@ class YouTrackBoard:
         return normalize_youtrack(raw, self._key_pattern, self._base,
                                   attachments=contents)
 
+    def normalize_meta(self, raw: RawTask) -> dict:
+        """Дешёвая нормализация без I/O (PRI-207): чистый normalize_youtrack без
+        резолва вложений. Плоские поля (project/url/status) корректны."""
+        return normalize_youtrack(raw, self._key_pattern, self._base)
+
     def finish(self, key: str, pr_url: str, *, note: str | None = None,
                mark_done: bool = True, done_state: str | None = None,
                done_column: str | None = None) -> dict:

--- a/reviewer/tasks/service.py
+++ b/reviewer/tasks/service.py
@@ -218,6 +218,35 @@ class TaskService:
 
         return results
 
+    def refresh_meta_batch(self, metas: list[dict]) -> dict:
+        """Дешёвый self-healing meta-refresh (PRI-207): backfill плоских
+        метаданных (project/title/status/url/aliases) для задач ниже watermark.
+        Стор — один батч update_meta_batch; граф — upsert_task per-task (fail-soft).
+        НИКОГДА не эмбедит и не upsert-ит полную строку (не воскрешает задачу,
+        отсутствующую в сторе) и не линкует PR. metas — как из normalize_meta."""
+        metas = [m for m in metas if isinstance(m, dict) and m.get("key")]
+        if not metas:
+            return {"meta_refreshed": 0, "warnings": []}
+        warnings: list[str] = []
+        try:
+            self._store.update_meta_batch(metas)
+        except Exception as e:
+            log.warning("refresh_meta_batch: сбой update_meta_batch", exc_info=True)
+            warnings.append(f"store: {type(e).__name__}: {e}")
+        if self._graph is None:
+            warnings.append("graph unavailable: task projects not refreshed in graph")
+        else:
+            for m in metas:
+                try:
+                    self._graph.upsert_task(
+                        m["key"], m.get("aliases") or [], m.get("title") or "",
+                        m.get("status"), m.get("url"), m.get("project") or "")
+                except Exception as e:
+                    log.warning("refresh_meta_batch: сбой графа для %s",
+                                m["key"], exc_info=True)
+                    warnings.append(f"graph {m['key']}: {type(e).__name__}: {e}")
+        return {"meta_refreshed": len(metas), "warnings": warnings}
+
     def search_tasks(self, query: str, top_k: int | None = None,
                      project: str | None = None) -> str:
         """Похожие задачи (RRF, без реранкера) с рельсой ceiling (PRI-202).

--- a/reviewer/tasks/service.py
+++ b/reviewer/tasks/service.py
@@ -221,9 +221,11 @@ class TaskService:
     def refresh_meta_batch(self, metas: list[dict]) -> dict:
         """Дешёвый self-healing meta-refresh (PRI-207): backfill плоских
         метаданных (project/title/status/url/aliases) для задач ниже watermark.
-        Стор — один батч update_meta_batch; граф — upsert_task per-task (fail-soft).
-        НИКОГДА не эмбедит и не upsert-ит полную строку (не воскрешает задачу,
-        отсутствующую в сторе) и не линкует PR. metas — как из normalize_meta."""
+        Стор — один батч update_meta_batch (UPDATE по key: 0 строк, если задачи
+        нет — НЕ воскрешает её в сторе); граф — upsert_task per-task (MERGE: узел
+        :Task создаётся при отсутствии — заживляет прежний fail-soft пропуск графа),
+        fail-soft. НИКОГДА не эмбедит и не upsert-ит полную строку в стор и не
+        линкует PR. metas — как из normalize_meta."""
         metas = [m for m in metas if isinstance(m, dict) and m.get("key")]
         if not metas:
             return {"meta_refreshed": 0, "warnings": []}

--- a/reviewer/tasks/store.py
+++ b/reviewer/tasks/store.py
@@ -168,6 +168,23 @@ class TaskStore:
             )
             conn.commit()
 
+    def update_meta_batch(self, metas: list[dict]) -> None:
+        """Батч-обновление плоских метаданных (PRI-207 meta-refresh): один
+        executemany-UPDATE. Задача не в сторе → 0 строк (no-op, не создаёт
+        неполных строк, не трогает embedding). Пустой батч → no-op."""
+        rows = [(m.get("title") or "", m.get("status"), m.get("url"),
+                 m.get("aliases") or [], m.get("project") or "", m["key"])
+                for m in metas if isinstance(m, dict) and m.get("key")]
+        if not rows:
+            return
+        with self._connect() as conn, conn.cursor() as cur:
+            cur.executemany(
+                "UPDATE tasks SET title=%s, status=%s, url=%s, aliases=%s, "
+                "project=%s WHERE key=%s",
+                rows,
+            )
+            conn.commit()
+
     def list_keys(self, project: str | None = None) -> list[str]:
         """Ключи задач; при project — только этого проекта (для scoped purge)."""
         sql = "SELECT key FROM tasks"

--- a/reviewer/tasks/sync.py
+++ b/reviewer/tasks/sync.py
@@ -40,6 +40,7 @@ class SyncService:
 
         active_keys: list[str] = []
         changed: list[dict] = []
+        meta_refresh: list[dict] = []
         max_ts = cursor
         unchanged = 0
         for raw in provider.iter_raw(board, limit):
@@ -47,6 +48,11 @@ class SyncService:
             max_ts = max(max_ts, raw.timestamp)
             if raw.timestamp <= cursor:
                 unchanged += 1
+                try:
+                    meta_refresh.append(provider.normalize_meta(raw))
+                except Exception as e:
+                    log.warning("sync: сбой normalize_meta %s", raw.key, exc_info=True)
+                    warnings.append(f"normalize_meta {raw.key}: {type(e).__name__}: {e}")
                 continue
             try:
                 changed.append(provider.normalize(raw))
@@ -62,6 +68,12 @@ class SyncService:
         for r in results:
             warnings.extend(r.get("warnings") or [])
 
+        meta_refreshed = 0
+        if meta_refresh:
+            mr = self._tasks.refresh_meta_batch(meta_refresh)
+            meta_refreshed = mr.get("meta_refreshed", 0)
+            warnings.extend(mr.get("warnings") or [])
+
         cursor_advanced = False
         if limit:
             warnings.append("курсор не продвинут: задан limit (частичный обход)")
@@ -75,13 +87,15 @@ class SyncService:
         return active_keys, {
             "enumerated": len(active_keys), "changed": len(changed),
             "embedded": embedded, "refreshed": refreshed, "unchanged": unchanged,
+            "meta_refreshed": meta_refreshed,
             "failed": failed, "warnings": warnings, "cursor_advanced": cursor_advanced,
         }
 
     def run(self, board=None, limit=None, purge_orphaned=False,
             keep_with_prs=True, board_type=None, status_field=None) -> dict:
         agg = {"enumerated": 0, "changed": 0, "embedded": 0, "refreshed": 0,
-               "unchanged": 0, "failed": 0, "warnings": [], "cursor_advanced": False}
+               "unchanged": 0, "failed": 0, "meta_refreshed": 0,
+               "warnings": [], "cursor_advanced": False}
         # PRI-170: scoped-синк из репо — только один тип доски (board_type), а не все.
         providers = self._providers
         if board_type is not None:
@@ -100,7 +114,7 @@ class SyncService:
             active, one = self._sync_provider(provider, board, limit)
             all_active.extend(active)
             for k in ("enumerated", "changed", "embedded", "refreshed",
-                      "unchanged", "failed"):
+                      "unchanged", "failed", "meta_refreshed"):
                 agg[k] += one[k]
             agg["warnings"].extend(one["warnings"])
             agg["cursor_advanced"] = agg["cursor_advanced"] or one["cursor_advanced"]
@@ -108,7 +122,8 @@ class SyncService:
                 "board_type": provider.board_type,
                 "board": board or "*",
                 **{k: one[k] for k in ("enumerated", "changed", "embedded",
-                                        "refreshed", "unchanged", "failed")},
+                                        "refreshed", "unchanged", "failed",
+                                        "meta_refreshed")},
             })
 
         partial = bool(limit)

--- a/tests/tasks/boards/test_yougile_normalize.py
+++ b/tests/tasks/boards/test_yougile_normalize.py
@@ -233,3 +233,28 @@ def test_normalize_completed_maps_to_done_status():
 def test_normalize_not_completed_keeps_column_status():
     b = normalize_yougile(_raw(status="In progress", completed=False), KP, URL)
     assert b["status"] == "In progress"
+
+
+class _BoomClient:
+    """httpx-заглушка: любой сетевой вызов = ошибка (доказывает отсутствие I/O)."""
+
+    def get(self, *a, **k):
+        raise AssertionError("normalize_meta не должен делать сетевые вызовы")
+
+    def close(self):
+        pass
+
+
+def test_normalize_meta_no_io_yougile():
+    b = YougileBoard(api_key="k", api_base="https://yougile.com/api-v2",
+                     key_pattern=KP, url_template=URL)
+    b._client = _BoomClient()
+    # подзадачи и related-ссылки есть — дорогой normalize полез бы в сеть, meta — нет
+    raw = _raw(subtask_ids=["u1"], description="связано с PRI-96")
+    meta = b.normalize_meta(raw)
+    assert meta["key"] == "ID-10"
+    assert meta["aliases"] == ["PRI-10"]
+    assert meta["status"] == "Backlog"
+    assert meta["url"] == "https://ru.yougile.com/team/T/#PRI-10"
+    assert meta["project"] == "PRI"
+    assert meta["criteria"] == [] and meta["attachments"] == []

--- a/tests/tasks/boards/test_youtrack_normalize.py
+++ b/tests/tasks/boards/test_youtrack_normalize.py
@@ -203,3 +203,25 @@ def test_youtrack_selfhosted_with_port_allows_own_attachment():
     brief = board.normalize(raw)
     assert board._client.requested == [url]            # свой хост — скачан
     assert brief["attachments"][0]["content_text"] == "ТЗ"
+
+
+class _BoomClient:
+    """httpx-заглушка: любой сетевой вызов = ошибка (доказывает отсутствие I/O)."""
+
+    def get(self, *a, **k):
+        raise AssertionError("normalize_meta не должен делать сетевые вызовы")
+
+    def close(self):
+        pass
+
+
+def test_normalize_meta_no_io_youtrack():
+    b = YouTrackBoard(token="perm:x", base_url=BASE, key_pattern=KP)
+    b._client = _BoomClient()
+    raw = _issue_to_raw(_issue(idReadable="PRJ-7", description="связано с ABC-1"))
+    meta = b.normalize_meta(raw)
+    assert meta["key"] == "PRJ-7"
+    assert meta["status"] == "In Progress"
+    assert meta["url"] == "https://c.youtrack.cloud/issue/PRJ-7"
+    assert meta["project"] == "PRJ"
+    assert meta["criteria"] == [] and meta["attachments"] == []

--- a/tests/tasks/test_integration.py
+++ b/tests/tasks/test_integration.py
@@ -219,6 +219,29 @@ def test_purge_no_keep_with_prs_deletes_all(store, graph):
     assert store.list_keys() == []
 
 
+def test_update_meta_batch_backfills_project(store):
+    emb = _FakeEmbedder()
+    text = build_task_text("T1", "d1", [])
+    store.upsert_task(TaskRow(
+        key="ID-1", aliases=["PRI-1"], title="T1", description="d1",
+        status="Open", url=None, content_hash=task_content_hash(text),
+        text=text, embedding=emb.embed_documents([text])[0], project=""))
+    assert store.get_task("ID-1").project == ""
+
+    store.update_meta_batch([{"key": "ID-1", "title": "T1", "status": "Done",
+                              "url": "u", "aliases": ["PRI-1"], "project": "PRI"}])
+    row = store.get_task("ID-1")
+    assert row.project == "PRI"
+    assert row.status == "Done"
+
+    # задача не в сторе → no-op, ничего не создаётся
+    store.update_meta_batch([{"key": "ID-404", "project": "PRI"}])
+    assert store.get_task("ID-404") is None
+
+    # пустой батч → без ошибок
+    store.update_meta_batch([])
+
+
 def test_taskstore_get_task_by_key_and_alias(store):
     emb = _FakeEmbedder()
     text = build_task_text("Add logout", "Clear the session on logout", [])

--- a/tests/tasks/test_service_batch.py
+++ b/tests/tasks/test_service_batch.py
@@ -8,6 +8,7 @@ class _FakeStore:
         self._hashes = hashes or {}
         self.upserted = []
         self.meta_updates = []
+        self.meta_batch = None
 
     def existing_hash(self, key):
         return self._hashes.get(key)
@@ -17,6 +18,9 @@ class _FakeStore:
 
     def update_meta(self, key, title, status, url, aliases, project=""):
         self.meta_updates.append((key, title, status, url, aliases, project))
+
+    def update_meta_batch(self, metas):
+        self.meta_batch = list(metas)
 
 
 class _FakeGraph:
@@ -222,3 +226,44 @@ def test_index_batch_passes_attachments_to_row():
     task = _brief(attachments=attachments)
     TaskService(store, graph, emb).index_batch([task])
     assert store.upserted[-1].attachments == attachments
+
+
+def test_refresh_meta_batch_stamps_project_store_and_graph():
+    store, graph = _FakeStore(), _FakeGraph()
+    metas = [{"key": "ID-1", "aliases": ["PRI-1"], "title": "T", "status": "Open",
+              "url": "u", "project": "PRI"}]
+    res = TaskService(store, graph, _FakeEmbedder()).refresh_meta_batch(metas)
+    assert res["meta_refreshed"] == 1
+    assert store.meta_batch == metas               # батч ушёл в стор
+    assert graph.tasks == ["ID-1"]
+    assert graph.task_projects == ["PRI"]          # project достиг графа
+
+
+def test_refresh_meta_batch_never_embeds_or_upserts():
+    store, graph, emb = _FakeStore(), _FakeGraph(), _FakeEmbedder()
+    TaskService(store, graph, emb).refresh_meta_batch([{"key": "ID-1", "project": "PRI"}])
+    assert emb.doc_calls == []                     # НИКОГДА не эмбедит
+    assert store.upserted == []                    # и не upsert-ит (не воскрешает задачу)
+
+
+def test_refresh_meta_batch_empty():
+    store = _FakeStore()
+    res = TaskService(store, _FakeGraph(), _FakeEmbedder()).refresh_meta_batch([])
+    assert res == {"meta_refreshed": 0, "warnings": []}
+    assert store.meta_batch is None
+
+
+def test_refresh_meta_batch_graph_none_warns():
+    store = _FakeStore()
+    res = TaskService(store, None, _FakeEmbedder()).refresh_meta_batch(
+        [{"key": "ID-1", "project": "PRI"}])
+    assert res["meta_refreshed"] == 1
+    assert any("graph unavailable" in w for w in res["warnings"])
+
+
+def test_refresh_meta_batch_graph_failsoft():
+    store, graph = _FakeStore(), _FakeGraph(raise_on=("upsert_task",))
+    res = TaskService(store, graph, _FakeEmbedder()).refresh_meta_batch(
+        [{"key": "ID-1", "project": "PRI"}])
+    assert res["meta_refreshed"] == 1              # store прошёл, граф — fail-soft
+    assert any("graph" in w for w in res["warnings"])

--- a/tests/tasks/test_sync.py
+++ b/tests/tasks/test_sync.py
@@ -97,10 +97,9 @@ def test_no_changes_does_not_advance_cursor():
     summary = SyncService([prov], ts, meta).run()
     assert ts.indexed == []
     assert summary["changed"] == 0 and summary["unchanged"] == 2
-    assert summary["cursor_advanced"] is False
+    assert summary["cursor_advanced"] is False   # meta-refresh курсор НЕ двигает
     assert summary["meta_refreshed"] == 2        # обе задачи ниже курсора
     assert ts.meta_refreshed == [["ID-1", "ID-2"]]
-    assert summary["cursor_advanced"] is False   # meta-refresh курсор НЕ двигает
 
 
 def test_purge_uses_full_active_keys():

--- a/tests/tasks/test_sync.py
+++ b/tests/tasks/test_sync.py
@@ -22,16 +22,26 @@ class FakeProvider:
                 "description": raw.description, "criteria": [], "status": raw.status,
                 "url": None, "links": []}
 
+    def normalize_meta(self, raw):
+        return {"key": raw.key, "aliases": [raw.project_code], "title": raw.title,
+                "status": raw.status, "url": None,
+                "project": raw.project_code.split("-")[0]}
+
 
 class FakeTaskService:
     def __init__(self):
         self.indexed = []
         self.purged_with = None
+        self.meta_refreshed = []
 
     def index_batch(self, tasks):
         self.indexed.append([t["key"] for t in tasks])
         return [{"key": t["key"], "embedded": True, "links_upserted": 0,
                  "prs_linked": 0, "warnings": []} for t in tasks]
+
+    def refresh_meta_batch(self, metas):
+        self.meta_refreshed.append([m["key"] for m in metas])
+        return {"meta_refreshed": len(metas), "warnings": []}
 
     def purge_orphaned_tasks(self, active_keys, *, keep_with_prs=True, project=None):
         self.purged_with = (sorted(active_keys), keep_with_prs, project)
@@ -64,6 +74,8 @@ def test_first_sync_indexes_all_and_advances_cursor():
     assert summary["embedded"] == 2
     assert summary["cursor_advanced"] is True
     assert meta.store[("", "tasks:fake:*")] == "200"
+    assert summary["meta_refreshed"] == 0        # все changed, unchanged нет
+    assert ts.meta_refreshed == []
 
 
 def test_watermark_skips_unchanged():
@@ -74,6 +86,8 @@ def test_watermark_skips_unchanged():
     assert ts.indexed == [["ID-2"]]
     assert summary["changed"] == 1 and summary["unchanged"] == 1
     assert meta.store[("", "tasks:fake:*")] == "200"
+    assert summary["meta_refreshed"] == 1        # ID-1 (ниже курсора) meta-refreshнут
+    assert ts.meta_refreshed == [["ID-1"]]
 
 
 def test_no_changes_does_not_advance_cursor():
@@ -84,6 +98,9 @@ def test_no_changes_does_not_advance_cursor():
     assert ts.indexed == []
     assert summary["changed"] == 0 and summary["unchanged"] == 2
     assert summary["cursor_advanced"] is False
+    assert summary["meta_refreshed"] == 2        # обе задачи ниже курсора
+    assert ts.meta_refreshed == [["ID-1", "ID-2"]]
+    assert summary["cursor_advanced"] is False   # meta-refresh курсор НЕ двигает
 
 
 def test_purge_uses_full_active_keys():
@@ -209,3 +226,12 @@ def test_sync_run_resets_youtrack_status_field():
     assert yt._status_field == "Stage"
     svc.run(board_type="youtrack")           # без status_field → сброс к State
     assert yt._status_field == "State"
+
+
+def test_by_board_includes_meta_refreshed():
+    prov = FakeProvider([_raw("ID-1", 100), _raw("ID-2", 200)], board_type="yougile")
+    meta = FakeMeta({("", "tasks:yougile:*"): "150"})   # ID-1 ниже курсора
+    ts = FakeTaskService()
+    result = SyncService([prov], ts, meta).run()
+    assert result["meta_refreshed"] == 1
+    assert result["by_board"][0]["meta_refreshed"] == 1


### PR DESCRIPTION
## Проблема (PRI-207)

Инкрементальный `sync_board` продвигает watermark-курсор по `max_ts` и отсекает
задачи с `timestamp <= cursor` **до** пути индексации. Колонка `project`
(добавлена в PRI-170) заполняется только на пути индексации, поэтому у уже
синканных задач она никогда не backfill-илась: 94/97 задач с пустым `project`,
а scoped `search_tasks(project="PRI")` возвращал ~3 задачи вместо десятков.

## Решение — системный self-healing meta-refresh

Split на два пути внутри `_sync_provider`:

- **дорогой путь (без изменений):** изменённые задачи (`timestamp > cursor`) →
  полный `normalize` (REST: сабтаски/вложения) + эмбеддинг + upsert строки.
- **дешёвый путь (новый):** все перечисленные задачи ниже курсора →
  `provider.normalize_meta(raw)` (чистая функция, без I/O, без эмбеддинга) →
  батч `TaskService.refresh_meta_batch` → `TaskStore.update_meta_batch`
  (один `executemany` UPDATE плоских колонок по `key`; отсутствующую задачу
  **не воскрешает**) + per-task `TaskGraph.upsert_task` (MERGE, fail-soft).

Курсор по-прежнему двигается только по `max_ts` — meta-refresh его не трогает.
Дешёвый путь заживляет любое будущее обогащение метаданных (не только `project`)
без дорогого реиндекса и без затрат Voyage.

## Изменения

- `boards/base.py` — `normalize_meta` в Protocol `TaskBoardProvider`.
- `boards/yougile.py`, `boards/youtrack.py` — реализация (переиспользуют чистые
  module-level `normalize_*`).
- `tasks/store.py` — `update_meta_batch(metas)`.
- `tasks/service.py` — `refresh_meta_batch(metas)` (стор одним батчем, граф
  per-task fail-soft).
- `tasks/sync.py` — встройка в `_sync_provider` + `run`; ключ `meta_refreshed`
  в сводке (агрегат + per-board).

## Тесты

- unit: `tests/tasks/test_sync.py`, `test_service_batch.py`,
  `boards/test_yougile_normalize.py`, `test_youtrack_normalize.py`
  (no-I/O через `_BoomClient`) — `995 passed`.
- integration (маркер): `test_integration.py::test_update_meta_batch_backfills_project`.

## Приёмка после деплоя

`sync_board(board="PRI")` → `meta_refreshed ≈ 96`; scoped
`search_tasks(project="PRI")` возвращает десятки задач.

Артефакты трассы: `docs/superpowers/{briefs,specs,plans}/*pri-207*`.
