### PR TITLE
release: 0.3.6 (фикс codex-манифеста)

### DIFF
--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "rag-reviewer",
-  "version": "0.3.5+codex.1d89dfb9d927",
+  "version": "0.3.6+codex.a4532e8591f9",
   "description": "Agentic PR review: hybrid RAG + code graph via MCP, review skills for Codex",
   "repository": "https://github.com/mimfort/rag_for_git",
   "license": "MIT",

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "rag-reviewer",
-  "version": "0.3.5",
+  "version": "0.3.6",
   "description": "Agentic PR review: hybrid RAG + code graph via MCP, review skills for Claude Code"
 }

--- a/plugin/.codex-plugin/plugin.json
+++ b/plugin/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "rag-reviewer",
-  "version": "0.3.5+codex.1d89dfb9d927",
+  "version": "0.3.6+codex.a4532e8591f9",
   "description": "Agentic PR review: hybrid RAG + code graph via MCP, review skills for Codex",
   "repository": "https://github.com/mimfort/rag_for_git",
   "license": "MIT",


### PR DESCRIPTION
Довыпуск 0.3.6: пересобранный codex-манифест (e3de3c8) чинит рассинхрон pyproject=0.3.6 vs manifest=0.3.5, из-за которого упал publish.yml на предыдущем мерже #125. Включает фичу PRI-213 (создание задач на досках) + бамп версии.

После мержа publish.yml выкатит rag-reviewer 0.3.6 на PyPI.