### PR TITLE
fix(index): совместимость с pgvector 0.5.0 (сломанный импорт Vector)

### DIFF
--- a/reviewer/index/store.py
+++ b/reviewer/index/store.py
@@ -4,7 +4,8 @@ from dataclasses import dataclass
 from datetime import datetime
 from pathlib import Path
 import re
-from pgvector.psycopg import register_vector, Vector
+from pgvector import Vector
+from pgvector.psycopg import register_vector
 from psycopg_pool import ConnectionPool
 
 _BM25_STRIP = re.compile(r"[^\w\s]")

--- a/reviewer/index/summary_store.py
+++ b/reviewer/index/summary_store.py
@@ -9,7 +9,8 @@ import threading
 from datetime import datetime
 
 import psycopg.errors
-from pgvector.psycopg import Vector, register_vector
+from pgvector import Vector
+from pgvector.psycopg import register_vector
 from psycopg_pool import ConnectionPool
 
 

--- a/reviewer/tasks/store.py
+++ b/reviewer/tasks/store.py
@@ -12,7 +12,8 @@ import re
 import threading
 from dataclasses import dataclass, field
 
-from pgvector.psycopg import Vector, register_vector
+from pgvector import Vector
+from pgvector.psycopg import register_vector
 from psycopg_pool import ConnectionPool
 
 _BM25_STRIP = re.compile(r"[^\w\s]")


### PR DESCRIPTION
## Причина
Джоба **Publish to PyPI** (merge #101, run #73) упала на шаге `pytest -q`: 53 ошибки коллекции, все из одного импорта.

В `pgvector 0.5.0` подпакет `pgvector.psycopg` перестал реэкспортировать `Vector` (класс теперь только на верхнем уровне: `from pgvector import Vector`). CI ставит свежий pgvector (пин `pgvector>=0.3.6`, без верхней границы), поэтому `from pgvector.psycopg import ..., Vector` падал с `ImportError`, что рушило импорт `reviewer.index.store` и коллекцию всего набора.

## Фикс
`from pgvector import Vector` — работает и в 0.4.2 (локально), и в 0.5.0 (CI). `register_vector` остаётся в `pgvector.psycopg`. Правка в трёх стор-модулях.

## Проверка
- Изолированный venv с `pgvector==0.5.0`: старый импорт воспроизводит ошибку CI, новый — импортируется, `Vector([1,2,3])` конструируется.
- Локально (0.4.2): `pytest -q` → 1043 passed, ruff чист.