### PR TITLE
feat(skills): solve-task выбирает модель для сборки брифа (кросс-CLI, PRI-208)

### DIFF
--- a/README.md
+++ b/README.md
@@ -646,6 +646,11 @@ and enters brainstorming. It disciplines context-gathering — it does **not** w
   `docs/superpowers/briefs/` (`ГГГГ-ММ-ДД-<KEY>-<slug>.md`, survives context compaction) → hand off to
   `superpowers:brainstorming` with the brief file path as seed → **full superpowers cycle**: brainstorming →
   writing-plans → subagent-driven-development → executing-plans → finishing-a-development-branch.
+- **Cheaper model for the brief (cross-CLI).** Before building the brief, `solve-task` asks which
+  model tier to run it on (by tier — cheap / mid / premium — not by model name, so it works across
+  CLIs) and recommends a mid (Sonnet-class) default: gathering and distilling the brief is light
+  reasoning, so a top-tier model is overkill. Where the harness supports per-subagent model override
+  it dispatches the brief-building on the chosen model; otherwise it builds inline.
 
 ### `reviewer_sync-codebase` — build/update the base index
 

--- a/README.ru.md
+++ b/README.ru.md
@@ -565,7 +565,7 @@ RAG + граф кода и передаёт в **полный цикл superpowe
 
 - **Аргументы:** ключ задачи (напр. `PRI-4`, по `key_pattern`) **или** свободное описание (напр.
   «add a logout endpoint»). Board-less режим: описание + поиск по коду.
-- **MCP-тулы:** `get_board_config`, `index_task`, `get_task_context`, `search_tasks`,
+- **MCP-тулы:** `get_board_config`, `get_subsystem_summaries`, `get_task`, `index_task`, `get_task_context`, `search_tasks`,
   `search_codebase`, `related_symbols`, `callers`, `definition`, `get_pr_diff`; плюс подключённая
   доска (`mcp__<board>__*`) для чтения задачи.
 - **Поток:** preflight: проверка свежести индекса → прогрев корпуса задач через `sync_board` →

--- a/README.ru.md
+++ b/README.ru.md
@@ -577,6 +577,11 @@ RAG + граф кода и передаёт в **полный цикл superpowe
   → **полный superpowers-цикл**: brainstorming → writing-plans → subagent-driven-development →
   executing-plans → finishing-a-development-branch.
   `project=<task_board.project>` на всех task-тулах.
+- **Дешевле модель под бриф (кросс-CLI).** Перед сборкой брифа `solve-task` спрашивает, на каком
+  tier'е модели его собрать (по tier'ам — cheap / mid / premium, а не по имени модели, чтобы работало
+  в разных CLI) и рекомендует mid (Sonnet-класс) по умолчанию: сбор и распил брифа — лёгкий reasoning,
+  топ-модель избыточна. Где харнесс умеет per-subagent override — сборка брифа идёт на выбранной
+  модели; иначе — inline.
 
 ### `reviewer_sync-codebase` — построить/обновить base-индекс
 

--- a/docs/superpowers/briefs/2026-07-03-PRI-208-brief-model-choice.md
+++ b/docs/superpowers/briefs/2026-07-03-PRI-208-brief-model-choice.md
@@ -1,0 +1,78 @@
+# Brief — PRI-208 [solve-task] Выбор модели для сборки брифа (спрашивать у юзера, рекомендовать дешевле, кросс-CLI)
+https://ru.yougile.com/team/686c049c8af8/#PRI-208
+
+## Task
+Сейчас сборка брифа в `solve-task` (шаги 3–4: gather context + distill) идёт на дефолтной/сессионной
+модели оркестратора. Для брифа топ-модель избыточна — это лёгкий reasoning поверх session-less MCP-тулов.
+Нужно: **перед** сборкой брифа спрашивать у юзера, на какой из доступных моделей запустить, с рекомендацией
+более дешёвого tier'а. Должно работать в **разных CLI** → спрашивать по tier'ам (cheap/mid/premium), не
+хардкодя Claude-имена. Дефолт-рекомендация (решение юзера) — **Sonnet-класс (mid)**; Fable не рекомендовать.
+Критерии: шаг выбора модели перед брифом · рекомендация дефолта · где харнесс умеет per-subagent override —
+диспатч сабагента на выбранной модели, где нет — inline-фолбэк + пометка · fail-open · guard-тест в
+`tests/skills/` · синк README EN+RU. (данные задачи — из стора reviewer после sync_board)
+
+## Related work
+- **ID-162** (done) [solve-task] include_tests для TDD-хендоффа — прецедент *формы* этой правки: новый шаг в
+  `solve-task` + guard-тест в `tests/skills/` + синк README. Мимикрировать структуру.
+- **ID-183** [solve-task] Параллельный wave-1 retrieval в Step 3 — Step 3 (gather) ровно та фаза, что оборачиваем
+  в сабагента; правки пересекаются по региону → учесть взаимодействие при проектировании границы.
+- Граница оркестратор↔сабагент: **ID-187** (верификация brief перед hand-off) и **ID-189** (sanity gate перед
+  hand-off) остаются на оркестраторе (сессионная модель), а не на дешёвом сабагенте — держать hand-off вне
+  «удешевлённого» участка.
+- (dropped 3: ID-184 freshness-guard сводок, ID-181 детекция блокеров, ID-153 relevance-score — другой механизм;
+  + необследованный хвост рельсы 8/30, не был нужен для реализации)
+
+## Subsystems
+- `reviewer` — `reviewer/install.py` перечисляет целевые CLI-клиенты (Cursor, VS Code, Claude Code, Gemini,
+  Codex, Mimo, OpenCode, Kimi, Windsurf, Trae) — это и есть «разные CLI»; tier-абстракция должна их покрыть.
+- `plugin/hooks` — хук `brief_cost` детерминированно считает LLM-токены брифа **по модели** и пишет блок в бриф;
+  пропуск sidechain'ов — прямой конфликт с переносом сборки в сабагента (см. Constraints).
+
+## Relevant code
+- `plugin/skills/solve-task/SKILL.md` — **файл правки**: добавить шаг выбора модели ПЕРЕД шагами 3–4; шаги 3–4
+  (gather+distill, стр. ~106–204) — то, что оборачиваем в сабагента/inline.
+- `plugin/skills/summarize-subsystems/SKILL.md:48-65` — **образец паттерна для порта**: шаг 4 «Choose the summary
+  model» (спроси tier, дефолт дешёвый) + шаг 5 «dispatch a subagent on the chosen model … where override is
+  unavailable, write inline … and note this». Копировать структуру, поменять «summaries»→«brief».
+- `plugin/skills/solve-task/SKILL.md:55-58` — существующий эскейп-хатч «Прогрею сам» (preflight шаг 0.4):
+  прецедент кросс-CLI-варианта «запущу на своём CLI/дешёвой модели» — переиспользовать как фолбэк.
+- `plugin/hooks/brief_cost.py:100-115` (`aggregate_usage`), `:88` (`find_window_start`) — ⚠️ считает токены по
+  `message.get("model")` для assistant-ходов главного цикла, **пропуская sidechain** → сабагент-бриф обнулит/
+  исказит блок «Модель: …». Blast radius.
+- `plugin/skills/_common/` (anti-hallucination.md, branch-selection.md, tool-usage.md, …) — кандидат-локация
+  для общего `model-selection.md` include (DRY с summarize-subsystems) — см. открытый вопрос.
+- `reviewer/install.py` — `Client`/`build_plan`/`install_skills`: список поддерживаемых CLI (не редактируем, но
+  это источник истины про «разные CLI» для формулировки tier-нейтральности).
+- (dropped 0)
+
+## Test exemplars
+- `tests/skills/test_summarize_subsystems.py:35-53` — **образец guard-теста**: `test_skill_asks_model_choice`
+  (assert `"Ask the user which model tier to use for writing summaries" in text` + дешёвый дефолт) и
+  `test_skill_dispatches_subagent_on_chosen_model`. Для solve-task ввести уникальную фразу («… for building the
+  brief») и зеркальные ассерты.
+- `tests/skills/test_solve_task_brief.py:15-70` — **куда добавлять**: существующие guard-тесты solve-task читают
+  `SKILL.md` и проверяют уникальные фразы шагов; добавить сюда ассерт нового маркера выбора модели.
+- `tests/hooks/` (тесты `brief_cost`, `aggregate_usage`/`find_window_start` с пропуском sidechain) — если тронем
+  хук ради корректного учёта subagent-токенов, расширить эти тесты.
+- (dropped 0)
+
+## Constraints / open questions
+- ⚠️ **Хук `brief_cost` vs сабагент.** `aggregate_usage` пропускает sidechain-ходы; сабагент (Task) — sidechain →
+  перенос сборки брифа в сабагента, скорее всего, обнулит по-модельный блок токенов. Развилка: (a) держать
+  оркестрацию inline, а на сабагента выносить только распил/дистилляцию; (b) научить хук читать sidechain-
+  транскрипт сабагента; (c) принять деградацию учёта и пометить. Решить в brainstorming.
+- **Кросс-CLI без per-subagent override.** Харнессы без override (platform-refs superpowers: codex/pi/antigravity)
+  → inline-фолбэк ИЛИ попросить юзера переключить модель/запустить самому (зеркало «Прогрею сам»). Спрашивать по
+  tier'ам, не по именам моделей.
+- **Открытый вопрос (DRY).** Общий `plugin/skills/_common/model-selection.md` include vs solve-task-local —
+  первое даёт единый источник с summarize-subsystems, но требует и его миграции на include. Решить при проектировании.
+- **Дефолт-tier = Sonnet-класс** (решение юзера). Память проекта: код через superpowers — Sonnet; Fable не применять.
+- **Индекс dev отстаёт на 14 коммитов** (`drift=14`) — не реиндексировал: задача правит markdown-скиллы, code-индекс
+  для неё нерелевантен. Якоря брифа — из grep/Read по markdown/hook-файлам, не из RAG.
+- **Догфуд.** Этот бриф собран на сессионной модели (Opus); внедряемая фича рекомендовала бы Sonnet-класс — в
+  следующий прогон запускать через новый шаг выбора модели.
+
+## Токены (этап solve-task)
+Модель: claude-opus-4-8
+fresh-in 48.8K · out 92.8K · cache-write 444.3K · cache-read 3.4M
+Всего: 4M токенов

--- a/docs/superpowers/plans/2026-07-03-pri-208-brief-model-choice.md
+++ b/docs/superpowers/plans/2026-07-03-pri-208-brief-model-choice.md
@@ -1,0 +1,189 @@
+# PRI-208 — Выбор модели для сборки брифа (solve-task) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Дать `solve-task` спрашивать у юзера, на какой (более дешёвой) модели собрать бриф, рекомендуя mid/Sonnet-класс, кросс-CLI — и исполнять шаги 2–4 на выбранной модели (subagent где есть override, иначе inline).
+
+**Architecture:** Правка одного Claude-Code-скилла `plugin/skills/solve-task/SKILL.md` (markdown): новый Step 1.5 «Choose the brief model» + wrapper над шагами 2–4 (пути A=subagent-on-chosen-model / B=inline-fallback + строка-маркер «Собран на: …»). Поведение фиксируется guard-тестами, читающими текст `SKILL.md` (как `tests/skills/test_summarize_subsystems.py`). Python-код и хук `brief_cost.py` не трогаем. Плюс синк README EN+RU.
+
+**Tech Stack:** Markdown-скиллы Claude Code; pytest (guard-тесты в `tests/skills/`, читают файл как текст, без БД/сети).
+
+## Global Constraints
+
+- Работать на фиче-ветке от `dev` (напр. `feat/pri-208-brief-model-choice`); `dev` защищена, интеграция через PR. Conventional Commits на русском, **без self-attribution** (никаких `Co-Authored-By`/Claude).
+- Тело `SKILL.md` — по-английски; текст инструктирует агента **общаться с юзером по-русски** (как весь скилл).
+- **НЕ трогать** `plugin/hooks/brief_cost.py`, `tests/hooks/*`, `plugin/skills/summarize-subsystems/*`, общий `_common/` (решение brainstorming: best-effort учёт токенов, solve-task-local).
+- **НЕ удалять** существующие anchor-фразы solve-task guard-тестов при правке `SKILL.md` (см. Task 1, шаг 0).
+- Прогон тестов: `.venv/bin/pytest tests/skills/ -q` (быстрые, без интеграции).
+- Дефолт-рекомендация tier — **mid / Sonnet-класс**; Fable не рекомендовать.
+
+---
+
+### Task 1: Step 1.5 «Choose the brief model» + brief-building-unit wrapper в SKILL.md (TDD)
+
+**Files:**
+- Modify: `plugin/skills/solve-task/SKILL.md` (вставка после Step 1 «Config», перед Step 2)
+- Test: `tests/skills/test_solve_task_brief.py` (добавить 3 теста)
+
+**Interfaces:**
+- Consumes: ничего от других задач.
+- Produces: уникальные фразы-маркеры в `SKILL.md`, на которые ассертят guard-тесты:
+  - `"Ask the user which model tier to use for building the brief"`
+  - `"mid tier (Sonnet-class)"`
+  - `"dispatch a subagent on the chosen model"`
+  - `"per-subagent model override unavailable"`
+  - `"Собран на"` (строка-маркер, которую скилл дописывает в бриф)
+
+- [ ] **Step 0: Зафиксировать существующие anchor-фразы (регрессия).** Перед правкой убедиться, что правка НЕ удалит фразы, которые уже проверяют другие тесты в `tests/skills/test_solve_task_brief.py`. Прогнать текущий набор — он должен быть зелёным ДО изменений:
+
+Run: `.venv/bin/pytest tests/skills/test_solve_task_brief.py -q`
+Expected: PASS (все существующие тесты зелёные). Эти фразы (`# Brief —`, `No fixed ceilings`, `bounded server-side`, `(dropped`, `directly informs`, `project=`, `task_board.project`, `docs/superpowers/briefs/`, `Persist the brief`, `file path`, `Board-less`, `Dedup related sources by key`, `linked ∪ similar`, `canonical task key`, `Thin-criteria enrichment`, `include_tests=True`, `Test exemplars`, `Lazy expansion (no user prompt)`, `top_k=`) вставку Step 1.5 переживают — вставляем НОВЫЙ шаг, ничего не удаляя.
+
+- [ ] **Step 1: Написать падающие guard-тесты.** Добавить в конец `tests/skills/test_solve_task_brief.py`:
+
+```python
+def test_solve_task_asks_brief_model_choice():
+    """Новый Step 1.5 должен спрашивать у юзера tier модели для сборки брифа."""
+    text = SOLVE.read_text(encoding="utf-8")
+    assert "Ask the user which model tier to use for building the brief" in text, (
+        "нет шага выбора модели для брифа (уникальная фраза шага удалена)"
+    )
+    # Рекомендация-дефолт — mid/Sonnet-класс
+    assert "mid tier (Sonnet-class)" in text, (
+        "скилл не рекомендует mid/Sonnet-класс как дефолт"
+    )
+
+
+def test_solve_task_dispatches_brief_subagent_on_chosen_model():
+    """Путь A: шаги 2–4 диспатчатся сабагентом на выбранной модели; путь B — inline-фолбэк."""
+    text = SOLVE.read_text(encoding="utf-8")
+    assert "dispatch a subagent on the chosen model" in text, (
+        "нет диспатча сабагента на выбранной модели (путь A)"
+    )
+    assert "per-subagent model override unavailable" in text, (
+        "нет inline-фолбэка для CLI без per-subagent override (путь B)"
+    )
+
+
+def test_solve_task_records_brief_model_marker():
+    """Оркестратор дописывает в бриф строку-маркер «Собран на: …»."""
+    text = SOLVE.read_text(encoding="utf-8")
+    assert "Собран на" in text, (
+        "нет строки-маркера «Собран на: <tier/модель>» (наблюдаемость выбора)"
+    )
+```
+
+- [ ] **Step 2: Прогнать новые тесты — убедиться, что падают.**
+
+Run: `.venv/bin/pytest tests/skills/test_solve_task_brief.py -q -k "brief_model_choice or brief_subagent or brief_model_marker"`
+Expected: FAIL (3 теста) — «уникальная фраза шага удалена» / AssertionError (фраз ещё нет в `SKILL.md`).
+
+- [ ] **Step 3: Вставить новый Step 1.5 в `SKILL.md`.** Найти в `plugin/skills/solve-task/SKILL.md` конец шага `1. **Config.** …` (он заканчивается строкой про board-less mode: «… → board-less mode (continue without it).») и **сразу после него, перед строкой `2. **Identify the task.**`** вставить:
+
+```markdown
+1.5. **Choose the brief model (cross-CLI).** Building the brief (Steps 2–4: gather + distill) is a
+   light reasoning task over session-less retrieval tools — a top-tier model is overkill and burns
+   tokens. Before building it, **Ask the user which model tier to use for building the brief**,
+   phrasing the choice by **tier (cheap / mid / premium)** — not by concrete model names — so it
+   works across CLIs (Claude Code, Codex, Gemini, Cursor, …). **Recommend a mid tier (Sonnet-class)
+   as the default** (do not recommend Fable — a coarse tier is fine but the brief still needs sound
+   judgment). Talk to the user in Russian. Remember the choice for this run. Fail-open: no answer or
+   a decline → use the default tier (or, on Path B below, the session model inline). Never block.
+```
+
+- [ ] **Step 4: Вставить brief-building-unit wrapper перед Step 2.** Сразу после вставленного Step 1.5 (и перед `2. **Identify the task.**`) добавить:
+
+```markdown
+**Brief-building unit (Steps 2–4) runs on the chosen model.** Steps 2–4 (identify → gather → distill
+→ persist) are non-interactive; run them on the model chosen in Step 1.5:
+- **Path A — per-subagent model override available:** **dispatch a subagent on the chosen model** to
+  execute Steps 2–4, giving it the reviewer session-less tools (`get_task`, `search_codebase`,
+  `get_subsystem_summaries`, `get_task_context`, `search_tasks`, the graph tools, `get_pr_diff`) plus
+  the harness `Read`/`Bash`/`Glob`/`Write` (to persist the brief). The subagent returns the brief file
+  path and a short summary (kept / dropped).
+- **Path B — per-subagent model override unavailable** (some CLIs): build the brief **inline** on the
+  session model, or offer the escape-hatch «switch model / run it yourself» in the spirit of the
+  preflight «Прогрею сам» option (Step 0.4). Note in the report that the brief was built inline.
+- **Existing-artifacts warn** (Step 4, user-facing «warn, don't block»): the **orchestrator** runs
+  that scan-and-warn **before dispatch** (a subagent must not prompt the user); the idempotency
+  overwrite-glob stays inside the subagent's persist.
+- After the unit returns, the orchestrator **appends a marker line to the brief**:
+  `Собран на: <tier/модель>, режим: subagent | inline` — records which model built the brief. The
+  `brief_cost` token block is best-effort and may miss subagent sidechain tokens (documented limitation).
+- Fail-open: an error or empty return from the subagent → the orchestrator finishes the brief inline
+  on the session model. Model choice must never break the pipeline.
+```
+
+- [ ] **Step 5: Прогнать новые тесты — убедиться, что проходят.**
+
+Run: `.venv/bin/pytest tests/skills/test_solve_task_brief.py -q -k "brief_model_choice or brief_subagent or brief_model_marker"`
+Expected: PASS (3 теста).
+
+- [ ] **Step 6: Прогнать весь набор скилл-тестов — регрессия (ничего не сломали).**
+
+Run: `.venv/bin/pytest tests/skills/ -q`
+Expected: PASS (все тесты, включая существующие solve-task/summarize/common/readme-grounding).
+
+- [ ] **Step 7: Commit.**
+
+```bash
+git add plugin/skills/solve-task/SKILL.md tests/skills/test_solve_task_brief.py
+git commit -m "feat(skills): solve-task спрашивает модель для сборки брифа (кросс-CLI, PRI-208)"
+```
+
+---
+
+### Task 2: Синк README EN + RU
+
+**Files:**
+- Modify: `README.md` (секция `### reviewer_solve-task — from task to implementation (killer feature)`, ~L629)
+- Modify: `README.ru.md` (секция `### reviewer_solve-task — от задачи до реализации (ключевая фича)`, ~L558)
+
+**Interfaces:**
+- Consumes: поведение из Task 1 (выбор модели для брифа).
+- Produces: doc-строки; тестами не покрывается (docs).
+
+- [ ] **Step 1: Прочитать целевые секции, чтобы вставить строку в существующий стиль.**
+
+Run: `sed -n '629,700p' README.md` и `sed -n '558,630p' README.ru.md`
+Expected: увидеть буллеты/абзацы описания `solve-task`, куда логично добавить строку про выбор модели.
+
+- [ ] **Step 2: Добавить строку в `README.md` (EN)** в секцию solve-task — например, отдельным буллетом в описании пайплайна:
+
+```markdown
+- **Cheaper model for the brief (cross-CLI).** Before building the brief, `solve-task` asks which
+  model tier to run it on (by tier — cheap / mid / premium — not by model name, so it works across
+  CLIs) and recommends a mid (Sonnet-class) default: gathering and distilling the brief is light
+  reasoning, so a top-tier model is overkill. Where the harness supports per-subagent model override
+  it dispatches the brief-building on the chosen model; otherwise it builds inline.
+```
+
+- [ ] **Step 3: Добавить зеркальную строку в `README.ru.md` (RU)** в секцию solve-task:
+
+```markdown
+- **Дешевле модель под бриф (кросс-CLI).** Перед сборкой брифа `solve-task` спрашивает, на каком
+  tier'е модели его собрать (по tier'ам — cheap / mid / premium, а не по имени модели, чтобы работало
+  в разных CLI) и рекомендует mid (Sonnet-класс) по умолчанию: сбор и распил брифа — лёгкий reasoning,
+  топ-модель избыточна. Где харнесс умеет per-subagent override — сборка брифа идёт на выбранной
+  модели; иначе — inline.
+```
+
+- [ ] **Step 4: Прогнать readme-grounding guard (не сломали блок).**
+
+Run: `.venv/bin/pytest tests/skills/test_readme_grounding_block.py -q`
+Expected: PASS.
+
+- [ ] **Step 5: Commit.**
+
+```bash
+git add README.md README.ru.md
+git commit -m "docs: README (EN+RU) — solve-task выбирает модель для сборки брифа (PRI-208)"
+```
+
+---
+
+## Self-Review (выполнено при написании плана)
+
+- **Spec coverage:** Step 1.5 (выбор модели, дефолт mid/Sonnet, кросс-CLI по tier'ам) → Task 1 Step 3; пути A/B (subagent/inline) + маркер «Собран на» → Task 1 Step 4; guard-тест → Task 1 Steps 1–2; README EN+RU → Task 2; fail-open → включён в текст шагов. Хук `brief_cost`/`summarize`/`_common` — явно вне скоупа (Global Constraints). Пробелов нет.
+- **Placeholder scan:** плейсхолдеров нет — весь текст `SKILL.md`/README/тестов приведён дословно.
+- **Type/phrase consistency:** уникальные фразы в `SKILL.md` (Step 3/4) дословно совпадают с ассертами guard-тестов (Step 1): `"Ask the user which model tier to use for building the brief"`, `"mid tier (Sonnet-class)"`, `"dispatch a subagent on the chosen model"`, `"per-subagent model override unavailable"`, `"Собран на"`.

--- a/docs/superpowers/specs/2026-07-03-pri-208-brief-model-choice-design.md
+++ b/docs/superpowers/specs/2026-07-03-pri-208-brief-model-choice-design.md
@@ -1,0 +1,105 @@
+# PRI-208 — Выбор модели для сборки брифа в solve-task
+
+**Задача:** https://ru.yougile.com/team/686c049c8af8/#PRI-208
+**Бриф:** `docs/superpowers/briefs/2026-07-03-PRI-208-brief-model-choice.md`
+**Тип:** правка Claude-Code-скилла (markdown) + guard-тест + доки. Python-код (в т.ч. хук
+`brief_cost.py`) **не трогаем**.
+
+## Проблема
+
+Этап сборки брифа в `plugin/skills/solve-task/SKILL.md` (шаги 2–4: identify → gather → distill →
+persist) выполняется на дефолтной/сессионной модели оркестратора. Для брифа топ-модель избыточна —
+это лёгкий reasoning поверх session-less MCP-тулов ретрива. Нужно давать юзеру выбрать более дешёвую
+модель под сборку брифа, с рекомендацией, и чтобы это работало в разных CLI (клиенты из
+`reviewer/install.py`: Claude Code, Codex, Gemini, Cursor, Mimo, OpenCode, Kimi, Windsurf, Trae …).
+
+## Решение (обзор)
+
+Один новый шаг в `solve-task/SKILL.md` + переформулировка шагов 2–4 как «brief-building unit»,
+диспатчащегося на выбранной модели, с inline-фолбэком. Образец паттерна — `summarize-subsystems`
+SKILL.md, шаги 4–5. Текст шага — по-английски (тело скилла), с инструкцией общаться с юзером
+по-русски (как в остальном скилле).
+
+### Принятые решения (из brainstorming)
+
+| Развилка | Решение |
+|---|---|
+| Что уезжает на выбранную модель | **Шаги 2–4** (gather + distill). Оркестратор держит интерактивный preflight (шаг 0) + hand-off (шаг 5). |
+| Хук `brief_cost` (пропускает sidechain) | **Best-effort:** хук не трогаем; скилл дописывает в бриф строку «Собран на: <tier/модель>». Точные subagent-токены могут не попасть — помечаем. |
+| DRY текста шага | **solve-task-local** (как summarize держит свой шаг инлайн; общий include не делаем). |
+| Дефолт-рекомендация tier | **mid / Sonnet-класс.** Fable не рекомендовать (память проекта). |
+
+## Обновлённый поток solve-task
+
+- **Step 0 — Preflight** (оркестратор). Интерактивные гейты (реиндекс, прогрев сводок). Без изменений.
+- **Step 1 — Config** (оркестратор). Резолв `task_board`. Без изменений.
+- **NEW Step 1.5 — Choose the brief model** (оркестратор):
+  - Спросить у юзера, на какой из доступных **в текущем CLI** моделей собрать бриф.
+  - Спрашивать по **tier'ам (cheap / mid / premium)**, НЕ по конкретным Claude-именам → кросс-CLI.
+  - Рекомендация-дефолт — **mid / Sonnet-класс**; пояснить, что топ-модель для брифа избыточна.
+  - Запомнить выбор на прогон. Fail-open: отказ/молчание → дефолт-tier (или сессионная модель inline).
+- **Steps 2–4 — Brief-building unit** (identify → gather → distill → persist):
+  - **Путь A (харнесс умеет per-subagent model override):** диспатч сабагента на выбранной модели.
+    Сабагент получает: reviewer session-less тулы (`get_task`, `search_codebase`,
+    `get_subsystem_summaries`, graph-тулы, `get_task_context`, `search_tasks`, `get_pr_diff`) +
+    harness `Read`/`Bash`/`Glob`/`Write` (для персиста брифа и idempotency-glob). Возвращает путь к
+    файлу брифа + краткое резюме (что нашёл, что дропнул).
+  - **Путь B (override недоступен — codex / pi / antigravity и др.):** inline-фолбэк — оркестратор
+    выполняет 2–4 сам на сессионной модели. Дополнительно допускается эскейп-хатч «переключи
+    модель / запусти сам» в духе preflight-опции «Прогрею сам» (шаг 0.4). Пометить, что сборка inline.
+  - После сборки оркестратор дописывает в бриф строку-маркер:
+    **`Собран на: <tier/модель>, режим: subagent | inline`** (наблюдаемость выбора).
+  - **User-facing warn про существующие артефакты** (текущий шаг 4, «warn, don't block»): пред-скан и
+    warn выполняет **оркестратор ДО диспатча** (сабагент неинтерактивен и не должен спрашивать юзера).
+    Idempotency-glob (перезапись совпавшего брифа) остаётся в persist сабагента. Правило «don't block —
+    continue unless user says no» сохраняется.
+- **Step 5 — Hand-off** (оркестратор). Показать бриф, путь к файлу, invoke `superpowers:brainstorming`.
+  Без изменений.
+
+## Fail-open (инварианты устойчивости)
+
+- Юзер не выбрал / отказался от выбора → дефолт-tier (Sonnet-класс) или inline на сессионной модели.
+- Per-subagent override недоступен → путь B (inline). Никогда не блокируем.
+- Ошибка/пустой возврат сабагента → оркестратор досбирает бриф inline на сессионной модели.
+- Выбор модели НИКОГДА не должен ронять пайплайн — бриф всё равно собирается и передаётся в hand-off.
+
+## Кросс-CLI
+
+- Спрашиваем по **абстрактным tier'ам**, не по именам моделей → формулировка не зависит от конкретного
+  CLI. Клиент сам мапит tier на доступную у него модель.
+- Наличие per-subagent model override — свойство харнесса. Скилл описывает ОБА пути (A и B) и предписывает
+  автодетект: где override есть — путь A, где нет — путь B. Референсы харнессов без override:
+  superpowers platform-refs (codex / pi / antigravity).
+
+## Guard-тест
+
+Файл: `tests/skills/test_solve_task_brief.py` (туда же, где остальные guard-тесты solve-task; читают
+текст `SKILL.md` и проверяют уникальные фразы шагов). Образец — `tests/skills/test_summarize_subsystems.py:35-53`
+(`test_skill_asks_model_choice`, `test_skill_dispatches_subagent_on_chosen_model`).
+
+Новые ассерты (уникальные фразы — их же вписываем в SKILL.md):
+- Шаг выбора модели присутствует: assert фразы вида `"which model tier to use for building the brief"`.
+- Рекомендация дефолта присутствует (mid / Sonnet-класс) — assert соответствующего маркера.
+- Диспатч сабагента на выбранной модели + inline-фолбэк — assert фразы про subagent-on-chosen-model и
+  про inline fallback (зеркало summarize-теста).
+
+## Docs
+
+- `README.md` (EN) + `README.ru.md` (RU): если solve-task описан — добавить строку про выбор модели для
+  брифа (кросс-CLI, рекомендация дешевле). Если не упоминается — пропустить, отметив в отчёте
+  (память проекта: README EN+RU держим синхронно).
+
+## Вне скоупа (YAGNI)
+
+- `plugin/hooks/brief_cost.py` и `tests/hooks/*` — не трогаем (best-effort учёт). Точный sidechain-учёт
+  subagent-токенов — потенциально отдельная PRI-задача, не здесь.
+- `summarize-subsystems` и общий `_common/model-selection.md` include — не делаем (local).
+- Реиндекс base-индекса (dev drift=14) — нерелевантен для markdown-правки.
+
+## Файлы, которые тронем
+
+| Файл | Изменение |
+|---|---|
+| `plugin/skills/solve-task/SKILL.md` | Новый Step 1.5 (выбор модели) + переформулировка шагов 2–4 как brief-building unit (пути A/B) + строка-маркер «Собран на: …». |
+| `tests/skills/test_solve_task_brief.py` | Новые guard-ассерты (выбор модели, дефолт, диспатч+фолбэк). |
+| `README.md`, `README.ru.md` | Строка про выбор модели брифа (если solve-task описан). |

--- a/plugin/skills/solve-task/SKILL.md
+++ b/plugin/skills/solve-task/SKILL.md
@@ -93,8 +93,11 @@ brief to `superpowers:brainstorming` (which leads to writing-plans → subagent-
   session model, or offer the escape-hatch «switch model / run it yourself» in the spirit of the
   preflight «Прогрею сам» option (Step 0.4). Note in the report that the brief was built inline.
 - **Existing-artifacts warn** (Step 4, user-facing «warn, don't block»): the **orchestrator** runs
-  that scan-and-warn **before dispatch** (a subagent must not prompt the user); the idempotency
-  overwrite-glob stays inside the subagent's persist.
+  that scan-and-warn **before dispatch** (a subagent must not prompt the user). It derives the task
+  KEY itself — the same `$ARGUMENTS`-vs-`key_pattern` regex match Step 2 opens with (no `get_task`
+  needed) — so the KEY-based artifact globs run pre-dispatch. When Steps 2–4 run in a subagent, the
+  Step 4 warn is thus **orchestrator-only**; only the idempotency overwrite-glob stays inside the
+  subagent's persist.
 - After the unit returns, the orchestrator **appends a marker line to the brief**:
   `Собран на: <tier/модель>, режим: subagent | inline` — records which model built the brief. The
   `brief_cost` token block is best-effort and may miss subagent sidechain tokens (documented limitation).

--- a/plugin/skills/solve-task/SKILL.md
+++ b/plugin/skills/solve-task/SKILL.md
@@ -73,6 +73,34 @@ brief to `superpowers:brainstorming` (which leads to writing-plans → subagent-
    are `mcp__<task_board.mcp>__*`. No block anywhere (`get_board_config()` → `null`), or the board MCP
    is not connected → board-less mode (continue without it).
 
+1.5. **Choose the brief model (cross-CLI).** Building the brief (Steps 2–4: gather + distill) is a
+   light reasoning task over session-less retrieval tools — a top-tier model is overkill and burns
+   tokens. Before building it, **Ask the user which model tier to use for building the brief**,
+   phrasing the choice by **tier (cheap / mid / premium)** — not by concrete model names — so it
+   works across CLIs (Claude Code, Codex, Gemini, Cursor, …). **Recommend a mid tier (Sonnet-class)
+   as the default** (do not recommend Fable — a coarse tier is fine but the brief still needs sound
+   judgment). Talk to the user in Russian. Remember the choice for this run. Fail-open: no answer or
+   a decline → use the default tier (or, on Path B below, the session model inline). Never block.
+
+**Brief-building unit (Steps 2–4) runs on the chosen model.** Steps 2–4 (identify → gather → distill
+→ persist) are non-interactive; run them on the model chosen in Step 1.5:
+- **Path A — per-subagent model override available:** **dispatch a subagent on the chosen model** to
+  execute Steps 2–4, giving it the reviewer session-less tools (`get_task`, `search_codebase`,
+  `get_subsystem_summaries`, `get_task_context`, `search_tasks`, the graph tools, `get_pr_diff`) plus
+  the harness `Read`/`Bash`/`Glob`/`Write` (to persist the brief). The subagent returns the brief file
+  path and a short summary (kept / dropped).
+- **Path B — per-subagent model override unavailable** (some CLIs): build the brief **inline** on the
+  session model, or offer the escape-hatch «switch model / run it yourself» in the spirit of the
+  preflight «Прогрею сам» option (Step 0.4). Note in the report that the brief was built inline.
+- **Existing-artifacts warn** (Step 4, user-facing «warn, don't block»): the **orchestrator** runs
+  that scan-and-warn **before dispatch** (a subagent must not prompt the user); the idempotency
+  overwrite-glob stays inside the subagent's persist.
+- After the unit returns, the orchestrator **appends a marker line to the brief**:
+  `Собран на: <tier/модель>, режим: subagent | inline` — records which model built the brief. The
+  `brief_cost` token block is best-effort and may miss subagent sidechain tokens (documented limitation).
+- Fail-open: an error or empty return from the subagent → the orchestrator finishes the brief inline
+  on the session model. Model choice must never break the pipeline.
+
 2. **Identify the task.**
    - If `$ARGUMENTS` matches the board's `key_pattern`:
      1. **Store-first.** Call reviewer `get_task(key, project=<task_board.project>)` — it returns the task's own normalized

--- a/tests/skills/test_solve_task_brief.py
+++ b/tests/skills/test_solve_task_brief.py
@@ -77,3 +77,34 @@ def test_solve_task_warns_on_existing_artifacts():
     assert "[Y/n]" in text                       # предупреждение с выбором
     assert "[existing_artifacts]" in text        # тег в Constraints
     assert "Do NOT block" in text or "not block" in text  # не блокировка
+
+
+def test_solve_task_asks_brief_model_choice():
+    """Новый Step 1.5 должен спрашивать у юзера tier модели для сборки брифа."""
+    text = SOLVE.read_text(encoding="utf-8")
+    assert "Ask the user which model tier to use for building the brief" in text, (
+        "нет шага выбора модели для брифа (уникальная фраза шага удалена)"
+    )
+    # Рекомендация-дефолт — mid/Sonnet-класс
+    assert "mid tier (Sonnet-class)" in text, (
+        "скилл не рекомендует mid/Sonnet-класс как дефолт"
+    )
+
+
+def test_solve_task_dispatches_brief_subagent_on_chosen_model():
+    """Путь A: шаги 2–4 диспатчатся сабагентом на выбранной модели; путь B — inline-фолбэк."""
+    text = SOLVE.read_text(encoding="utf-8")
+    assert "dispatch a subagent on the chosen model" in text, (
+        "нет диспатча сабагента на выбранной модели (путь A)"
+    )
+    assert "per-subagent model override unavailable" in text, (
+        "нет inline-фолбэка для CLI без per-subagent override (путь B)"
+    )
+
+
+def test_solve_task_records_brief_model_marker():
+    """Оркестратор дописывает в бриф строку-маркер «Собран на: …»."""
+    text = SOLVE.read_text(encoding="utf-8")
+    assert "Собран на" in text, (
+        "нет строки-маркера «Собран на: <tier/модель>» (наблюдаемость выбора)"
+    )


### PR DESCRIPTION
## Что и зачем (PRI-208)

Этап сборки брифа в скилле `solve-task` (шаги 2–4: gather + distill) — лёгкий reasoning поверх session-less MCP-тулов, топ-модель избыточна. Теперь скилл **перед сборкой брифа спрашивает у юзера, на какой модели её запустить**, рекомендуя более дешёвый tier.

## Изменения

- **`plugin/skills/solve-task/SKILL.md`** — новый **Step 1.5 «Choose the brief model»**: спрашивает tier (**cheap / mid / premium**, а не по именам моделей → кросс-CLI), рекомендует дефолт **mid / Sonnet-класс** (Fable не рекомендует). Шаги 2–4 обёрнуты в **brief-building unit**:
  - **Path A** — где харнесс умеет per-subagent override → диспатч сабагента на выбранной модели;
  - **Path B** — где не умеет (некоторые CLI) → inline-фолбэк (или эскейп-хатч «переключи модель / запусти сам» в духе preflight-опции «Прогрею сам»).
  - Оркестратор дописывает в бриф строку-маркер `Собран на: <tier/модель>, режим: subagent|inline`.
  - Fail-open на всех ветках: выбор модели никогда не роняет пайплайн.
- **`tests/skills/test_solve_task_brief.py`** — 3 guard-теста (TDD, по образцу `test_summarize_subsystems.py`): проверяют присутствие шага, рекомендацию дефолта, диспатч+inline-фолбэк.
- **`README.md` + `README.ru.md`** — синхронно описана фича в секции solve-task; заодно добит отставший RU-буллет MCP-тулов (`get_subsystem_summaries`, `get_task`).
- Трейс: бриф/спека/план в `docs/superpowers/`.

## Границы (осознанно вне скоупа)

- Хук `plugin/hooks/brief_cost.py` **не трогали**: он пропускает sidechain-ходы, поэтому по-модельный учёт токенов для subagent-брифа — **best-effort** (задокументировано; фича пишет строку-маркер модели). Точный sidechain-учёт — кандидат в отдельную задачу.
- `summarize-subsystems` и общий `_common/`-include не трогали (текст шага — solve-task-local).

## Проверка

- `.venv/bin/pytest tests/skills/ -q` → **89 passed**.
- Финальное whole-branch ревью: **Ready to merge — Yes**, 0 Critical/Important.