### PR TITLE
feat(hooks): проверять пути в solve-task brief (PRI-172)

### DIFF
--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "rag-reviewer",
-  "version": "0.3.5+codex.7efbed8bc9dc",
+  "version": "0.3.5+codex.edabb395477f",
   "description": "Agentic PR review: hybrid RAG + code graph via MCP, review skills for Codex",
   "repository": "https://github.com/mimfort/rag_for_git",
   "license": "MIT",

--- a/docs/superpowers/briefs/2026-07-21-PRI-172-solve-task-brief-path-guard.md
+++ b/docs/superpowers/briefs/2026-07-21-PRI-172-solve-task-brief-path-guard.md
@@ -1,0 +1,52 @@
+# Brief — PRI-172 solve-task: path-level anti-hallucination guard для brief (hook)
+https://ru.yougile.com/team/686c049c8af8/#PRI-172
+
+## Task
+- Задача реальна: prompt-only правило не мешает LLM сослаться в брифе на файл, которого не было в retrieval-выдаче.
+- Добавить stdlib-only `brief_guard.py`: после записи solve-task brief сверять его `path:line` цитаты с путями из tool results и помечать неподтверждённые.
+- Guard должен быть fail-open, идемпотентным, ограниченным `docs/superpowers/briefs/` и иметь `BRIEF_GUARD_DEBUG=1`.
+- Уточнение исходной постановки: это path-level warning, не доказательство корректности строки и не общий schema-validator брифа.
+- Уточнение парсинга: извлекать текст из структурированных `tool_result` блоков в solve-task окне, а не считать доказательством любое совпадение в transcript.
+
+## Related work
+- PRI-209 — переиспользовать проверенный паттерн standalone PostToolUse-хука: окно solve-task, JSONL, sidechain-семантика, fail-open и идемпотентная правка brief.
+- PRI-187 — не дублировать широкую верификацию структуры/caps брифа; PRI-172 отвечает только за grounding пути.
+- (dropped 11: остальные найденные solve-task/anti-hallucination задачи не задают механизм path-level guard либо относятся к общей hygiene/наблюдаемости.)
+
+## Subsystems
+- `plugin/hooks` — существующий `brief_cost` задаёт архитектуру standalone PostToolUse-хука над solve-task transcript и brief-файлом.
+- `tests/hooks` — готовые fixtures и проверки загрузки, fail-open, идемпотентности и регистрации hook-команд.
+
+## Relevant code
+- `plugin/hooks/brief_cost.py:98` — `_message_text` показывает поддерживаемые формы `message.content`; для guard нужен отдельный структурный обход `tool_result` блоков.
+- `plugin/hooks/brief_cost.py:112` — `find_window_start` находит последнее solve-task окно по двум маркерам; семантику следует сохранить.
+- `plugin/hooks/brief_cost.py:196` — `_under_briefs` ограничивает любые in-place изменения каталогом brief-артефактов.
+- `plugin/hooks/brief_cost.py:221` — `_read_jsonl` задаёт tolerant JSONL parsing с пропуском битых строк.
+- `plugin/hooks/brief_cost.py:253` — `run` показывает fail-open orchestration и получение `file_path`/`transcript_path` из hook payload.
+- (dropped 3: MCP service, install verification и config-флаг token cost не участвуют в grounding путей.)
+
+## Test exemplars
+- `tests/hooks/test_brief_cost.py:11` — динамическая загрузка standalone hook без записи `__pycache__`.
+- `tests/hooks/test_brief_cost.py:128` — fixture формата main/sidechain transcript; sidechain rows нельзя исключать, потому что Path A целиком записывается как sidechain.
+- `tests/hooks/test_brief_cost.py:185` — минимальный JSONL transcript fixture для unit/e2e сценариев.
+- `tests/hooks/test_brief_cost.py:196` — end-to-end паттерн `payload → run → изменённый brief`.
+- `tests/hooks/test_brief_cost.py:222` — no-op для файла вне `docs/superpowers/briefs/`.
+- `tests/hooks/test_brief_cost.py:245` — повторный запуск проверяет идемпотентность.
+- `tests/hooks/test_brief_cost.py:263` — guard-тест регистрации PostToolUse `Write`; итоговый config должен содержать одну команду-wrapper, а не два параллельных handler.
+- (dropped 5: token formatting/config и Codex payload tests не определяют поведение path guard.)
+
+## Constraints / open questions
+- [refined_scope] Guard предупреждает только об отсутствующем пути; line-level grounding намеренно остаётся вне задачи из-за несовместимых форматов диапазонов.
+- [refined_scope] Источником истины должны быть tool results текущего solve-task окна; user/assistant prompt text нельзя принимать за retrieval evidence.
+- [refined_scope] Сверять нормализованный repo-relative путь с точным совпадением либо suffix относительно абсолютного префикса; голый basename не должен подтверждать неоднозначные `utils.py`.
+- [refined_scope] Проверять только `## Relevant code` и `## Test exemplars`; Path B требует последний solve-task marker, а markerless Path A разрешён лишь при exact provenance текущего `Write` по payload и assistant tool block с `attributionSkill=rag-reviewer:solve-task`.
+- [refined_scope] Sidechain rows участвуют в evidence. Принимать только связанный user `tool_result` разрешённого reviewer retrieval tool; FastMCP JSON string `result` разворачивать, а Bash, task text и произвольные results отвергать.
+- [refined_scope] До трёх раз ждать появления текущего assistant `Write` tool_use в transcript; timeout означает no-op, связанный tool_result самого `Write` не требуется.
+- [refined_scope] Любой hard-truncation sentinel `[truncated]`, `[...truncated]` или `[…truncated]` в доверенном evidence означает no-op; cliff/rails notes не отключают guard.
+- [refined_scope] Claude запускает matching hook handlers параллельно, поэтому `hooks.json` регистрирует один `brief_post_write.py`, который в одном процессе последовательно и независимо fail-open вызывает cost, затем guard.
+- [platform_limit] `hooks.json` защищает Claude Code `PostToolUse/Write`; у Codex/OpenCode такой hook-контракт отсутствует, это нужно явно задокументировать, а не обещать cross-CLI enforcement.
+- [overlap] PRI-187 остаётся отдельной задачей про полноту/форму brief; не расширять PRI-172 до schema gate.
+- Task отсутствовал в reviewer store после sync, прочитан через YouGile fallback и проиндексирован; связанных PR у PRI-172 нет.
+- Base-index `dev` обновлён перед сбором брифа: drift 0, SCIP-граф доступен; сводки подсистем и task corpus доступны.
+
+Собран на: premium (gpt-5.6-sol), режим: inline

--- a/docs/superpowers/plans/2026-07-21-pri-172-brief-path-guard.md
+++ b/docs/superpowers/plans/2026-07-21-pri-172-brief-path-guard.md
@@ -1,0 +1,661 @@
+# PRI-172 Brief Path Guard Implementation Plan
+
+## Execution correction (final)
+
+Этот раздел отражает финальную реализацию и **заменяет любые конфликтующие указания и snippets в
+Task 1-4 ниже**. В частности, sidechain rows не исключаются, а две отдельные hook-команды не
+регистрируются: наблюдаемый Claude Code запускает matching handlers параллельно.
+
+### Task 5: Закрыть provenance, evidence и freshness gaps
+
+**Files:**
+- Modify: `plugin/hooks/brief_guard.py`
+- Modify: `tests/hooks/test_brief_guard.py`
+
+**TDD regressions:**
+- Path B использует последний solve-task marker; markerless Path A со всеми `isSidechain=true`
+  rows проходит только при exact provenance текущего `Write` по payload
+  `agent_id/tool_use_id/tool_name/file_path` и assistant row
+  `agentId/attributionSkill=rag-reviewer:solve-task`/tool block. Наблюдаемая attribution schema
+  относится к Claude Code 2.1.209; при drift markerless path fail-closed.
+- Transcript читается не более трёх раз до появления текущего assistant `Write` tool use;
+  timeout даёт no-op, current tool result не требуется.
+- Evidence берётся только из linked user tool result для direct/plugin-prefixed
+  `search_codebase`, `related_symbols`, `callers`, `implementations`, `definition`; FastMCP string
+  `result` разворачивается, а Bash, arbitrary, orphan и near-prefix results отвергаются.
+- `[truncated]`, `[...truncated]` и `[…truncated]` дают no-op только в trusted result; cliff/rails
+  notes не останавливают guard. Path matching, last-marker semantics и scope двух code/test секций
+  остаются прежними.
+
+**Verification command/result:**
+- `.venv/bin/pytest -q tests/hooks/test_brief_guard.py` → `48 passed in 0.17s`.
+
+### Task 6: Сериализовать hooks и зафиксировать packaging scope
+
+**Files:**
+- Create: `plugin/hooks/brief_post_write.py`
+- Create: `tests/hooks/test_brief_post_write.py`
+- Modify: `plugin/hooks/hooks.json`
+- Modify: `tests/hooks/test_brief_cost.py`
+- Packaging/generated updates: `.codex-plugin/plugin.json`,
+  `plugin/.codex-plugin/plugin.json`, `uv.lock`
+
+**TDD regressions:**
+- `hooks.json` содержит ровно один `PostToolUse/Write` handler для `brief_post_write.py`.
+- Wrapper в одном процессе передаёт один payload сначала `brief_cost.run`, затем
+  `brief_guard.run`; исключения из cost и guard изолированы, malformed stdin и любой исход
+  возвращают 0.
+- Изменения plugin manifests/lock отражают упаковку нового plugin content и не добавляют runtime
+  semantics guard.
+
+**Verification commands/results:**
+- `.venv/bin/pytest -q tests/hooks/test_brief_guard.py tests/hooks/test_brief_post_write.py tests/hooks/test_brief_cost.py`
+  → `76 passed in 0.10s`.
+- `.venv/bin/ruff check plugin/hooks/brief_guard.py plugin/hooks/brief_post_write.py tests/hooks/test_brief_guard.py tests/hooks/test_brief_post_write.py`
+  → `All checks passed!`.
+
+---
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Помечать в solve-task brief ссылки на файлы, которые не подтверждены code-retrieval tool results текущего transcript-окна.
+
+**Architecture:** Отдельный stdlib-only `brief_guard.py` парсит Claude Code JSONL, извлекает evidence только из `tool_result` code headers и идемпотентно аннотирует две code/test секции. Тонкая fail-open orchestration атомарно пишет файл; существующий `brief_cost.py` не меняется.
+
+**Tech Stack:** Python 3.11+, stdlib (`json`, `os`, `re`, `tempfile`), Claude Code plugin hooks, pytest, Ruff.
+
+---
+
+## File Structure
+
+- Create: `plugin/hooks/brief_guard.py` — transcript parsing, path matching, brief annotation и fail-open entrypoint.
+- Create: `tests/hooks/test_brief_guard.py` — unit/e2e тесты нового hook.
+- Modify: `plugin/hooks/hooks.json` — запуск guard после token-cost hook.
+- Reference only: `plugin/hooks/brief_cost.py` — паттерн payload/JSONL/atomic write; файл не менять.
+
+### Task 1: Transcript evidence parsing и path matching
+
+> **Obsolete assumption:** snippets ниже, исключающие `isSidechain`, сохранены только как история
+> первоначального плана. Финальная семантика задана Task 5 выше.
+
+**Files:**
+- Create: `tests/hooks/test_brief_guard.py`
+- Create: `plugin/hooks/brief_guard.py`
+
+- [ ] **Step 1: Write failing parser and matching tests**
+
+Создать `tests/hooks/test_brief_guard.py` с динамической загрузкой hook и тестами:
+
+```python
+import importlib.util
+import pathlib
+import sys
+
+ROOT = pathlib.Path(__file__).resolve().parents[2]
+HOOK_PATH = ROOT / "plugin" / "hooks" / "brief_guard.py"
+
+
+def _load():
+    spec = importlib.util.spec_from_file_location("brief_guard", HOOK_PATH)
+    mod = importlib.util.module_from_spec(spec)
+    previous = sys.dont_write_bytecode
+    sys.dont_write_bytecode = True
+    try:
+        spec.loader.exec_module(mod)
+    finally:
+        sys.dont_write_bytecode = previous
+    return mod
+
+
+bg = _load()
+
+
+def test_tool_result_texts_excludes_plain_text_and_sidechain():
+    rows = [
+        {"type": "user", "message": {"content": [
+            {"type": "text", "text": "// fake.py#x (fake.py:1-2)"},
+            {"type": "tool_result", "content": "// real.py#f (real.py:1-2)"},
+        ]}},
+        {"type": "user", "isSidechain": True, "message": {"content": [
+            {"type": "tool_result", "content": "// side.py#f (side.py:1-2)"},
+        ]}},
+        {"type": "user", "message": {"content": [
+            {"type": "tool_result", "content": [
+                {"type": "text", "text": "pkg/mod.py#f (pkg/mod.py:4)"},
+            ]},
+        ]}},
+    ]
+    texts = bg.tool_result_texts(rows, 0)
+    assert texts == [
+        "// real.py#f (real.py:1-2)",
+        "pkg/mod.py#f (pkg/mod.py:4)",
+    ]
+
+
+def test_evidence_paths_require_code_header():
+    paths = bg.evidence_paths([
+        "// reviewer/index/store.py#ChunkStore (reviewer/index/store.py:10-40)\n"
+        "task mentions invented.py:20",
+        "tests/test_store.py#test_x (tests/test_store.py:7)",
+    ])
+    assert paths == {"reviewer/index/store.py", "tests/test_store.py"}
+
+
+def test_path_matching_is_exact_or_safe_prefixed_suffix():
+    observed = {"utils.py", "/tmp/worktree/reviewer/index/store.py", "a/utils.py"}
+    assert bg.path_is_observed("utils.py", observed) is True
+    assert bg.path_is_observed("reviewer/index/store.py", observed) is True
+    assert bg.path_is_observed("store.py", observed) is False
+    assert bg.path_is_observed("b/utils.py", observed) is False
+```
+
+- [ ] **Step 2: Run tests to verify RED**
+
+Run: `.venv/bin/pytest -q tests/hooks/test_brief_guard.py`
+
+Expected: collection fails because `plugin/hooks/brief_guard.py` does not exist.
+
+- [ ] **Step 3: Implement minimal parsing and matching core**
+
+Создать начало `plugin/hooks/brief_guard.py`:
+
+```python
+"""PostToolUse-хук: помечает неподтверждённые path:line ссылки solve-task brief."""
+from __future__ import annotations
+
+import json
+import os
+import re
+import sys
+import tempfile
+
+WARNING = "⚠️ [файл не в результатах поиска]"
+SKILL_MARKER = "skills/solve-task"
+BASE_DIR_MARKER = "Base directory for this skill:"
+CHECKED_SECTIONS = {"## Relevant code", "## Test exemplars"}
+
+_HEADER_RE = re.compile(
+    r"(?m)^(?://\s+)?\S*#\S+\s+\(([^()\s]+):\d+(?:-\d+)?\)"
+)
+
+
+def _block_text(content) -> str:
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        return "\n".join(
+            block["text"]
+            for block in content
+            if isinstance(block, dict) and isinstance(block.get("text"), str)
+        )
+    return ""
+
+
+def tool_result_texts(lines: list, start_idx: int) -> list[str]:
+    texts: list[str] = []
+    for line in lines[start_idx + 1:]:
+        if line.get("isSidechain"):
+            continue
+        content = (line.get("message") or {}).get("content")
+        if not isinstance(content, list):
+            continue
+        for block in content:
+            if not isinstance(block, dict) or block.get("type") != "tool_result":
+                continue
+            text = _block_text(block.get("content"))
+            if text:
+                texts.append(text)
+    return texts
+
+
+def normalize_path(path: str) -> str:
+    normalized = path.replace("\\", "/")
+    while "//" in normalized:
+        normalized = normalized.replace("//", "/")
+    while normalized.startswith("./"):
+        normalized = normalized[2:]
+    return normalized
+
+
+def evidence_paths(texts: list[str]) -> set[str]:
+    return {
+        normalize_path(match.group(1))
+        for text in texts
+        for match in _HEADER_RE.finditer(text)
+    }
+
+
+def path_is_observed(cited: str, observed: set[str]) -> bool:
+    cited = normalize_path(cited)
+    if cited in observed:
+        return True
+    if "/" not in cited:
+        return False
+    return any(path.endswith("/" + cited) for path in observed)
+```
+
+- [ ] **Step 4: Run parser tests to verify GREEN**
+
+Run: `.venv/bin/pytest -q tests/hooks/test_brief_guard.py`
+
+Expected: 3 passed.
+
+- [ ] **Step 5: Checkpoint**
+
+Inspect `git diff -- plugin/hooks/brief_guard.py tests/hooks/test_brief_guard.py`. Do not commit unless the user explicitly requests it.
+
+### Task 2: Scoped and idempotent brief annotation
+
+**Files:**
+- Modify: `tests/hooks/test_brief_guard.py`
+- Modify: `plugin/hooks/brief_guard.py`
+
+- [ ] **Step 1: Add failing annotation tests**
+
+Append:
+
+```python
+def test_guard_brief_marks_only_missing_code_and_test_paths():
+    brief = (
+        "# Brief\n"
+        "## Task\nmissing/task.py:1 stays\n"
+        "## Relevant code\n"
+        "- pkg/known.py:10 — known\n"
+        "- pkg/missing.py:20 — missing\n"
+        "## Subsystems\nmissing/subsystem.py:3 stays\n"
+        "## Test exemplars\n- tests/test_missing.py:7 — missing\n"
+        "## Constraints / open questions\nmissing/constraint.py:4 stays\n"
+    )
+    guarded, cited, missing = bg.guard_brief(brief, {"pkg/known.py"})
+    assert "pkg/known.py:10 ⚠️" not in guarded
+    assert f"pkg/missing.py:20 {bg.WARNING}" in guarded
+    assert f"tests/test_missing.py:7 {bg.WARNING}" in guarded
+    assert "missing/task.py:1 stays" in guarded
+    assert "missing/subsystem.py:3 stays" in guarded
+    assert "missing/constraint.py:4 stays" in guarded
+    assert cited == ["pkg/known.py", "pkg/missing.py", "tests/test_missing.py"]
+    assert missing == ["pkg/missing.py", "tests/test_missing.py"]
+
+
+def test_guard_brief_is_idempotent_and_handles_multiple_citations():
+    brief = "## Relevant code\n- a.py:1 calls b.py:2\n"
+    once, _, _ = bg.guard_brief(brief, {"a.py"})
+    twice, _, _ = bg.guard_brief(once, {"a.py"})
+    assert once == twice
+    assert once.count(bg.WARNING) == 1
+    assert f"b.py:2 {bg.WARNING}" in once
+```
+
+- [ ] **Step 2: Run annotation tests to verify RED**
+
+Run: `.venv/bin/pytest -q tests/hooks/test_brief_guard.py -k guard_brief`
+
+Expected: FAIL because `guard_brief` is undefined.
+
+- [ ] **Step 3: Implement scoped annotation**
+
+Add after `path_is_observed`:
+
+```python
+_CITATION_RE = re.compile(r"(?<![\w/.-])([\w./+\\-]+\.[A-Za-z0-9]{1,6}):\d+")
+
+
+def guard_brief(text: str, observed: set[str]) -> tuple[str, list[str], list[str]]:
+    active = False
+    cited: list[str] = []
+    missing: list[str] = []
+    out: list[str] = []
+
+    for line in text.splitlines(keepends=True):
+        heading = line.strip()
+        if heading.startswith("## "):
+            active = heading in CHECKED_SECTIONS
+            out.append(line)
+            continue
+        if not active:
+            out.append(line)
+            continue
+
+        def replace(match: re.Match) -> str:
+            path = normalize_path(match.group(1))
+            cited.append(path)
+            if path_is_observed(path, observed):
+                return match.group(0)
+            missing.append(path)
+            rest = line[match.end():]
+            if rest.lstrip().startswith(WARNING):
+                return match.group(0)
+            return f"{match.group(0)} {WARNING}"
+
+        out.append(_CITATION_RE.sub(replace, line))
+
+    return "".join(out), cited, missing
+```
+
+- [ ] **Step 4: Run annotation tests to verify GREEN**
+
+Run: `.venv/bin/pytest -q tests/hooks/test_brief_guard.py -k guard_brief`
+
+Expected: 2 passed.
+
+- [ ] **Step 5: Run all guard tests**
+
+Run: `.venv/bin/pytest -q tests/hooks/test_brief_guard.py`
+
+Expected: 5 passed.
+
+### Task 3: Fail-open hook orchestration
+
+**Files:**
+- Modify: `tests/hooks/test_brief_guard.py`
+- Modify: `plugin/hooks/brief_guard.py`
+
+- [ ] **Step 1: Add failing end-to-end and no-op tests**
+
+Добавить imports `json` и `os`, затем append:
+
+```python
+_SOLVE_USER = {"type": "user", "message": {"content": [
+    {"type": "text", "text": "Base directory for this skill: skills/solve-task"},
+]}}
+
+
+def _write_transcript(tmp_path, rows):
+    path = tmp_path / "session.jsonl"
+    path.write_text("\n".join(json.dumps(row) for row in rows) + "\n", encoding="utf-8")
+    return path
+
+
+def _brief(tmp_path, body):
+    path = tmp_path / "docs" / "superpowers" / "briefs" / "brief.md"
+    path.parent.mkdir(parents=True)
+    path.write_text(body, encoding="utf-8")
+    return path
+
+
+def _payload(brief, transcript):
+    return {
+        "tool_name": "Write",
+        "tool_input": {"file_path": str(brief)},
+        "transcript_path": str(transcript),
+    }
+
+
+def test_run_marks_missing_path_and_is_idempotent(tmp_path):
+    brief = _brief(tmp_path, "## Relevant code\n- known.py:1\n- missing.py:2\n")
+    transcript = _write_transcript(tmp_path, [
+        _SOLVE_USER,
+        {"type": "user", "message": {"content": [
+            {"type": "tool_result", "content": "// known.py#f (known.py:1-3)"},
+        ]}},
+    ])
+    assert bg.run(_payload(brief, transcript)) == 0
+    first = brief.read_text(encoding="utf-8")
+    assert f"missing.py:2 {bg.WARNING}" in first
+    assert bg.run(_payload(brief, transcript)) == 0
+    assert brief.read_text(encoding="utf-8") == first
+
+
+def test_run_noops_without_evidence_or_with_truncated_result(tmp_path):
+    body = "## Relevant code\n- missing.py:2\n"
+    brief = _brief(tmp_path, body)
+    no_evidence = _write_transcript(tmp_path, [_SOLVE_USER])
+    assert bg.run(_payload(brief, no_evidence)) == 0
+    assert brief.read_text(encoding="utf-8") == body
+
+    truncated = _write_transcript(tmp_path, [
+        _SOLVE_USER,
+        {"type": "user", "message": {"content": [
+            {"type": "tool_result", "content": "// known.py#f (known.py:1)\n[truncated]"},
+        ]}},
+    ])
+    assert bg.run(_payload(brief, truncated)) == 0
+    assert brief.read_text(encoding="utf-8") == body
+
+
+def test_run_noops_outside_briefs_and_without_solve_marker(tmp_path):
+    outside = tmp_path / "spec.md"
+    outside.write_text("## Relevant code\n- missing.py:2\n", encoding="utf-8")
+    transcript = _write_transcript(tmp_path, [{"type": "user", "message": {"content": []}}])
+    assert bg.run(_payload(outside, transcript)) == 0
+    assert bg.run(_payload(_brief(tmp_path, "# Brief\n"), transcript)) == 0
+
+
+def test_run_debug_lists_paths(tmp_path, monkeypatch, capsys):
+    brief = _brief(tmp_path, "## Relevant code\n- missing.py:2\n")
+    transcript = _write_transcript(tmp_path, [
+        _SOLVE_USER,
+        {"type": "user", "message": {"content": [
+            {"type": "tool_result", "content": "// known.py#f (known.py:1)"},
+        ]}},
+    ])
+    monkeypatch.setenv("BRIEF_GUARD_DEBUG", "1")
+    bg.run(_payload(brief, transcript))
+    err = capsys.readouterr().err
+    assert "observed: known.py" in err
+    assert "cited: missing.py" in err
+    assert "missing: missing.py" in err
+```
+
+- [ ] **Step 2: Run orchestration tests to verify RED**
+
+Run: `.venv/bin/pytest -q tests/hooks/test_brief_guard.py -k run`
+
+Expected: FAIL because `run` is undefined.
+
+- [ ] **Step 3: Implement fail-open orchestration and entrypoint**
+
+Append to `brief_guard.py`:
+
+```python
+def _message_text(line: dict) -> str:
+    content = (line.get("message") or {}).get("content")
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        return "\n".join(
+            block["text"]
+            for block in content
+            if isinstance(block, dict) and isinstance(block.get("text"), str)
+        )
+    return ""
+
+
+def find_window_start(lines: list) -> int:
+    start = -1
+    for index, line in enumerate(lines):
+        if line.get("type") != "user":
+            continue
+        text = _message_text(line)
+        if BASE_DIR_MARKER in text and SKILL_MARKER in text:
+            start = index
+    return start
+
+
+def _under_briefs(path: str) -> bool:
+    normalized = os.path.normpath(path).replace(os.sep, "/")
+    return (
+        "/docs/superpowers/briefs/" in normalized
+        or normalized.startswith("docs/superpowers/briefs/")
+    )
+
+
+def _read_text(path):
+    try:
+        with open(path, encoding="utf-8") as handle:
+            return handle.read()
+    except OSError:
+        return None
+
+
+def _read_jsonl(path) -> list:
+    rows: list = []
+    try:
+        with open(path, encoding="utf-8") as handle:
+            for raw in handle:
+                raw = raw.strip()
+                if not raw:
+                    continue
+                try:
+                    rows.append(json.loads(raw))
+                except ValueError:
+                    continue
+    except OSError:
+        return []
+    return rows
+
+
+def _write_text(path, text) -> None:
+    directory = os.path.dirname(path) or "."
+    fd, temporary = tempfile.mkstemp(dir=directory, suffix=".tmp")
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            handle.write(text)
+        os.replace(temporary, path)
+    except Exception:
+        try:
+            os.unlink(temporary)
+        except OSError:
+            pass
+        raise
+
+
+def _debug(label: str, paths) -> None:
+    if os.environ.get("BRIEF_GUARD_DEBUG"):
+        sys.stderr.write(f"brief_guard {label}: {', '.join(sorted(set(paths)))}\n")
+
+
+def run(payload: dict) -> int:
+    try:
+        file_path = (payload.get("tool_input") or {}).get("file_path") or ""
+        if not _under_briefs(file_path):
+            return 0
+        lines = _read_jsonl(payload.get("transcript_path") or "")
+        start = find_window_start(lines)
+        if start < 0:
+            return 0
+        results = tool_result_texts(lines, start)
+        if any("[truncated]" in result for result in results):
+            return 0
+        observed = evidence_paths(results)
+        if not observed:
+            return 0
+        brief = _read_text(file_path)
+        if brief is None:
+            return 0
+        guarded, cited, missing = guard_brief(brief, observed)
+        _debug("observed", observed)
+        _debug("cited", cited)
+        _debug("missing", missing)
+        if guarded != brief:
+            _write_text(file_path, guarded)
+    except Exception:
+        return 0
+    return 0
+
+
+def main() -> int:
+    try:
+        payload = json.load(sys.stdin)
+    except Exception:
+        return 0
+    return run(payload)
+
+
+if __name__ == "__main__":
+    sys.exit(main())
+```
+
+- [ ] **Step 4: Run all guard tests to verify GREEN**
+
+Run: `.venv/bin/pytest -q tests/hooks/test_brief_guard.py`
+
+Expected: 9 passed.
+
+- [ ] **Step 5: Verify malformed JSONL stays fail-open**
+
+В `test_run_marks_missing_path_and_is_idempotent` после `_write_transcript(...)` добавить:
+
+```python
+    valid_transcript = transcript.read_text(encoding="utf-8")
+    transcript.write_text("not-json\n" + valid_transcript, encoding="utf-8")
+```
+
+Это гарантирует, что `_read_jsonl` пропускает битую строку и продолжает использовать валидные
+tool results ниже.
+
+Run: `.venv/bin/pytest -q tests/hooks/test_brief_guard.py::test_run_marks_missing_path_and_is_idempotent`
+
+Expected: PASS.
+
+### Task 4: Hook registration and regression verification
+
+> **Obsolete assumption:** две команды в одном matcher не дают требуемого порядка, потому что
+> Claude запускает matching handlers параллельно. Финальная регистрация wrapper задана Task 6.
+
+**Files:**
+- Modify: `tests/hooks/test_brief_guard.py`
+- Modify: `plugin/hooks/hooks.json`
+
+- [ ] **Step 1: Add failing hook registration test**
+
+Append:
+
+```python
+def test_hooks_json_runs_cost_then_guard():
+    hooks = json.loads((ROOT / "plugin" / "hooks" / "hooks.json").read_text(encoding="utf-8"))
+    entries = hooks["hooks"]["PostToolUse"]
+    write = next(entry for entry in entries if entry.get("matcher") == "Write")
+    commands = [hook["command"] for hook in write["hooks"]]
+    assert len(commands) == 2
+    assert "brief_cost.py" in commands[0]
+    assert "brief_guard.py" in commands[1]
+    assert all("${CLAUDE_PLUGIN_ROOT}" in command for command in commands)
+```
+
+- [ ] **Step 2: Run registration test to verify RED**
+
+Run: `.venv/bin/pytest -q tests/hooks/test_brief_guard.py::test_hooks_json_runs_cost_then_guard`
+
+Expected: FAIL because only `brief_cost.py` is registered.
+
+- [ ] **Step 3: Register the second command**
+
+Изменить `plugin/hooks/hooks.json` hooks array to:
+
+```json
+"hooks": [
+  {
+    "type": "command",
+    "command": "python3 \"${CLAUDE_PLUGIN_ROOT}/hooks/brief_cost.py\""
+  },
+  {
+    "type": "command",
+    "command": "python3 \"${CLAUDE_PLUGIN_ROOT}/hooks/brief_guard.py\""
+  }
+]
+```
+
+- [ ] **Step 4: Run focused hook regression**
+
+Run: `.venv/bin/pytest -q tests/hooks/test_brief_guard.py tests/hooks/test_brief_cost.py`
+
+Expected: all tests pass.
+
+- [ ] **Step 5: Run Ruff on changed Python files**
+
+Run: `.venv/bin/ruff check plugin/hooks/brief_guard.py tests/hooks/test_brief_guard.py`
+
+Expected: `All checks passed!`
+
+- [ ] **Step 6: Run the full unit suite**
+
+Run: `.venv/bin/pytest -q`
+
+Expected: all non-integration tests pass.
+
+- [ ] **Step 7: Inspect final scope**
+
+Run: `git diff --check` and `git diff -- plugin/hooks/brief_guard.py plugin/hooks/hooks.json tests/hooks/test_brief_guard.py docs/superpowers/briefs/2026-07-21-PRI-172-solve-task-brief-path-guard.md docs/superpowers/specs/2026-07-21-pri-172-brief-path-guard-design.md docs/superpowers/plans/2026-07-21-pri-172-brief-path-guard.md`
+
+Expected: no whitespace errors; only PRI-172 implementation and artifacts are shown. Do not alter or stage unrelated untracked user files.

--- a/docs/superpowers/specs/2026-07-21-pri-172-brief-path-guard-design.md
+++ b/docs/superpowers/specs/2026-07-21-pri-172-brief-path-guard-design.md
@@ -1,0 +1,154 @@
+# PRI-172: Path-level guard для solve-task brief
+
+## Цель
+
+Добавить дешёвую детерминированную проверку, которая после записи solve-task brief помечает
+`path:line` ссылки на файлы, отсутствующие в code-retrieval выдаче текущего solve-task окна.
+Guard снижает риск передачи выдуманного пути в planning, но намеренно не валидирует номер строки
+и не заменяет общую проверку структуры brief из PRI-187.
+
+## Scope
+
+- Новый stdlib-only guard `plugin/hooks/brief_guard.py` и same-process wrapper
+  `plugin/hooks/brief_post_write.py`.
+- Один handler в существующем matcher `PostToolUse/Write`: wrapper последовательно вызывает
+  `brief_cost.run(payload)`, затем `brief_guard.run(payload)`.
+- Проверяются только секции `## Relevant code` и `## Test exemplars`.
+- Неподтверждённая цитата сохраняется и получает inline-маркер
+  `⚠️ [файл не в результатах поиска]`.
+- Механический guard доступен только в Claude Code plugin hooks. В клиентах без
+  `PostToolUse/Write` остаётся prompt-контракт solve-task.
+
+Не входят в задачу: line-level validation, schema/caps validation всего brief, новый config-флаг,
+рефакторинг `brief_cost.py`, изменение solve-task skill и cross-CLI hook emulation.
+
+## Архитектура
+
+Claude Code запускает matching hook handlers параллельно. Поэтому `hooks.json` сохраняет один
+`Write` matcher и одну команду `brief_post_write.py`; это не две последовательно
+зарегистрированные команды. Wrapper один раз читает payload и в том же процессе вызывает cost,
+затем guard. Каждый вызов окружён собственным `try/except`, поэтому сбой cost не пропускает guard,
+а сбой guard не меняет успешный результат cost; wrapper всегда возвращает 0.
+
+`brief_guard.py` остаётся отдельно тестируемым executable stdlib-модулем с pure-функциями
+парсинга и тонкой fail-open orchestration `run(payload)`. Он не требует `.review.yml`; отсутствие
+доверенного контекста, schema mismatch или исключение означает no-op.
+
+Есть два transcript path. Path B (main) допускается только после последнего user marker с
+`skills/solve-task` и `Base directory for this skill:`. В Path A transcript сабагента может не
+быть marker, а все rows имеют `isSidechain=true`; такой markerless запуск допускается только при
+точном provenance текущего `Write`: совпадают payload `agent_id`, `tool_use_id`, `tool_name` и
+`tool_input.file_path`, а найденная assistant row имеет тот же `agentId`,
+`attributionSkill=rag-reviewer:solve-task` и соответствующий `Write` tool block. Поля
+`agentId`/`attributionSkill` наблюдались в Claude Code 2.1.209 и не считаются стабильным публичным
+контрактом, поэтому при schema drift markerless path закрывается fail-closed.
+
+## Поток данных
+
+1. Из `payload.tool_input.file_path` берётся путь записанного файла. Путь вне
+   `docs/superpowers/briefs/` немедленно отбрасывается.
+2. JSONL из `payload.transcript_path` читается tolerant-образом максимум три раза, пока не
+   появится assistant `tool_use` с exact `payload.tool_use_id`; между попытками пауза 50 ms.
+   Пустой id или timeout дают no-op. Текущий user `tool_result` для `Write` не требуется.
+3. Для Path B выбирается последнее solve-task окно. Если marker отсутствует, применяется
+   fail-closed provenance-проверка Path A; при успехе рассматривается весь markerless transcript.
+   Sidechain rows не фильтруются ни в одном path.
+4. Evidence принимается только из user `tool_result`, чей `tool_use_id` связан с предшествующим
+   assistant `tool_use` из allowlist. Разрешены direct/plugin prefixes `mcp__reviewer__` и
+   `mcp__plugin_rag-reviewer_reviewer__` для `search_codebase`, `related_symbols`, `callers`,
+   `implementations`, `definition`. Bash, task/обычный text, orphan results, near-prefix и другие
+   tools отвергаются.
+5. `tool_result.content` поддерживается как строка и как список text-блоков. Если строка является
+   FastMCP JSON envelope с string-полем `result`, evidence берётся из этого поля.
+6. Evidence path извлекается только из code/graph headers вида
+   `// path#fqn (path:start-end)` или `path#fqn (path:line)`. Произвольный `path:line` внутри
+   task/search text не подтверждает цитату.
+7. Brief обрабатывается построчно. Состояние проверки включается после точного заголовка
+   `## Relevant code` или `## Test exemplars` и выключается на следующем заголовке `## `.
+8. В проверяемых строках извлекаются цитаты формата `path.ext:line`. Для каждой цитаты
+   выполняется нормализация и matching. Неподтверждённая цитата получает inline-маркер.
+9. Файл атомарно заменяется через временный файл только если текст реально изменился.
+
+## Matching путей
+
+Нормализация заменяет `\\` на `/`, удаляет начальный `./` и повторные `/`. Основное правило —
+точное совпадение repository-relative путей.
+
+Suffix-match нужен только для observed path с внешним абсолютным/worktree-префиксом:
+`/tmp/worktree/reviewer/index/store.py` подтверждает `reviewer/index/store.py`. Он разрешён лишь
+когда цитата содержит `/`. Поэтому голая цитата `utils.py` не подтверждается найденным
+`a/utils.py`; root-level `utils.py` подтверждается только точным observed path `utils.py`.
+
+Номер строки извлекается для определения цитаты, но не участвует в matching.
+
+## Идемпотентность
+
+Маркер добавляется непосредственно после конкретной цитаты. Перед вставкой guard проверяет текст
+между концом match и концом строки; если там уже начинается тот же маркер, повторной вставки нет.
+Это поддерживает строки с несколькими цитатами и повторный PostToolUse запуск без накопления
+warning-текста.
+
+## Fail-open и диагностика
+
+Guard возвращает exit code 0 при любом исходе. Файл не меняется, если:
+
+- путь не относится к brief-каталогу;
+- нет transcript, текущего `Write` tool use или читаемого brief;
+- нет последнего solve-task marker и exact markerless Path A provenance;
+- после фильтрации нет ни одного evidence path;
+- любой доверенный tool result содержит hard-truncation sentinel `[truncated]`,
+  `[...truncated]` или `[…truncated]`;
+- чтение, парсинг или атомарная запись завершились исключением.
+
+Сообщения `(граф недоступен)` и `(ничего не найдено)` не считаются ошибкой и просто не добавляют
+evidence. Adaptive cliff/rails notes и похожие не-sentinel сообщения не отключают guard.
+
+При `BRIEF_GUARD_DEBUG=1` hook печатает в stderr нормализованные observed, cited и missing paths.
+Без флага stdout/stderr остаются пустыми.
+
+## Тестирование
+
+Новый `tests/hooks/test_brief_guard.py` загружает скрипт через `importlib` без создания bytecode и
+проверяет:
+
+- exact linkage user result к allowlisted direct/plugin tool use, FastMCP unwrap и отказ от
+  arbitrary/Bash/orphan/near-prefix evidence;
+- Path B по последнему marker и markerless Path A по exact current-Write provenance, включая
+  transcript, состоящий из sidechain rows;
+- bounded freshness polling, no-op без текущего tool use и отсутствие требования current
+  `tool_result`;
+- извлечение evidence headers;
+- exact match и suffix-match абсолютного префикса;
+- отказ принимать basename вложенного файла и корректность для двух `utils.py`;
+- проверку только `Relevant code`/`Test exemplars`;
+- inline marking отсутствующего пути, несколько цитат и идемпотентность;
+- no-op вне briefs, без trusted context/evidence и при трёх hard-truncation sentinel;
+- продолжение guard при cliff/rails notes и игнорирование truncation из недоверенного tool;
+- tolerant parsing битого JSONL и fail-open orchestration;
+- debug output в stderr;
+- регистрацию единственного wrapper в `hooks.json`.
+
+`tests/hooks/test_brief_post_write.py` отдельно фиксирует same-payload порядок cost → guard,
+независимый fail-open обоих вызовов и malformed stdin. Регрессия в
+`tests/hooks/test_brief_cost.py` также требует ровно один registered wrapper. Проверки выполняются
+unit-командами без сети и инфраструктуры, затем запускается Ruff для изменённых Python-файлов.
+
+## File scope
+
+- Созданы `plugin/hooks/brief_guard.py`, `plugin/hooks/brief_post_write.py`,
+  `tests/hooks/test_brief_guard.py` и `tests/hooks/test_brief_post_write.py`.
+- Изменены `plugin/hooks/hooks.json` и registration regression в
+  `tests/hooks/test_brief_cost.py`.
+- Обновления `.codex-plugin/plugin.json` и `plugin/.codex-plugin/plugin.json` являются
+  packaging/generated consequence нового plugin content, а не дополнительной runtime-логикой
+  guard.
+
+## Критерии приёмки
+
+- Подтверждённые code/test citations остаются без изменений.
+- Неподтверждённые citations получают ровно один inline-маркер.
+- Ссылки вне двух code/test секций не меняются.
+- Неоднозначный basename не подтверждается suffix-match вложенного файла.
+- Недостаток или усечение evidence не портит brief.
+- Существующий `brief_cost` продолжает работать без изменений.
+- Все новые и существующие unit-тесты и Ruff проходят.

--- a/plugin/.codex-plugin/plugin.json
+++ b/plugin/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "rag-reviewer",
-  "version": "0.3.5+codex.7efbed8bc9dc",
+  "version": "0.3.5+codex.edabb395477f",
   "description": "Agentic PR review: hybrid RAG + code graph via MCP, review skills for Codex",
   "repository": "https://github.com/mimfort/rag_for_git",
   "license": "MIT",

--- a/plugin/hooks/brief_guard.py
+++ b/plugin/hooks/brief_guard.py
@@ -1,0 +1,352 @@
+"""Проверка подтверждённых путей для PostToolUse-хука solve-task brief."""
+from __future__ import annotations
+
+import json
+import os
+import re
+import sys
+import tempfile
+import time
+
+WARNING = "⚠️ [файл не в результатах поиска]"
+SKILL_MARKER = "skills/solve-task"
+BASE_DIR_MARKER = "Base directory for this skill:"
+SOLVE_ATTRIBUTION = "rag-reviewer:solve-task"
+CHECKED_SECTIONS = ("## Relevant code", "## Test exemplars")
+MCP_TOOL_PREFIXES = (
+    "mcp__reviewer__",
+    "mcp__plugin_rag-reviewer_reviewer__",
+)
+ALLOWED_LOGICAL_TOOLS = frozenset({
+    "search_codebase",
+    "related_symbols",
+    "callers",
+    "implementations",
+    "definition",
+})
+ALLOWED_TOOL_NAMES = frozenset(
+    prefix + logical
+    for prefix in MCP_TOOL_PREFIXES
+    for logical in ALLOWED_LOGICAL_TOOLS
+)
+
+_HEADER_RE = re.compile(
+    r"^\s*(?://\s*)?\S+#\S+\s+\((?P<path>[^()\r\n]+?):\d+(?:-\d+)?\)",
+    re.MULTILINE,
+)
+_CITATION_RE = re.compile(
+    r"([A-Za-z0-9_./\\+\-]+\.[A-Za-z0-9]{1,6}):\d+(?:-\d+)?"
+)
+_INCOMPLETE_RE = re.compile(r"\[(?:\.\.\.|…)?truncated\]")
+
+
+def _block_text(content: object) -> str:
+    """Вернуть текст строкового content или его вложенных text-блоков."""
+    if isinstance(content, str):
+        return content
+    if not isinstance(content, list):
+        return ""
+    return "\n".join(
+        block["text"]
+        for block in content
+        if isinstance(block, dict) and isinstance(block.get("text"), str)
+    )
+
+
+def _message_text(line: dict) -> str:
+    """Вернуть текст строкового message.content или его text-блоков."""
+    message = line.get("message")
+    if not isinstance(message, dict):
+        return ""
+    return _block_text(message.get("content"))
+
+
+def find_window_start(lines: list[dict]) -> int:
+    """Найти последнее user-сообщение с обоими маркерами solve-task."""
+    start = -1
+    for index, line in enumerate(lines):
+        if line.get("type") != "user":
+            continue
+        text = _message_text(line)
+        if BASE_DIR_MARKER in text and SKILL_MARKER in text:
+            start = index
+    return start
+
+
+def tool_result_texts(lines: list[dict], start_idx: int) -> list[str]:
+    """Собрать связанные результаты разрешённых retrieval-вызовов."""
+    texts: list[str] = []
+    allowed_ids: set[str] = set()
+    for line in lines[start_idx + 1:]:
+        content = (line.get("message") or {}).get("content")
+        if not isinstance(content, list):
+            continue
+        for block in content:
+            if not isinstance(block, dict):
+                continue
+            if line.get("type") == "assistant" and block.get("type") == "tool_use":
+                tool_id = block.get("id")
+                if (
+                    isinstance(tool_id, str)
+                    and block.get("name") in ALLOWED_TOOL_NAMES
+                ):
+                    allowed_ids.add(tool_id)
+                continue
+            if (
+                line.get("type") != "user"
+                or block.get("type") != "tool_result"
+                or block.get("tool_use_id") not in allowed_ids
+            ):
+                continue
+            text = _block_text(block.get("content"))
+            if text:
+                try:
+                    envelope = json.loads(text)
+                except ValueError:
+                    envelope = None
+                if isinstance(envelope, dict) and isinstance(envelope.get("result"), str):
+                    text = envelope["result"]
+                texts.append(text)
+    return texts
+
+
+def normalize_path(path: str) -> str:
+    """Нормализовать разделители без разрешения пути через файловую систему."""
+    path = re.sub(r"/+", "/", path.replace("\\", "/"))
+    while path.startswith("./"):
+        path = path[2:]
+    return path
+
+
+def evidence_paths(texts: list[str]) -> set[str]:
+    """Извлечь пути только из заголовков результатов поиска кода."""
+    return {
+        normalize_path(match.group("path"))
+        for text in texts
+        for match in _HEADER_RE.finditer(text)
+    }
+
+
+def _result_is_incomplete(text: str) -> bool:
+    """Проверить наличие точного sentinel жёсткого усечения результата."""
+    return bool(_INCOMPLETE_RE.search(text))
+
+
+def path_is_observed(cited: str, observed: set[str]) -> bool:
+    """Проверить exact или suffix repo-relative пути во внешнем absolute path."""
+    cited = normalize_path(cited)
+    for candidate in observed:
+        candidate = normalize_path(candidate)
+        if candidate == cited:
+            return True
+        is_absolute = candidate.startswith("/") or bool(
+            re.match(r"^[A-Za-z]:/", candidate)
+        )
+        if is_absolute and "/" in cited and candidate.endswith("/" + cited):
+            return True
+    return False
+
+
+def guard_brief(text: str, observed: set[str]) -> tuple[str, list[str], list[str]]:
+    """Пометить неподтверждённые пути в проверяемых секциях brief."""
+    cited: list[str] = []
+    missing: list[str] = []
+    guarded_lines: list[str] = []
+    active = False
+
+    for line in text.splitlines(keepends=True):
+        heading = line.rstrip("\r\n")
+        if heading.startswith("## "):
+            active = heading in CHECKED_SECTIONS
+            guarded_lines.append(line)
+            continue
+        if not active:
+            guarded_lines.append(line)
+            continue
+
+        def annotate(match: re.Match[str]) -> str:
+            path = normalize_path(match.group(1))
+            cited.append(path)
+            if path_is_observed(path, observed):
+                return match.group(0)
+            missing.append(path)
+            following = line[match.end():]
+            if re.match(r"[ \t]*" + re.escape(WARNING), following):
+                return match.group(0)
+            return f"{match.group(0)} {WARNING}"
+
+        guarded_lines.append(_CITATION_RE.sub(annotate, line))
+
+    return "".join(guarded_lines), cited, missing
+
+
+def _under_briefs(path: str) -> bool:
+    norm = os.path.normpath(path).replace(os.sep, "/")
+    return "/docs/superpowers/briefs/" in norm or norm.startswith(
+        "docs/superpowers/briefs/"
+    )
+
+
+def _read_text(path: str) -> str | None:
+    try:
+        with open(path, encoding="utf-8") as handle:
+            return handle.read()
+    except OSError:
+        return None
+
+
+def _read_jsonl(path: str) -> list[dict]:
+    rows: list[dict] = []
+    try:
+        with open(path, encoding="utf-8") as handle:
+            for line in handle:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    row = json.loads(line)
+                except ValueError:
+                    continue
+                if isinstance(row, dict):
+                    rows.append(row)
+    except OSError:
+        return []
+    return rows
+
+
+def _find_tool_use(
+    lines: list[dict],
+    tool_use_id: str,
+) -> tuple[dict, dict] | None:
+    """Найти assistant-строку и tool_use с точным id."""
+    for line in lines:
+        if line.get("type") != "assistant":
+            continue
+        content = (line.get("message") or {}).get("content")
+        if not isinstance(content, list):
+            continue
+        for block in content:
+            if (
+                isinstance(block, dict)
+                and block.get("type") == "tool_use"
+                and block.get("id") == tool_use_id
+            ):
+                return line, block
+    return None
+
+
+def _read_fresh_transcript(
+    path: str,
+    tool_use_id: object,
+) -> tuple[list[dict], tuple[dict, dict] | None]:
+    """Дождаться появления текущего tool_use в transcript."""
+    if not isinstance(tool_use_id, str) or not tool_use_id:
+        return [], None
+    for attempt in range(3):
+        lines = _read_jsonl(path)
+        current = _find_tool_use(lines, tool_use_id)
+        if current is not None:
+            return lines, current
+        if attempt < 2:
+            time.sleep(0.05)
+    return [], None
+
+
+def _markerless_write_is_trusted(
+    payload: dict,
+    row: dict,
+    block: dict,
+) -> bool:
+    """Проверить provenance текущего Path A Write без skill marker."""
+    agent_id = payload.get("agent_id")
+    tool_input = payload.get("tool_input")
+    block_input = block.get("input")
+    return bool(
+        agent_id
+        and row.get("type") == "assistant"
+        and row.get("agentId") == agent_id
+        and row.get("attributionSkill") == SOLVE_ATTRIBUTION
+        and block.get("type") == "tool_use"
+        and block.get("id") == payload.get("tool_use_id")
+        and block.get("name") == payload.get("tool_name") == "Write"
+        and isinstance(tool_input, dict)
+        and isinstance(block_input, dict)
+        and block_input.get("file_path") == tool_input.get("file_path")
+    )
+
+
+def _write_text(path: str, text: str) -> None:
+    directory = os.path.dirname(path) or "."
+    fd, temp_path = tempfile.mkstemp(dir=directory, suffix=".tmp")
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            handle.write(text)
+        os.replace(temp_path, path)
+    except Exception:
+        try:
+            os.unlink(temp_path)
+        except OSError:
+            pass
+        raise
+
+
+def _debug(label: str, paths: list[str] | set[str]) -> None:
+    if os.environ.get("BRIEF_GUARD_DEBUG"):
+        rendered = ", ".join(sorted(set(paths)))
+        sys.stderr.write(f"brief_guard {label}: {rendered}\n")
+
+
+def run(payload: dict) -> int:
+    """Оркестрация fail-open хука проверки brief."""
+    try:
+        file_path = (payload.get("tool_input") or {}).get("file_path") or ""
+        if not _under_briefs(file_path):
+            return 0
+
+        lines, current = _read_fresh_transcript(
+            payload.get("transcript_path") or "",
+            payload.get("tool_use_id"),
+        )
+        if not lines or current is None:
+            return 0
+        start = find_window_start(lines)
+        if start < 0:
+            current_row, current_block = current
+            if not _markerless_write_is_trusted(
+                payload,
+                current_row,
+                current_block,
+            ):
+                return 0
+
+        result_texts = tool_result_texts(lines, start)
+        if any(_result_is_incomplete(text) for text in result_texts):
+            return 0
+        observed = evidence_paths(result_texts)
+        if not observed:
+            return 0
+
+        brief = _read_text(file_path)
+        if brief is None:
+            return 0
+        guarded, cited, missing = guard_brief(brief, observed)
+        _debug("observed", observed)
+        _debug("cited", cited)
+        _debug("missing", missing)
+        if guarded != brief:
+            _write_text(file_path, guarded)
+    except Exception:
+        return 0
+    return 0
+
+
+def main() -> int:
+    try:
+        payload = json.load(sys.stdin)
+    except Exception:
+        return 0
+    return run(payload)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/plugin/hooks/brief_post_write.py
+++ b/plugin/hooks/brief_post_write.py
@@ -1,0 +1,32 @@
+"""Последовательно запускает PostToolUse-хуки записи brief."""
+
+import json
+import sys
+
+import brief_cost
+import brief_guard
+
+
+def run(payload: dict) -> int:
+    """Запустить cost и guard по порядку, независимо и fail-open."""
+    try:
+        brief_cost.run(payload)
+    except Exception:
+        pass
+    try:
+        brief_guard.run(payload)
+    except Exception:
+        pass
+    return 0
+
+
+def main() -> int:
+    try:
+        payload = json.load(sys.stdin)
+    except Exception:
+        return 0
+    return run(payload)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/plugin/hooks/hooks.json
+++ b/plugin/hooks/hooks.json
@@ -6,7 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python3 \"${CLAUDE_PLUGIN_ROOT}/hooks/brief_cost.py\""
+            "command": "python3 \"${CLAUDE_PLUGIN_ROOT}/hooks/brief_post_write.py\""
           }
         ]
       }

--- a/tests/hooks/test_brief_cost.py
+++ b/tests/hooks/test_brief_cost.py
@@ -23,9 +23,14 @@ def _load():
 bc = _load()
 
 
-def test_hook_import_does_not_create_bytecode_cache():
+def test_hook_import_does_not_create_new_bytecode_cache():
     cache = HOOK_PATH.parent / "__pycache__"
-    assert not list(cache.glob("brief_cost*.pyc"))
+    before = set(cache.glob("brief_cost*.pyc"))
+
+    _load()
+
+    after = set(cache.glob("brief_cost*.pyc"))
+    assert after == before
 
 
 def test_human_tokens_formats_k_and_m():
@@ -255,14 +260,18 @@ def test_run_replaces_on_rerun(tmp_path):
     assert out.count("## Токены (этап solve-task)") == 1
 
 
-def test_hooks_json_registers_posttooluse_write():
+def test_hooks_json_registers_single_posttooluse_write_wrapper():
     hooks = json.loads((ROOT / "plugin" / "hooks" / "hooks.json").read_text(encoding="utf-8"))
     entries = hooks["hooks"]["PostToolUse"]
     write_entries = [e for e in entries if e.get("matcher") == "Write"]
-    assert write_entries, "нужен PostToolUse-матчер на Write"
-    command = write_entries[0]["hooks"][0]["command"]
-    assert "brief_cost.py" in command
+    assert len(write_entries) == 1, "нужен ровно один PostToolUse-матчер на Write"
+    write_hooks = write_entries[0]["hooks"]
+    assert len(write_hooks) == 1
+    command = write_hooks[0]["command"]
+    assert "brief_post_write.py" in command
     assert "${CLAUDE_PLUGIN_ROOT}" in command
+    assert "brief_cost.py" not in command
+    assert "brief_guard.py" not in command
 
 
 def test_read_flag_fallback_block_style_true():

--- a/tests/hooks/test_brief_guard.py
+++ b/tests/hooks/test_brief_guard.py
@@ -1,0 +1,734 @@
+"""Unit-тесты разбора evidence для PostToolUse-хука brief_guard."""
+import importlib.util
+import json
+import pathlib
+import sys
+
+import pytest
+
+ROOT = pathlib.Path(__file__).resolve().parents[2]
+HOOK_PATH = ROOT / "plugin" / "hooks" / "brief_guard.py"
+
+
+def _load():
+    spec = importlib.util.spec_from_file_location("brief_guard", HOOK_PATH)
+    mod = importlib.util.module_from_spec(spec)
+    previous = sys.dont_write_bytecode
+    sys.dont_write_bytecode = True
+    try:
+        spec.loader.exec_module(mod)
+    finally:
+        sys.dont_write_bytecode = previous
+    return mod
+
+
+bg = _load()
+
+_SOLVE_USER = {"type": "user", "message": {"content": [
+    {"type": "text", "text": "Base directory for this skill: skills/solve-task"},
+]}}
+_SOLVE_ATTRIBUTION = "rag-reviewer:solve-task"
+_WRITE_ID = "write-brief"
+
+
+def test_hooks_json_runs_single_sequential_wrapper():
+    config = json.loads(
+        (ROOT / "plugin" / "hooks" / "hooks.json").read_text(encoding="utf-8")
+    )
+    write_entries = [
+        entry
+        for entry in config["hooks"]["PostToolUse"]
+        if entry["matcher"] == "Write"
+    ]
+    commands = [
+        hook["command"]
+        for entry in write_entries
+        for hook in entry["hooks"]
+    ]
+
+    assert len(write_entries) == 1
+    assert commands == [
+        'python3 "${CLAUDE_PLUGIN_ROOT}/hooks/brief_post_write.py"'
+    ]
+    assert all("brief_cost.py" not in command for command in commands)
+    assert all("brief_guard.py" not in command for command in commands)
+
+
+def _write_transcript(tmp_path, rows):
+    transcript = tmp_path / "session.jsonl"
+    transcript.write_text(
+        "\n".join(json.dumps(row) for row in rows) + "\n", encoding="utf-8"
+    )
+    return transcript
+
+
+def _brief(tmp_path, body):
+    briefs = tmp_path / "docs" / "superpowers" / "briefs"
+    briefs.mkdir(parents=True)
+    brief = briefs / "task.md"
+    brief.write_text(body, encoding="utf-8")
+    return brief
+
+
+def _tool_use(
+    tool_id,
+    name,
+    *,
+    sidechain=False,
+    agent_id=None,
+    attribution_skill=None,
+    tool_input=None,
+):
+    block = {
+        "type": "tool_use",
+        "id": tool_id,
+        "name": name,
+    }
+    if tool_input is not None:
+        block["input"] = tool_input
+    row = {"type": "assistant", "message": {"content": [block]}}
+    if sidechain:
+        row["isSidechain"] = True
+    if agent_id is not None:
+        row["agentId"] = agent_id
+    if attribution_skill is not None:
+        row["attributionSkill"] = attribution_skill
+    return row
+
+
+def _tool_result(tool_id, content, *, sidechain=False, agent_id=None):
+    row = {"type": "user", "message": {"content": [{
+        "type": "tool_result",
+        "tool_use_id": tool_id,
+        "content": content,
+    }]}}
+    if sidechain:
+        row["isSidechain"] = True
+    if agent_id is not None:
+        row["agentId"] = agent_id
+    return row
+
+
+def _retrieval_rows(
+    content,
+    *,
+    sidechain=False,
+    tool_id="search",
+    agent_id=None,
+    attribution_skill=None,
+):
+    return [
+        _tool_use(
+            tool_id,
+            "mcp__reviewer__search_codebase",
+            sidechain=sidechain,
+            agent_id=agent_id,
+            attribution_skill=attribution_skill,
+        ),
+        _tool_result(
+            tool_id,
+            content,
+            sidechain=sidechain,
+            agent_id=agent_id,
+        ),
+    ]
+
+
+def _write_call(
+    *,
+    sidechain=False,
+    tool_id=_WRITE_ID,
+    name="Write",
+    agent_id=None,
+    attribution_skill=None,
+    file_path=None,
+):
+    tool_input = None if file_path is None else {"file_path": file_path}
+    return _tool_use(
+        tool_id,
+        name,
+        sidechain=sidechain,
+        agent_id=agent_id,
+        attribution_skill=attribution_skill,
+        tool_input=tool_input,
+    )
+
+
+def _payload(brief, transcript, *, agent_id=None):
+    payload = {
+        "tool_name": "Write",
+        "tool_use_id": _WRITE_ID,
+        "tool_input": {"file_path": str(brief)},
+        "transcript_path": str(transcript),
+    }
+    if agent_id is not None:
+        payload["agent_id"] = agent_id
+    return payload
+
+
+def test_tool_result_texts_accepts_only_linked_allowed_retrieval_calls():
+    rows = [
+        {"type": "user", "isSidechain": True, "message": {"content": "start"}},
+        {"type": "assistant", "isSidechain": True, "message": {"content": [
+            {
+                "type": "tool_use",
+                "id": "direct-search",
+                "name": "mcp__reviewer__search_codebase",
+            },
+            {
+                "type": "tool_use",
+                "id": "plugin-graph",
+                "name": "mcp__plugin_rag-reviewer_reviewer__related_symbols",
+            },
+            {"type": "tool_use", "id": "bash", "name": "Bash"},
+            {"type": "text", "text": "// plain.py#f (plain.py:1)"},
+        ]}},
+        {"type": "user", "isSidechain": True, "message": {"content": [
+            {
+                "type": "tool_result",
+                "tool_use_id": "direct-search",
+                "content": json.dumps({
+                    "result": "// direct.py#f (direct.py:2)",
+                    "metadata": {"ignored": True},
+                }),
+            },
+            {
+                "type": "tool_result",
+                "tool_use_id": "plugin-graph",
+                "content": "// graph.py#f (graph.py:3)",
+            },
+            {
+                "type": "tool_result",
+                "tool_use_id": "bash",
+                "content": "// fake.py#f (fake.py:4)",
+            },
+            {
+                "type": "tool_result",
+                "tool_use_id": "orphan",
+                "content": "// orphan.py#f (orphan.py:5)",
+            },
+            {
+                "type": "tool_result",
+                "tool_use_id": "direct-search-typo",
+                "content": "// mismatch.py#f (mismatch.py:6)",
+            },
+            {"type": "text", "text": "// normal.py#f (normal.py:7)"},
+        ]}},
+    ]
+
+    assert bg.tool_result_texts(rows, 0) == [
+        "// direct.py#f (direct.py:2)",
+        "// graph.py#f (graph.py:3)",
+    ]
+
+
+def test_tool_result_texts_rejects_linked_result_from_assistant_row():
+    rows = [
+        _tool_use("retrieval", "mcp__reviewer__search_codebase"),
+        {"type": "assistant", "message": {"content": [{
+            "type": "tool_result",
+            "tool_use_id": "retrieval",
+            "content": "untrusted",
+        }]}},
+    ]
+
+    assert bg.tool_result_texts(rows, -1) == []
+
+
+@pytest.mark.parametrize(
+    "prefix",
+    ["mcp__reviewer__", "mcp__plugin_rag-reviewer_reviewer__"],
+)
+@pytest.mark.parametrize(
+    "logical_name",
+    [
+        "search_codebase",
+        "related_symbols",
+        "callers",
+        "implementations",
+        "definition",
+    ],
+)
+def test_tool_result_texts_accepts_allowed_names(prefix, logical_name):
+    rows = [
+        {"type": "assistant", "message": {"content": [{
+            "type": "tool_use",
+            "id": "retrieval",
+            "name": prefix + logical_name,
+        }]}},
+        {"type": "user", "message": {"content": [{
+            "type": "tool_result",
+            "tool_use_id": "retrieval",
+            "content": "trusted",
+        }]}},
+    ]
+
+    assert bg.tool_result_texts(rows, -1) == ["trusted"]
+
+
+@pytest.mark.parametrize(
+    "tool_name",
+    [
+        "mcp__reviewer_extra__search_codebase",
+        "mcp__reviewer__search_code",
+        "mcp__plugin_rag-reviewer_reviewer__unknown",
+    ],
+)
+def test_tool_result_texts_rejects_near_prefix_and_unknown_names(tool_name):
+    rows = [
+        {"type": "assistant", "message": {"content": [{
+            "type": "tool_use",
+            "id": "untrusted",
+            "name": tool_name,
+        }]}},
+        {"type": "user", "message": {"content": [{
+            "type": "tool_result",
+            "tool_use_id": "untrusted",
+            "content": "untrusted",
+        }]}},
+    ]
+
+    assert bg.tool_result_texts(rows, -1) == []
+
+
+@pytest.mark.parametrize(
+    "sentinel",
+    ["[truncated]", "[...truncated]", "[…truncated]"],
+)
+def test_result_is_incomplete_accepts_only_hard_truncation_sentinels(sentinel):
+    assert bg._result_is_incomplete(f"retrieval output\n{sentinel}") is True
+
+
+@pytest.mark.parametrize(
+    "note",
+    [
+        "results stopped at the reranker cliff",
+        "results limited by retrieval rails",
+        "(truncated)",
+        "(truncated 42 more)",
+        "Граф ограничен внутренним лимитом результатов",
+    ],
+)
+def test_result_is_incomplete_rejects_non_sentinel_notes(note):
+    assert bg._result_is_incomplete(note) is False
+
+
+def test_evidence_paths_require_code_header():
+    texts = [
+        "// reviewer/index/store.py#ChunkStore (reviewer/index/store.py:10-40)",
+        "task mentions invented.py:20",
+        "tests/test_store.py#test_x (tests/test_store.py:7)",
+    ]
+
+    assert bg.evidence_paths(texts) == {
+        "reviewer/index/store.py",
+        "tests/test_store.py",
+    }
+
+
+def test_path_matching_is_exact_or_safe_prefixed_suffix():
+    observed = {
+        "utils.py",
+        "/tmp/worktree/reviewer/index/store.py",
+        "a/utils.py",
+    }
+
+    assert bg.path_is_observed("utils.py", observed) is True
+    assert bg.path_is_observed("reviewer/index/store.py", observed) is True
+    assert bg.path_is_observed(
+        "reviewer/index/store.py",
+        {r"C:\tmp\worktree\reviewer\index\store.py"},
+    ) is True
+    assert bg.path_is_observed("store.py", observed) is False
+    assert bg.path_is_observed("b/utils.py", observed) is False
+
+
+def test_path_matching_rejects_repo_relative_prefix():
+    assert bg.path_is_observed(
+        "reviewer/index/store.py",
+        {"other/reviewer/index/store.py"},
+    ) is False
+
+
+def test_guard_brief_marks_only_missing_code_and_test_paths():
+    brief = (
+        "## Task\n"
+        "- task/spec.py:1\n"
+        "\n"
+        "## Relevant code\n"
+        "- pkg/known.py:10\n"
+        "- pkg/missing.py:20\n"
+        "\n"
+        "## Subsystems\n"
+        "- pkg/subsystem.py:30\n"
+        "\n"
+        "## Test exemplars\n"
+        "- tests/test_missing.py:40\n"
+        "\n"
+        "## Constraints\n"
+        "- docs/constraint.md:50\n"
+    )
+
+    guarded, cited, missing = bg.guard_brief(brief, {"pkg/known.py"})
+
+    assert guarded == (
+        "## Task\n"
+        "- task/spec.py:1\n"
+        "\n"
+        "## Relevant code\n"
+        "- pkg/known.py:10\n"
+        f"- pkg/missing.py:20 {bg.WARNING}\n"
+        "\n"
+        "## Subsystems\n"
+        "- pkg/subsystem.py:30\n"
+        "\n"
+        "## Test exemplars\n"
+        f"- tests/test_missing.py:40 {bg.WARNING}\n"
+        "\n"
+        "## Constraints\n"
+        "- docs/constraint.md:50\n"
+    )
+    assert cited == ["pkg/known.py", "pkg/missing.py", "tests/test_missing.py"]
+    assert missing == ["pkg/missing.py", "tests/test_missing.py"]
+
+
+def test_guard_brief_is_idempotent_and_handles_multiple_citations():
+    brief = "## Relevant code\r\n- a.py:1 calls b.py:2\r\n## Constraints\r\n"
+
+    first, cited, missing = bg.guard_brief(brief, {"a.py"})
+    second, second_cited, second_missing = bg.guard_brief(first, {"a.py"})
+
+    assert first == f"## Relevant code\r\n- a.py:1 calls b.py:2 {bg.WARNING}\r\n## Constraints\r\n"
+    assert first.count(bg.WARNING) == 1
+    assert second == first
+    assert cited == second_cited == ["a.py", "b.py"]
+    assert missing == second_missing == ["b.py"]
+
+
+def test_run_marks_only_missing_evidence_and_is_idempotent(tmp_path):
+    brief = _brief(
+        tmp_path,
+        "## Relevant code\n- known.py:1\n- missing.py:2\n",
+    )
+    transcript = _write_transcript(
+        tmp_path,
+        [
+            _SOLVE_USER,
+            *_retrieval_rows("// known.py#known (known.py:1-3)"),
+            _write_call(),
+        ],
+    )
+    transcript.write_text(
+        "not-json\n" + transcript.read_text(encoding="utf-8"), encoding="utf-8"
+    )
+    payload = _payload(brief, transcript)
+
+    assert bg.run(payload) == 0
+    first = brief.read_bytes()
+    assert b"known.py:1\n" in first
+    assert f"known.py:1 {bg.WARNING}".encode() not in first
+    assert f"missing.py:2 {bg.WARNING}".encode() in first
+
+    assert bg.run(payload) == 0
+    assert brief.read_bytes() == first
+
+
+def test_run_noop_without_evidence_or_with_truncated_result(tmp_path):
+    original = "## Relevant code\n- missing.py:2\n"
+    brief = _brief(tmp_path, original)
+    no_evidence = _write_transcript(
+        tmp_path,
+        [
+            _SOLVE_USER,
+            *_retrieval_rows("No matching code found"),
+            _write_call(),
+        ],
+    )
+
+    assert bg.run(_payload(brief, no_evidence)) == 0
+    assert brief.read_text(encoding="utf-8") == original
+
+    truncated = _write_transcript(
+        tmp_path,
+        [
+            _SOLVE_USER,
+            *_retrieval_rows("// known.py#known (known.py:1)\n[...truncated]"),
+            _write_call(),
+        ],
+    )
+    assert bg.run(_payload(brief, truncated)) == 0
+    assert brief.read_text(encoding="utf-8") == original
+
+
+def test_run_continues_for_cliff_note_and_ignores_untrusted_truncation(tmp_path):
+    brief = _brief(
+        tmp_path,
+        "## Relevant code\n- known.py:1\n- missing.py:2\n",
+    )
+    transcript = _write_transcript(
+        tmp_path,
+        [
+            _SOLVE_USER,
+            *_retrieval_rows(
+                "// known.py#known (known.py:1)\nStopped at reranker cliff",
+            ),
+            _tool_use("shell", "Bash"),
+            _tool_result("shell", "// fake.py#fake (fake.py:1)\n[...truncated]"),
+            _write_call(),
+        ],
+    )
+
+    assert bg.run(_payload(brief, transcript)) == 0
+    guarded = brief.read_text(encoding="utf-8")
+    assert f"known.py:1 {bg.WARNING}" not in guarded
+    assert f"missing.py:2 {bg.WARNING}" in guarded
+
+
+def test_run_noop_outside_briefs_or_without_solve_marker(tmp_path):
+    specs = tmp_path / "docs" / "superpowers" / "specs"
+    specs.mkdir(parents=True)
+    outside = specs / "task.md"
+    original = "## Relevant code\n- missing.py:2\n"
+    outside.write_text(original, encoding="utf-8")
+    evidence = _retrieval_rows("// known.py#known (known.py:1)")
+    transcript = _write_transcript(
+        tmp_path,
+        [_SOLVE_USER, *evidence, _write_call()],
+    )
+
+    assert bg.run(_payload(outside, transcript)) == 0
+    assert outside.read_text(encoding="utf-8") == original
+
+    brief = _brief(tmp_path, original)
+    no_marker = _write_transcript(tmp_path, [*evidence, _write_call()])
+    assert bg.run(_payload(brief, no_marker)) == 0
+    assert brief.read_text(encoding="utf-8") == original
+
+
+def test_run_path_a_scans_sidechain_without_solve_marker(tmp_path):
+    brief = _brief(
+        tmp_path,
+        "## Relevant code\n- known.py:1\n- missing.py:2\n",
+    )
+    transcript = _write_transcript(
+        tmp_path,
+        [
+            *_retrieval_rows(
+                "// known.py#known (known.py:1)",
+                sidechain=True,
+                agent_id="agent-1",
+                attribution_skill=_SOLVE_ATTRIBUTION,
+            ),
+            _write_call(
+                sidechain=True,
+                agent_id="agent-1",
+                attribution_skill=_SOLVE_ATTRIBUTION,
+                file_path=str(brief),
+            ),
+        ],
+    )
+
+    assert bg.run(_payload(brief, transcript, agent_id="agent-1")) == 0
+    guarded = brief.read_text(encoding="utf-8")
+    assert f"known.py:1 {bg.WARNING}" not in guarded
+    assert f"missing.py:2 {bg.WARNING}" in guarded
+
+
+@pytest.mark.parametrize(
+    ("current_overrides", "payload_overrides"),
+    [
+        ({"attribution_skill": "other:skill"}, {}),
+        ({"attribution_skill": None}, {}),
+        ({"agent_id": "agent-2"}, {}),
+        ({"name": "Read"}, {}),
+        ({"name": "Read"}, {"tool_name": "Read"}),
+        ({}, {"tool_name": "Read"}),
+        ({"file_path": "/different/task.md"}, {}),
+    ],
+    ids=[
+        "unrelated-attribution",
+        "missing-attribution",
+        "different-agent",
+        "different-block-tool-name",
+        "matching-non-write-tool-name",
+        "different-payload-tool-name",
+        "different-file-path",
+    ],
+)
+def test_run_markerless_path_a_requires_current_write_provenance(
+    tmp_path,
+    current_overrides,
+    payload_overrides,
+):
+    original = "## Relevant code\n- missing.py:2\n"
+    brief = _brief(tmp_path, original)
+    current = {
+        "sidechain": True,
+        "agent_id": "agent-1",
+        "attribution_skill": _SOLVE_ATTRIBUTION,
+        "file_path": str(brief),
+    }
+    current.update(current_overrides)
+    transcript = _write_transcript(
+        tmp_path,
+        [
+            *_retrieval_rows(
+                "// known.py#known (known.py:1)",
+                sidechain=True,
+                agent_id="agent-1",
+                attribution_skill=_SOLVE_ATTRIBUTION,
+            ),
+            _write_call(**current),
+        ],
+    )
+    payload = _payload(brief, transcript, agent_id="agent-1")
+    payload.update(payload_overrides)
+
+    assert bg.run(payload) == 0
+    assert brief.read_text(encoding="utf-8") == original
+
+
+def test_run_markerless_path_a_uses_only_current_write_provenance(tmp_path):
+    original = "## Relevant code\n- missing.py:2\n"
+    brief = _brief(tmp_path, original)
+    transcript = _write_transcript(
+        tmp_path,
+        [
+            *_retrieval_rows(
+                "// known.py#known (known.py:1)",
+                sidechain=True,
+                agent_id="agent-1",
+                attribution_skill=_SOLVE_ATTRIBUTION,
+            ),
+            _write_call(
+                sidechain=True,
+                tool_id="older-write",
+                agent_id="agent-1",
+                attribution_skill=_SOLVE_ATTRIBUTION,
+                file_path=str(brief),
+            ),
+            _write_call(
+                sidechain=True,
+                agent_id="agent-1",
+                attribution_skill="other:skill",
+                file_path=str(brief),
+            ),
+        ],
+    )
+
+    assert bg.run(_payload(brief, transcript, agent_id="agent-1")) == 0
+    assert brief.read_text(encoding="utf-8") == original
+
+
+def test_run_uses_last_solve_marker_for_main_transcript(tmp_path):
+    brief = _brief(
+        tmp_path,
+        "## Relevant code\n- old.py:1\n- current.py:2\n",
+    )
+    transcript = _write_transcript(
+        tmp_path,
+        [
+            _SOLVE_USER,
+            *_retrieval_rows("// old.py#old (old.py:1)", tool_id="old-search"),
+            _SOLVE_USER,
+            *_retrieval_rows(
+                "// current.py#current (current.py:2)",
+                tool_id="current-search",
+            ),
+            _write_call(),
+        ],
+    )
+
+    assert bg.run(_payload(brief, transcript)) == 0
+    guarded = brief.read_text(encoding="utf-8")
+    assert f"old.py:1 {bg.WARNING}" in guarded
+    assert f"current.py:2 {bg.WARNING}" not in guarded
+
+
+def test_run_waits_until_current_write_call_is_in_transcript(tmp_path, monkeypatch):
+    brief = _brief(tmp_path, "## Relevant code\n- missing.py:2\n")
+    transcript = tmp_path / "session.jsonl"
+    earlier_rows = [
+        _SOLVE_USER,
+        *_retrieval_rows("// known.py#known (known.py:1)"),
+    ]
+    snapshots = [earlier_rows, [*earlier_rows, _write_call()]]
+    reads = []
+
+    def read_snapshot(path):
+        reads.append(path)
+        return snapshots[min(len(reads) - 1, len(snapshots) - 1)]
+
+    monkeypatch.setattr(bg, "_read_jsonl", read_snapshot)
+    monkeypatch.setattr("time.sleep", lambda _delay: None)
+
+    assert bg.run(_payload(brief, transcript)) == 0
+    assert reads == [str(transcript), str(transcript)]
+    assert f"missing.py:2 {bg.WARNING}" in brief.read_text(encoding="utf-8")
+
+
+def test_run_noops_when_current_write_call_never_reaches_transcript(
+    tmp_path,
+    monkeypatch,
+):
+    original = "## Relevant code\n- missing.py:2\n"
+    brief = _brief(tmp_path, original)
+    transcript = tmp_path / "session.jsonl"
+    stale_rows = [
+        _SOLVE_USER,
+        *_retrieval_rows("// known.py#known (known.py:1)"),
+    ]
+    reads = []
+
+    def read_stale(path):
+        reads.append(path)
+        return stale_rows
+
+    monkeypatch.setattr(bg, "_read_jsonl", read_stale)
+    monkeypatch.setattr("time.sleep", lambda _delay: None)
+
+    assert bg.run(_payload(brief, transcript)) == 0
+    assert reads == [str(transcript)] * 3
+    assert brief.read_text(encoding="utf-8") == original
+
+
+@pytest.mark.parametrize("tool_use_id", [None, ""])
+def test_run_noops_without_nonempty_current_tool_use_id(tmp_path, tool_use_id):
+    brief = _brief(tmp_path, "## Relevant code\n- missing.py:2\n")
+    transcript = _write_transcript(
+        tmp_path,
+        [
+            _SOLVE_USER,
+            *_retrieval_rows("// known.py#known (known.py:1)"),
+            _write_call(),
+        ],
+    )
+    payload = _payload(brief, transcript)
+    if tool_use_id is None:
+        payload.pop("tool_use_id")
+    else:
+        payload["tool_use_id"] = tool_use_id
+    original = brief.read_bytes()
+
+    assert bg.run(payload) == 0
+    assert brief.read_bytes() == original
+
+
+def test_run_debug_reports_observed_cited_and_missing(tmp_path, monkeypatch, capsys):
+    brief = _brief(tmp_path, "## Relevant code\n- missing.py:2\n")
+    transcript = _write_transcript(
+        tmp_path,
+        [
+            _SOLVE_USER,
+            *_retrieval_rows("// known.py#known (known.py:1)"),
+            _write_call(),
+        ],
+    )
+    monkeypatch.setenv("BRIEF_GUARD_DEBUG", "1")
+
+    assert bg.run(_payload(brief, transcript)) == 0
+
+    stderr = capsys.readouterr().err
+    assert "observed: known.py" in stderr
+    assert "cited: missing.py" in stderr
+    assert "missing: missing.py" in stderr

--- a/tests/hooks/test_brief_post_write.py
+++ b/tests/hooks/test_brief_post_write.py
@@ -1,0 +1,90 @@
+"""Unit-тесты последовательного PostToolUse-хука brief_post_write."""
+
+import importlib.util
+import io
+import pathlib
+import sys
+
+import pytest
+
+ROOT = pathlib.Path(__file__).resolve().parents[2]
+HOOKS_DIR = ROOT / "plugin" / "hooks"
+HOOK_PATH = HOOKS_DIR / "brief_post_write.py"
+
+
+def _load():
+    if not HOOK_PATH.is_file():
+        pytest.fail(f"отсутствует wrapper hook: {HOOK_PATH}")
+    spec = importlib.util.spec_from_file_location("brief_post_write", HOOK_PATH)
+    mod = importlib.util.module_from_spec(spec)
+    previous_bytecode = sys.dont_write_bytecode
+    sys.dont_write_bytecode = True
+    sys.path.insert(0, str(HOOKS_DIR))
+    try:
+        spec.loader.exec_module(mod)
+    finally:
+        sys.path.pop(0)
+        sys.dont_write_bytecode = previous_bytecode
+    return mod
+
+
+@pytest.fixture
+def hook_module():
+    return _load()
+
+
+def test_run_calls_cost_then_guard_with_same_payload(hook_module, monkeypatch):
+    payload = {"tool_name": "Write"}
+    calls = []
+
+    monkeypatch.setattr(
+        hook_module.brief_cost,
+        "run",
+        lambda value: calls.append(("cost", value)),
+    )
+    monkeypatch.setattr(
+        hook_module.brief_guard,
+        "run",
+        lambda value: calls.append(("guard", value)),
+    )
+
+    assert hook_module.run(payload) == 0
+    assert calls == [("cost", payload), ("guard", payload)]
+
+
+def test_run_calls_guard_when_cost_raises(hook_module, monkeypatch):
+    payload = {"tool_name": "Write"}
+    calls = []
+
+    def raise_cost(value):
+        calls.append(("cost", value))
+        raise RuntimeError("cost failed")
+
+    monkeypatch.setattr(hook_module.brief_cost, "run", raise_cost)
+    monkeypatch.setattr(
+        hook_module.brief_guard,
+        "run",
+        lambda value: calls.append(("guard", value)),
+    )
+
+    assert hook_module.run(payload) == 0
+    assert calls == [("cost", payload), ("guard", payload)]
+
+
+def test_run_returns_zero_when_guard_raises(hook_module, monkeypatch):
+    payload = {"tool_name": "Write"}
+
+    monkeypatch.setattr(hook_module.brief_cost, "run", lambda _payload: 0)
+    monkeypatch.setattr(
+        hook_module.brief_guard,
+        "run",
+        lambda _payload: (_ for _ in ()).throw(RuntimeError("guard failed")),
+    )
+
+    assert hook_module.run(payload) == 0
+
+
+def test_main_returns_zero_for_malformed_stdin(hook_module, monkeypatch):
+    monkeypatch.setattr(hook_module.sys, "stdin", io.StringIO("not-json"))
+
+    assert hook_module.main() == 0


### PR DESCRIPTION
## Summary
- добавить path-level grounding guard для `Relevant code` и `Test exemplars` solve-task brief
- учитывать Path A/Path B Claude transcripts, provenance MCP tool results и hard truncation
- последовательно запускать token cost и path guard через единый PostToolUse wrapper

## Test Plan
- `.venv/bin/pytest -q`
- `.venv/bin/ruff check plugin/hooks/brief_guard.py plugin/hooks/brief_post_write.py tests/hooks/test_brief_guard.py tests/hooks/test_brief_post_write.py tests/hooks/test_brief_cost.py`
- `.venv/bin/python scripts/update_codex_plugin_manifest.py --check`

Task: PRI-172