### PR TITLE
chore(release): 0.3.4

### DIFF
--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "rag-reviewer",
-  "version": "0.3.3+codex.bcb7220a5d90",
+  "version": "0.3.4+codex.320f247144d7",
   "description": "Agentic PR review: hybrid RAG + code graph via MCP, review skills for Codex",
   "repository": "https://github.com/mimfort/rag_for_git",
   "license": "MIT",

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "rag-reviewer",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "description": "Agentic PR review: hybrid RAG + code graph via MCP, review skills for Claude Code"
 }

--- a/plugin/.codex-plugin/plugin.json
+++ b/plugin/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "rag-reviewer",
-  "version": "0.3.3+codex.bcb7220a5d90",
+  "version": "0.3.4+codex.320f247144d7",
   "description": "Agentic PR review: hybrid RAG + code graph via MCP, review skills for Codex",
   "repository": "https://github.com/mimfort/rag_for_git",
   "license": "MIT",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "rag-reviewer"
-version = "0.3.3"
+version = "0.3.4"
 description = "AI pull-request reviewer: hybrid RAG + a code graph + Claude Code. Whole-repo context, inline GitHub comments grounded on exact code."
 readme = "README.md"
 license = { text = "MIT" }


### PR DESCRIPTION
Бамп версии 0.3.3 → 0.3.4 + пересинк манифестов плагина (Claude `0.3.4`, Codex `0.3.4+codex.320f247144d7`).

Готовит релиз фичи персиста исходов находок (`review_findings.outcome/reject_reason`, PR #116) в main → PyPI.

Тесты: 1367 passed, install 266 passed, `update_codex_plugin_manifest.py --check` exit 0.