### PR TITLE
fix(ci): синхронизировать манифесты плагинов с версией 0.3.1

### DIFF
--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "rag-reviewer",
-  "version": "0.3.0+codex.8ccc23a95b2d",
+  "version": "0.3.1+codex.9e2282830dd2",
   "description": "Agentic PR review: hybrid RAG + code graph via MCP, review skills for Codex",
   "repository": "https://github.com/mimfort/rag_for_git",
   "license": "MIT",

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "rag-reviewer",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Agentic PR review: hybrid RAG + code graph via MCP, review skills for Claude Code"
 }

--- a/plugin/.codex-plugin/plugin.json
+++ b/plugin/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "rag-reviewer",
-  "version": "0.3.0+codex.8ccc23a95b2d",
+  "version": "0.3.1+codex.9e2282830dd2",
   "description": "Agentic PR review: hybrid RAG + code graph via MCP, review skills for Codex",
   "repository": "https://github.com/mimfort/rag_for_git",
   "license": "MIT",

--- a/tests/install/test_codex_install.py
+++ b/tests/install/test_codex_install.py
@@ -44,6 +44,12 @@ def result(argv: tuple[str, ...], stdout: str = "", returncode: int = 0) -> Comm
     return CommandResult(argv, returncode, stdout, "failure" if returncode else "")
 
 
+@pytest.fixture
+def stub_uvx(monkeypatch):
+    """Подменяет поиск uvx: launch_command не должен зависеть от PATH раннера."""
+    monkeypatch.setattr("reviewer.install.shutil.which", lambda name: "/opt/uvx")
+
+
 def state_runner(exe, marketplace_data: object, plugin_data: object) -> MappingRunner:
     marketplace_argv = (str(exe), "plugin", "marketplace", "list", "--json")
     plugin_argv = (str(exe), "plugin", "list", "--available", "--json")
@@ -1841,7 +1847,7 @@ def test_plugin_marketplace_metadata_clobber_is_verified_and_rolled_back(
     )
 
 
-def test_mcp_verification_tolerates_codex_plugin_table_spacing(tmp_path):
+def test_mcp_verification_tolerates_codex_plugin_table_spacing(tmp_path, stub_uvx):
     """Codex `plugin add` keeps MCP settings but inserts a blank separator."""
     config = tmp_path / "config.toml"
     plan = generic_install.build_plan(
@@ -1857,7 +1863,7 @@ def test_mcp_verification_tolerates_codex_plugin_table_spacing(tmp_path):
     codex_install._verify_mcp_config(generic_install, config, "latest")
 
 
-def test_mcp_verification_preserves_additive_reviewer_options(tmp_path):
+def test_mcp_verification_preserves_additive_reviewer_options(tmp_path, stub_uvx):
     config = tmp_path / "config.toml"
     plan = generic_install.build_plan(
         generic_install.CLIENTS["codex"], path_override=str(config)
@@ -1878,7 +1884,7 @@ def test_mcp_verification_preserves_additive_reviewer_options(tmp_path):
     ("command", "args", "disabled"),
     ids=("command", "args", "disabled"),
 )
-def test_mcp_verification_rejects_unusable_reviewer_entry(tmp_path, mutation):
+def test_mcp_verification_rejects_unusable_reviewer_entry(tmp_path, mutation, stub_uvx):
     config = tmp_path / "config.toml"
     plan = generic_install.build_plan(
         generic_install.CLIENTS["codex"], path_override=str(config)


### PR DESCRIPTION
## Проблема

После бампа версии `51f2e52` (0.3.0 → 0.3.1, тронул только `pyproject.toml`) CI на `main` красный:

- **Codex Plugin** (ubuntu/macos/windows) — падает шаг `update_codex_plugin_manifest.py --check`: `manifest version '0.3.0+codex...' != '0.3.1+codex...'`
- **Publish to PyPI** — 17 упавших тестов, релиз 0.3.1 не опубликован

## Причины

1. **Рассинхрон версий.** Производные манифесты остались на `0.3.0`: `plugin/.claude-plugin/plugin.json`, `plugin/.codex-plugin/plugin.json`, `.codex-plugin/plugin.json`. Часть тестов (`test_claude_plugin_manifest_version_matches_project_release`, `test_repo_codex_payload_is_synchronized`) и `snapshot verification` в install-тестах сверяют манифест с версией пакета → красное.

2. **Тесты зависели от реального `uv` в PATH.** Пять тестов `test_mcp_verification_*` зовут `build_plan()` без мока `shutil.which`, а `launch_command()` бросает `RuntimeError: uvx/uv не найден`. На машине разработчика `uv` стоит → зелено, на раннере GitHub его нет → красно.

## Фикс

- Все три манифеста синхронизированы на `0.3.1` (`plugin.json` — руками, codex-манифесты — через `scripts/update_codex_plugin_manifest.py`; payload digest пересчитан, т.к. версия Claude-манифеста входит в него).
- Фикстура `stub_uvx` подменяет `reviewer.install.shutil.which` в пяти `test_mcp_verification_*` — тесты больше не зависят от PATH раннера (паттерн уже используется в этом файле).

## Проверка

`env PATH="/usr/bin:/bin:/usr/sbin" pytest -q` (эмуляция раннера без uv) → **1234 passed, 1 skipped**; `update_codex_plugin_manifest.py --check` → OK; `ruff check` → чисто.