### PR TITLE
release: зелёный CI — синк манифестов 0.3.3 + пул Postgres вне unit-тестов

### DIFF
--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "rag-reviewer",
-  "version": "0.3.2+codex.9d551e36d655",
+  "version": "0.3.3+codex.9aa7a5c3958b",
   "description": "Agentic PR review: hybrid RAG + code graph via MCP, review skills for Codex",
   "repository": "https://github.com/mimfort/rag_for_git",
   "license": "MIT",

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "rag-reviewer",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "description": "Agentic PR review: hybrid RAG + code graph via MCP, review skills for Claude Code"
 }

--- a/plugin/.codex-plugin/plugin.json
+++ b/plugin/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "rag-reviewer",
-  "version": "0.3.2+codex.9d551e36d655",
+  "version": "0.3.3+codex.9aa7a5c3958b",
   "description": "Agentic PR review: hybrid RAG + code graph via MCP, review skills for Codex",
   "repository": "https://github.com/mimfort/rag_for_git",
   "license": "MIT",

--- a/reviewer/web/app.py
+++ b/reviewer/web/app.py
@@ -33,12 +33,15 @@ _FRONTEND_DIST = Path(__file__).parent.parent.parent / "web" / "frontend" / "dis
 def create_app(settings: Settings) -> FastAPI:
     """Создать и настроить FastAPI-приложение.
 
-    - Инициализирует ReviewHistory и schema (fail-soft: если БД недоступна,
-      сервер всё равно стартует с предупреждением).
+    - Инициализирует ReviewHistory; схема создаётся на старте сервера в lifespan
+      (fail-soft: если БД недоступна, сервер всё равно стартует с предупреждением).
     - Монтирует API-роутер (/api/*).
     - Монтирует собранный SPA на / (если dist существует) или отдаёт заглушку.
     - Настраивает CORS для dev-сервера Vite (:5173).
     - При завершении работы закрывает пул соединений к Postgres.
+
+    Пул Postgres создаётся лениво (init_schema — в lifespan, не в теле фабрики),
+    поэтому простое конструирование приложения к БД не подключается.
     """
     history = ReviewHistory(
         settings.pg_dsn,
@@ -48,6 +51,16 @@ def create_app(settings: Settings) -> FastAPI:
 
     @asynccontextmanager
     async def _lifespan(app: FastAPI):
+        # История прогонов: инициализация схемы на старте (fail-soft).
+        try:
+            history.init_schema()
+        except Exception as exc:
+            log.warning(
+                "Не удалось инициализировать схему БД истории (%s). "
+                "Убедитесь, что Postgres запущен: docker compose up -d. "
+                "API-эндпоинты вернут ошибку 500 до подключения к БД.",
+                exc,
+            )
         yield
         history.close()
 
@@ -67,18 +80,7 @@ def create_app(settings: Settings) -> FastAPI:
         allow_headers=["*"],
     )
 
-    # История прогонов
-    try:
-        history.init_schema()
-    except Exception as exc:
-        log.warning(
-            "Не удалось инициализировать схему БД истории (%s). "
-            "Убедитесь, что Postgres запущен: docker compose up -d. "
-            "API-эндпоинты вернут ошибку 500 до подключения к БД.",
-            exc,
-        )
-
-    # API-роутер
+    # API-роутер (схема БД инициализируется в lifespan на старте сервера)
     app.include_router(make_router(history, settings))
 
     # Статика / SPA


### PR DESCRIPTION
Релиз `dev → main`. Чинит красный CI (Codex Plugin, Publish to PyPI).

- Манифесты плагина синхронизированы с версией 0.3.3 (PR #112 бампнул версию без пересборки).
- `create_app()` больше не открывает пул Postgres при конструировании (init_schema перенесён в lifespan).

Локально: `update_codex_plugin_manifest.py --check` → exit 0; `pytest -q` → 1341 passed. См. PR #114.