### PR TITLE
fix(mcp): дефекты учёта шагов/токенов из ревью PRI-209

### DIFF
--- a/plugin/hooks/brief_cost.py
+++ b/plugin/hooks/brief_cost.py
@@ -50,6 +50,11 @@ def render_block(by_model: dict, sidechain: dict | None = None) -> str:
     for model, b in by_model.items():
         lines.extend(_format_bucket(model, b))
         total += _bucket_total(b)
+    # «Всего» — грандтотал этапа (главный агент + sidechain-сабагент), чтобы
+    # подпись «В т.ч. sidechain-сабагент» ниже была корректной: sidechain
+    # действительно входит в «Всего», а не идёт отдельной, не учтённой суммой.
+    if sidechain:
+        total += sum(_bucket_total(b) for b in sidechain.values())
     lines.append(f"Всего: {human_tokens(total)} токенов")
     if sidechain:
         side_total = 0

--- a/reviewer/mcp/service.py
+++ b/reviewer/mcp/service.py
@@ -127,9 +127,9 @@ class MCPReviewService:
             return {"status": "skipped",
                     "reason": f"branch '{e.branch}' not tracked (REVIEW_BRANCHES)"}
         ctx = self._tool_context(prepared)
-        self._sessions[(repo, pr)] = _Session(
-            prepared, ctx, started_at=datetime.now(timezone.utc)
-        )
+        # started_at проставляет default_factory поля _Session.started_at
+        # (datetime.now(timezone.utc)) — явный аргумент здесь был бы дублем.
+        self._sessions[(repo, pr)] = _Session(prepared, ctx)
         store = self._ensure_session_store()
         if store is not None:
             store.save(repo, pr, to_payload(prepared))
@@ -1090,7 +1090,7 @@ class MCPReviewService:
         dry_run: bool,
         posted: bool,
         error: str,
-        session: _Session | None = None,
+        session: _Session,
         metadata: _RunMetadata | None = None,
     ) -> int | None:
         """Записать прогон в историю (fail-soft).
@@ -1110,8 +1110,7 @@ class MCPReviewService:
             if history is None:
                 return None
             now = datetime.now(timezone.utc)
-            started_at = metadata.started_at
-            started = started_at or (session.started_at if session is not None else None) or now
+            started = metadata.started_at or session.started_at or now
             if started.tzinfo is None:
                 started = started.replace(tzinfo=timezone.utc)
             duration_ms = max(0, int((now - started).total_seconds() * 1000))
@@ -1120,18 +1119,20 @@ class MCPReviewService:
             # PRI-156: analyzed — все candidates (до verify-фильтра); грунтовка строк
             # выполнена только для survived, не для отвергнутых candidates.
             findings_analyzed = len({f.fingerprint() for f in analyzed})
-            steps = metadata.steps
-            all_steps = None
-            if session is not None:
-                client_steps = steps or []
-                # PRI-209: не даём клиентскому списку шагов вызвать пиковое O(N)
-                # выделение памяти при слиянии с session.steps.
-                max_client = max(0, _MAX_SESSION_STEPS - len(session.steps))
-                if len(client_steps) > max_client:
-                    client_steps = client_steps[-max_client:]
-                all_steps = session.steps + client_steps
-            elif steps:
-                all_steps = steps[-_MAX_SESSION_STEPS:] if len(steps) > _MAX_SESSION_STEPS else steps
+            # PRI-209: сливаем серверные шаги сессии с клиентскими. session всегда
+            # задан (publish_review → _session, который либо возвращает сессию, либо
+            # бросает ValueError), поэтому ветки на session is None здесь нет.
+            client_steps = metadata.steps or []
+            # Не даём клиентскому списку раздуть слияние с session.steps (пиковое
+            # O(N)-выделение). При заполненной сессии max_client == 0 → отбрасываем
+            # клиентские шаги ЦЕЛИКОМ: срез client_steps[-0:] вернул бы весь список
+            # (отрицательный ноль == ноль), и кэп бы не сработал.
+            max_client = max(0, _MAX_SESSION_STEPS - len(session.steps))
+            if max_client == 0:
+                client_steps = []
+            elif len(client_steps) > max_client:
+                client_steps = client_steps[-max_client:]
+            all_steps = session.steps + client_steps
             if all_steps:
                 # Не мутируем шаги клиента/сессии — копируем перед нормализацией seq.
                 all_steps = [{**step, "seq": i} for i, step in enumerate(all_steps)]

--- a/tests/hooks/test_brief_cost.py
+++ b/tests/hooks/test_brief_cost.py
@@ -144,6 +144,9 @@ def test_render_block_shows_sidechain():
     assert "В т.ч. sidechain-сабагент:" in block
     assert "Модель: side-model" in block
     assert "Sidechain всего: 1.4K токенов" in block
+    # «Всего» — грандтотал: main (1000+2000) + sidechain (500+600+100+200) = 4400.
+    # Подпись «В т.ч.» ниже верна только если sidechain входит в «Всего».
+    assert "Всего: 4.4K токенов" in block
 
 
 def test_read_flag_true_only_when_set():

--- a/tests/mcp/test_publish.py
+++ b/tests/mcp/test_publish.py
@@ -13,7 +13,7 @@ from datetime import datetime, timedelta, timezone
 from unittest.mock import MagicMock, patch
 
 from reviewer.config.settings import Settings
-from reviewer.mcp.service import MCPReviewService
+from reviewer.mcp.service import _MAX_SESSION_STEPS, MCPReviewService
 from reviewer.vcs.base import Finding, PullRequest
 
 # Исходник a.py: строка `x = 1` стоит на строке 2.
@@ -483,6 +483,29 @@ def test_publish_accepts_metadata_override(_ov, _ch) -> None:
     assert run["total_cost"] == 0.00123
     assert run["duration_ms"] >= 0
     assert history.steps[0] == [{"tool": "step1", "seq": 0}]
+
+
+@patch("reviewer.services.review_service.chunk_python", side_effect=_fake_chunk)
+@patch("reviewer.services.review_service.build_overlay")
+def test_publish_caps_client_steps_when_session_full(_ov, _ch) -> None:
+    """PRI-209: при заполненной сессии (session.steps == _MAX_SESSION_STEPS)
+    клиентские шаги отбрасываются целиком.
+
+    Регрессия на баг «отрицательного нуля»: при max_client == 0 срез
+    client_steps[-0:] раньше возвращал ВЕСЬ список клиента, и кэп не срабатывал.
+    """
+    svc, _, history = _make_mcp_service_with_publish()
+    svc.prepare_review("o/r", 7)
+    s = svc._session("o/r", 7)
+    s.steps = [{"stage": "analyze", "seq": i} for i in range(_MAX_SESSION_STEPS)]
+    svc.submit_findings("o/r", 7, [RAW])
+    svc.publish_review(
+        "o/r", 7, summary="s", dry_run=True,
+        steps=[{"tool": "client"} for _ in range(5)],
+    )
+    # Клиентские шаги отброшены целиком: в истории только серверные _MAX_SESSION_STEPS.
+    assert len(history.steps[0]) == _MAX_SESSION_STEPS
+    assert all(step.get("tool") != "client" for step in history.steps[0])
 
 
 @patch("reviewer.services.review_service.chunk_python", side_effect=_fake_chunk)


### PR DESCRIPTION
## Summary
Follow-up к PRI-209 (PR #99, уже смержен): устранены находки авто-ревью.

- **`_record_history` (correctness):** баг «отрицательного нуля» в слиянии шагов — при заполненной сессии (`len(session.steps)==_MAX_SESSION_STEPS`) `max_client==0`, и срез `client_steps[-0:]` протаскивал весь клиентский список, кэп памяти не срабатывал. Теперь при `max_client==0` клиентские шаги отбрасываются целиком.
- **`brief_cost.render_block` (correctness):** «Всего» теперь грандтотал (main + sidechain) — подпись «В т.ч. sidechain-сабагент» стала корректной (sidechain входит в «Всего», а не идёт неучтённой суммой).
- **`_record_history` (maintainability):** `session` сделан обязательным, убрана недостижимая ветка `elif` и опциональность `| None`.
- **`prepare_review` (maintainability):** убран дублирующий явный `started_at` — полагаемся на `default_factory` поля `_Session`.

## Test Plan
- [x] `pytest tests/mcp tests/hooks tests/web` — 213 passed
- [x] `pytest tests/skills` — 92 passed
- [x] Регрессии: `test_publish_caps_client_steps_when_session_full`, грандтотал в `test_render_block_shows_sidechain`
- [x] `ruff check` на изменённых файлах — чисто