### PR TITLE
fix: зелёный CI — синк манифестов 0.3.3 + пул Postgres вне unit-тестов

### DIFF
--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "rag-reviewer",
-  "version": "0.3.2+codex.9d551e36d655",
+  "version": "0.3.3+codex.9aa7a5c3958b",
   "description": "Agentic PR review: hybrid RAG + code graph via MCP, review skills for Codex",
   "repository": "https://github.com/mimfort/rag_for_git",
   "license": "MIT",

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "rag-reviewer",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "description": "Agentic PR review: hybrid RAG + code graph via MCP, review skills for Claude Code"
 }

--- a/plugin/.codex-plugin/plugin.json
+++ b/plugin/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "rag-reviewer",
-  "version": "0.3.2+codex.9d551e36d655",
+  "version": "0.3.3+codex.9aa7a5c3958b",
   "description": "Agentic PR review: hybrid RAG + code graph via MCP, review skills for Codex",
   "repository": "https://github.com/mimfort/rag_for_git",
   "license": "MIT",

--- a/reviewer/web/app.py
+++ b/reviewer/web/app.py
@@ -33,12 +33,15 @@ _FRONTEND_DIST = Path(__file__).parent.parent.parent / "web" / "frontend" / "dis
 def create_app(settings: Settings) -> FastAPI:
     """Создать и настроить FastAPI-приложение.
 
-    - Инициализирует ReviewHistory и schema (fail-soft: если БД недоступна,
-      сервер всё равно стартует с предупреждением).
+    - Инициализирует ReviewHistory; схема создаётся на старте сервера в lifespan
+      (fail-soft: если БД недоступна, сервер всё равно стартует с предупреждением).
     - Монтирует API-роутер (/api/*).
     - Монтирует собранный SPA на / (если dist существует) или отдаёт заглушку.
     - Настраивает CORS для dev-сервера Vite (:5173).
     - При завершении работы закрывает пул соединений к Postgres.
+
+    Пул Postgres создаётся лениво (init_schema — в lifespan, не в теле фабрики),
+    поэтому простое конструирование приложения к БД не подключается.
     """
     history = ReviewHistory(
         settings.pg_dsn,
@@ -48,6 +51,16 @@ def create_app(settings: Settings) -> FastAPI:
 
     @asynccontextmanager
     async def _lifespan(app: FastAPI):
+        # История прогонов: инициализация схемы на старте (fail-soft).
+        try:
+            history.init_schema()
+        except Exception as exc:
+            log.warning(
+                "Не удалось инициализировать схему БД истории (%s). "
+                "Убедитесь, что Postgres запущен: docker compose up -d. "
+                "API-эндпоинты вернут ошибку 500 до подключения к БД.",
+                exc,
+            )
         yield
         history.close()
 
@@ -67,18 +80,7 @@ def create_app(settings: Settings) -> FastAPI:
         allow_headers=["*"],
     )
 
-    # История прогонов
-    try:
-        history.init_schema()
-    except Exception as exc:
-        log.warning(
-            "Не удалось инициализировать схему БД истории (%s). "
-            "Убедитесь, что Postgres запущен: docker compose up -d. "
-            "API-эндпоинты вернут ошибку 500 до подключения к БД.",
-            exc,
-        )
-
-    # API-роутер
+    # API-роутер (схема БД инициализируется в lifespan на старте сервера)
     app.include_router(make_router(history, settings))
 
     # Статика / SPA


### PR DESCRIPTION
## Что и зачем

Чинит красный CI на `dev`/`main` (джобы **Codex Plugin** и **Publish to PyPI**).

### 1. Рассинхрон манифестов плагина (корень падения CI)
PR #112 бампнул версию `0.3.2 → 0.3.3` в `pyproject.toml`, но манифесты плагина не пересобрали. Из-за этого падали `scripts/update_codex_plugin_manifest.py --check` и 12 install-тестов (`test_claude_install`, `test_codex_install`, `test_codex_plugin_payload`).

Пересобрано скриптом синка:
- Claude-манифест → `0.3.3`
- Codex canonical/root → `0.3.3+codex.9aa7a5c3958b` (digest пересчитан по обновлённому payload)

### 2. Пул Postgres при конструировании web-app (латентный дефект)
`create_app()` жадно звал `history.init_schema()`, открывая пул Postgres уже при создании приложения. На машине с собранным фронтом это ловил новый guard изоляции инфраструктуры из PR #111 (`test_spa_fallback_serves_index_on_client_routes` → «Unit-тесту запрещено создание пула Postgres»). В CI фронт не собирается → тест скипался, поэтому дефект не всплывал в джобах.

Инициализация схемы перенесена в startup-часть `lifespan` (fail-soft сохранён). Прод (`reviewer serve` → uvicorn) поведения не меняет; конструирование app без lifespan к БД больше не подключается.

## Проверка
- `update_codex_plugin_manifest.py --check` → exit 0
- `.venv/bin/pytest -q` → **1341 passed, 0 failed**
- `ruff check reviewer/web/app.py` → clean