### PR TITLE
fix(install): не ломать payload на байткоде и синкать Claude-манифест

### DIFF
--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "rag-reviewer",
-  "version": "0.3.1+codex.9e2282830dd2",
+  "version": "0.3.2+codex.9d551e36d655",
   "description": "Agentic PR review: hybrid RAG + code graph via MCP, review skills for Codex",
   "repository": "https://github.com/mimfort/rag_for_git",
   "license": "MIT",

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "rag-reviewer",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "Agentic PR review: hybrid RAG + code graph via MCP, review skills for Claude Code"
 }

--- a/plugin/.codex-plugin/plugin.json
+++ b/plugin/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "rag-reviewer",
-  "version": "0.3.1+codex.9e2282830dd2",
+  "version": "0.3.2+codex.9d551e36d655",
   "description": "Agentic PR review: hybrid RAG + code graph via MCP, review skills for Codex",
   "repository": "https://github.com/mimfort/rag_for_git",
   "license": "MIT",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "rag-reviewer"
-version = "0.3.1"
+version = "0.3.2"
 description = "AI pull-request reviewer: hybrid RAG + a code graph + Claude Code. Whole-repo context, inline GitHub comments grounded on exact code."
 readme = "README.md"
 license = { text = "MIT" }

--- a/reviewer/install_codex.py
+++ b/reviewer/install_codex.py
@@ -11,7 +11,7 @@ import tomllib
 from uuid import uuid4
 from dataclasses import dataclass
 from datetime import datetime, timezone
-from pathlib import Path
+from pathlib import Path, PurePath, PurePosixPath
 from typing import Any, Callable, Literal, Protocol
 
 PLUGIN_NAME = "rag-reviewer"
@@ -21,7 +21,11 @@ MARKETPLACE_GIT_SOURCE = "https://github.com/mimfort/rag_for_git.git"
 MARKETPLACE_REF = "main"
 MARKETPLACE_SPARSE = (".agents/plugins", "plugin")
 _NORMALIZED_VERSION = "0.0.0+codex.normalized"
-_FORBIDDEN_PAYLOAD_PARTS = {".git", ".env", ".venv", "__pycache__", "build", "dist"}
+_FORBIDDEN_PAYLOAD_PARTS = {".git", ".env", ".venv", "build", "dist"}
+# Байткод — производное от .py, которые уже в digest: запуск хуков плагина не должен
+# ломать install (payload_digest падал на plugin/hooks/__pycache__/*.pyc).
+_IGNORED_PAYLOAD_PARTS = {"__pycache__"}
+_IGNORED_PAYLOAD_SUFFIXES = {".pyc", ".pyo"}
 _WINDOWS_REPARSE_POINT = 0x400
 
 
@@ -86,6 +90,12 @@ def _payload_bytes(path: Path, plugin_root: Path) -> bytes:
     return (json.dumps(data, sort_keys=True, ensure_ascii=False) + "\n").encode()
 
 
+def _is_ignored_payload(rel: PurePath) -> bool:
+    if any(part in _IGNORED_PAYLOAD_PARTS for part in rel.parts):
+        return True
+    return PurePosixPath(rel.as_posix()).suffix in _IGNORED_PAYLOAD_SUFFIXES
+
+
 def payload_digest(plugin_root: Path) -> str:
     _reject_symlink_tree(plugin_root, "plugin payload")
     digest = hashlib.sha256()
@@ -95,6 +105,8 @@ def payload_digest(plugin_root: Path) -> str:
     )
     for path in files:
         rel = path.relative_to(plugin_root)
+        if _is_ignored_payload(rel):
+            continue
         if any(part in _FORBIDDEN_PAYLOAD_PARTS for part in rel.parts):
             raise ValueError(f"forbidden payload path: {rel.as_posix()}")
         rel_bytes = rel.as_posix().encode()
@@ -142,15 +154,22 @@ def sync_plugin_metadata(repo_root: Path, *, check: bool) -> list[str]:
     plugin_root = repo_root / "plugin"
     canonical_path = plugin_root / ".codex-plugin" / "plugin.json"
     project_path = repo_root / ".codex-plugin" / "plugin.json"
+    claude_path = plugin_root / ".claude-plugin" / "plugin.json"
     payload_icon = plugin_root / "assets" / "icon.svg"
     source_icon = repo_root / "assets" / "icon.svg"
+    base_version = project_version(repo_root)
     if not check:
         canonical = json.loads(canonical_path.read_text(encoding="utf-8"))
         canonical.pop("mcpServers", None)
         payload_icon.parent.mkdir(parents=True, exist_ok=True)
         shutil.copyfile(source_icon, payload_icon)
-        canonical["version"] = project_version(repo_root)
+        canonical["version"] = base_version
         canonical_path.write_text(_canonical_json(canonical), encoding="utf-8")
+        claude = json.loads(claude_path.read_text(encoding="utf-8"))
+        claude["version"] = base_version
+        claude_path.write_text(_canonical_json(claude), encoding="utf-8")
+        # digest берётся после записи Claude-манифеста: он лежит внутри payload и,
+        # в отличие от Codex-манифеста, его версия не нормализуется.
         canonical["version"] = expected_plugin_version(repo_root)
         canonical_path.write_text(_canonical_json(canonical), encoding="utf-8")
         project_path.write_text(
@@ -161,6 +180,9 @@ def sync_plugin_metadata(repo_root: Path, *, check: bool) -> list[str]:
     errors: list[str] = []
     canonical = _checked_json(canonical_path, "canonical Codex manifest", errors)
     actual_project = _checked_json(project_path, "root Codex manifest", errors)
+    claude = _checked_json(claude_path, "Claude manifest", errors)
+    if claude is not None and claude.get("version") != base_version:
+        errors.append(f"Claude manifest version {claude.get('version')!r} != {base_version!r}")
     if canonical is not None:
         expected = expected_plugin_version(repo_root)
         if canonical.get("version") != expected:

--- a/tests/install/test_codex_plugin_payload.py
+++ b/tests/install/test_codex_plugin_payload.py
@@ -3,6 +3,8 @@ import json
 import subprocess
 from pathlib import Path, PurePosixPath
 
+import pytest
+
 from reviewer.install_codex import (
     expected_plugin_version,
     payload_digest,
@@ -30,6 +32,9 @@ def _synced_repo(tmp_path: Path) -> Path:
             }
         )
     )
+    claude_manifest = tmp_path / "plugin" / ".claude-plugin" / "plugin.json"
+    claude_manifest.parent.mkdir(parents=True)
+    claude_manifest.write_text(json.dumps({"name": "rag-reviewer", "version": "0.1.0"}))
     (tmp_path / ".codex-plugin").mkdir()
     assert sync_plugin_metadata(tmp_path, check=False) == []
     return tmp_path
@@ -60,6 +65,33 @@ def test_payload_digest_ignores_only_manifest_version(tmp_path):
     assert payload_digest(plugin) == first
     (plugin / "skills" / "ask" / "SKILL.md").write_text("changed")
     assert payload_digest(plugin) != first
+
+
+def test_payload_digest_ignores_python_bytecode_artifacts(tmp_path):
+    """Хуки плагина при запуске оставляют __pycache__ — payload от этого не меняется."""
+    plugin = tmp_path / "plugin"
+    hooks = plugin / "hooks"
+    hooks.mkdir(parents=True)
+    (hooks / "brief_cost.py").write_text("print('cost')\n")
+    clean = payload_digest(plugin)
+
+    cache = hooks / "__pycache__"
+    cache.mkdir()
+    (cache / "brief_cost.cpython-313.pyc").write_bytes(b"\x00bytecode")
+    (hooks / "stray.pyc").write_bytes(b"\x00stray")
+
+    assert payload_digest(plugin) == clean
+
+
+@pytest.mark.parametrize("part", (".git", ".env", ".venv", "build", "dist"))
+def test_payload_digest_still_rejects_forbidden_paths(tmp_path, part):
+    """Секреты и артефакты сборки в payload остаются жёсткой ошибкой."""
+    plugin = tmp_path / "plugin"
+    plugin.mkdir()
+    (plugin / part).write_text("secret")
+
+    with pytest.raises(ValueError, match="forbidden payload path"):
+        payload_digest(plugin)
 
 
 def test_payload_digest_frames_file_boundaries(tmp_path):
@@ -191,6 +223,37 @@ def test_check_reports_invalid_root_manifest(tmp_path):
     (repo / ".codex-plugin" / "plugin.json").write_text("{")
 
     assert "root Codex manifest is invalid" in sync_plugin_metadata(repo, check=True)
+
+
+def test_sync_writes_project_version_into_claude_manifest(tmp_path):
+    """Бамп версии в pyproject доводится до Claude-манифеста, а не только до Codex."""
+    repo = _synced_repo(tmp_path)
+
+    claude = json.loads(
+        (repo / "plugin" / ".claude-plugin" / "plugin.json").read_text(encoding="utf-8")
+    )
+    assert claude["version"] == "1.2.3"
+    assert claude["name"] == "rag-reviewer"
+    assert sync_plugin_metadata(repo, check=True) == []
+
+
+def test_check_reports_claude_manifest_version_drift(tmp_path):
+    repo = _synced_repo(tmp_path)
+    manifest_path = repo / "plugin" / ".claude-plugin" / "plugin.json"
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    manifest["version"] = "0.3.0"
+    manifest_path.write_text(json.dumps(manifest))
+
+    assert "Claude manifest version '0.3.0' != '1.2.3'" in sync_plugin_metadata(
+        repo, check=True
+    )
+
+
+def test_check_reports_missing_claude_manifest(tmp_path):
+    repo = _synced_repo(tmp_path)
+    (repo / "plugin" / ".claude-plugin" / "plugin.json").unlink()
+
+    assert "Claude manifest is missing" in sync_plugin_metadata(repo, check=True)
 
 
 def test_repo_codex_payload_is_synchronized():


### PR DESCRIPTION
Два follow-up фикса к разбору красного CI (#108) — оба про грабли, которые остались бы на будущее.

## 1. `payload_digest` падал на `__pycache__`

Хуки плагина (`plugin/hooks/*.py`) при запуске оставляют байткод, а `__pycache__` лежал в `_FORBIDDEN_PAYLOAD_PARTS` — обход payload бросал `ValueError: forbidden payload path`. В CI дерево чистое, но у пользователя это ломало `reviewer install codex` на шаге `snapshot verification`.

Байткод — производное от `.py`, которые уже входят в digest, поэтому `__pycache__` и `*.pyc/*.pyo` теперь **игнорируются**, а не запрещаются. Запрет на `.git/.env/.venv/build/dist` — это защита от утечки секретов и артефактов сборки в payload, он сохранён и закреплён параметризованным тестом.

Digest реального payload при этом не изменился — манифесты на `main` остаются валидными.

## 2. Бамп версии снова сломал бы CI

`sync_plugin_metadata` вёл только Codex-манифесты, а `plugin/.claude-plugin/plugin.json` надо было править руками — ровно поэтому бамп `0.3.0 → 0.3.1` положил CI. Теперь скрипт синка обновляет и Claude-манифест, а `--check` явно сообщает о рассинхроне (`Claude manifest version '0.3.1' != '0.3.2'`) вместо загадочного расхождения digest.

Порядок важен: Claude-манифест пишется **до** вычисления digest, потому что он лежит внутри payload и его версия, в отличие от Codex-манифеста, не нормализуется.

Проверено симуляцией бампа на `0.3.2`: один прогон `scripts/update_codex_plugin_manifest.py` приводит все три манифеста в согласованное состояние, `--check` зелёный.

## Проверка

`env PATH="/usr/bin:/bin:/usr/sbin" pytest -q` (эмуляция раннера без `uv`) → **1243 passed, 1 skipped**; `ruff check .` → чисто. Тесты написаны до фиксов и падали на старом коде.