### PR TITLE
fix(ci): починить publish и закрыть класс рассинхрона манифестов гейтом на dev

### DIFF
--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "rag-reviewer",
-  "version": "0.3.6+codex.e43ad86cf323",
+  "version": "0.3.7+codex.1d1b50f164ef",
   "description": "Agentic PR review: hybrid RAG + code graph via MCP, review skills for Codex",
   "repository": "https://github.com/mimfort/rag_for_git",
   "license": "MIT",

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,29 @@
+name: Tests
+
+# Гейт на пути feature → dev → main. Релизные workflow (publish, codex-plugin)
+# висят только на main, поэтому без этого прогона поломка, попавшая в dev,
+# всплывает лишь после мержа в main и блокирует публикацию.
+on:
+  pull_request:
+    branches: [dev, main]
+  push:
+    branches: [dev]
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1  # v6.3.0
+        with:
+          python-version: "3.11"
+      - run: pip install -e ".[dev,web]"
+      # Раньше полного прогона: рассинхрон сгенерированных манифестов плагина
+      # с версией pyproject даёт здесь одну внятную строку вместо десятка
+      # падений в тестах install.
+      - run: python scripts/update_codex_plugin_manifest.py --check
+      - run: pytest -q

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "rag-reviewer",
-  "version": "0.3.6",
+  "version": "0.3.7",
   "description": "Agentic PR review: hybrid RAG + code graph via MCP, review skills for Claude Code"
 }

--- a/plugin/.codex-plugin/plugin.json
+++ b/plugin/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "rag-reviewer",
-  "version": "0.3.6+codex.d996bae35a7d",
+  "version": "0.3.7+codex.1d1b50f164ef",
   "description": "Agentic PR review: hybrid RAG + code graph via MCP, review skills for Codex",
   "repository": "https://github.com/mimfort/rag_for_git",
   "license": "MIT",

--- a/scripts/update_codex_plugin_manifest.py
+++ b/scripts/update_codex_plugin_manifest.py
@@ -15,6 +15,17 @@ def main() -> int:
     if errors:
         for error in errors:
             print(error)
+        if args.check:
+            # Манифесты плагина — сгенерированный артефакт, но лежат в git: их
+            # читает marketplace прямо из репозитория. Значит версию pyproject
+            # они не наследуют автоматически, и после бампа их надо пересобрать.
+            print(
+                "\nМанифесты плагина рассинхронизированы с pyproject. Почини так:\n"
+                "  python scripts/update_codex_plugin_manifest.py\n"
+                "  git add .codex-plugin plugin/.codex-plugin plugin/.claude-plugin "
+                "plugin/assets\n"
+                "и закоммить результат."
+            )
         return 1
     if not args.check:
         print("Codex plugin manifests synchronized")

--- a/tests/test_ci_gates.py
+++ b/tests/test_ci_gates.py
@@ -1,0 +1,80 @@
+"""Гейты CI покрывают ветки, через которые код доезжает до main.
+
+Инвариант: ни один коммит не попадает в main непроверенным. Разработка идёт в dev,
+поэтому прогон тестов обязан висеть и на PR в dev, и на прямых push в dev — иначе
+поломка обнаруживается только после мержа dev → main, где она блокирует publish
+(так и произошло с рассинхроном версии манифеста 0.3.6 vs pyproject 0.3.7).
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+WORKFLOWS = Path(__file__).resolve().parents[1] / ".github" / "workflows"
+
+
+def _triggers(workflow: dict) -> dict:
+    """Секция триггеров workflow.
+
+    В YAML голый ключ ``on:`` — булев литерал, поэтому safe_load кладёт его как
+    ``True``, а не как строку "on" (грабля YAML 1.1).
+    """
+    return workflow.get("on", workflow.get(True)) or {}
+
+
+def _runs_full_test_suite(workflow: dict) -> bool:
+    for job in (workflow.get("jobs") or {}).values():
+        for step in job.get("steps") or []:
+            if "pytest -q" in str(step.get("run", "")):
+                return True
+    return False
+
+
+def _branches(triggers: dict, event: str) -> set[str]:
+    spec = triggers.get(event)
+    if not isinstance(spec, dict):
+        return set()
+    return set(spec.get("branches") or [])
+
+
+@pytest.fixture(scope="module")
+def workflows() -> list[dict]:
+    loaded = []
+    for path in sorted(WORKFLOWS.glob("*.yml")):
+        loaded.append(yaml.safe_load(path.read_text(encoding="utf-8")))
+    return loaded
+
+
+@pytest.mark.parametrize(
+    ("event", "branch"),
+    [
+        ("pull_request", "dev"),   # feature → dev
+        ("pull_request", "main"),  # dev → main
+        ("push", "dev"),           # прямой коммит в dev (в т.ч. правка через веб-UI)
+        ("push", "main"),          # финальный гейт перед публикацией
+    ],
+)
+def test_full_test_suite_gates_every_path_into_main(workflows, event, branch):
+    gating = [w for w in workflows if _runs_full_test_suite(w)]
+    assert gating, "ни один workflow не запускает полный прогон pytest -q"
+    covered = any(branch in _branches(_triggers(w), event) for w in gating)
+    assert covered, f"{event} в ветку {branch} не покрыт прогоном тестов"
+
+
+def test_manifest_sync_is_checked_before_merge(workflows):
+    # Рассинхрон сгенерированных манифестов плагина с версией pyproject ловится
+    # раньше и внятнее полного прогона: отдельным шагом с понятной подсказкой.
+    checking = [
+        w
+        for w in workflows
+        if any(
+            "update_codex_plugin_manifest.py --check" in str(step.get("run", ""))
+            for job in (w.get("jobs") or {}).values()
+            for step in job.get("steps") or []
+        )
+    ]
+    assert checking, "проверка синхронности манифестов не запускается в CI"
+    covered = any("dev" in _branches(_triggers(w), "pull_request") for w in checking)
+    assert covered, "проверка манифестов не гейтит PR в dev"


### PR DESCRIPTION
## Что сломалось

Прогон `Publish to PyPI` на main лёг: 10 тестов install краснели на рассинхроне версий — `pyproject` уже `0.3.7`, а манифесты плагина остались на `0.3.6`.

Тесты были правы, чинить надо не их.

## Корневая причина

Версия живёт в двух местах: `pyproject.toml` (истина) и сгенерированные манифесты плагина, которые лежат в git, потому что их читает marketplace прямо из репозитория. Синхронизирует их `sync_plugin_metadata`, запускаемая вручную скриптом.

Триггер — коммит a9593ee «Update pyproject.toml»: бамп `0.3.6 → 0.3.7` через **веб-интерфейс GitHub**, прямым коммитом в `dev`, минуя локальные хуки и тесты.

**Но настоящий дефект — расположение гейтов.** Все три workflow висели только на main:

| Workflow | Триггеры |
|---|---|
| `publish.yml` | `push: [main]` |
| `codex-plugin.yml` | `pull_request/push: [main]` |
| `hol-plugin-scanner.yml` | `pull_request/push: [main]` |

Разработка идёт в `dev` — то есть проверки стояли за той самой границей, которую ломающий коммит пересекает последней. Детектор `scripts/update_codex_plugin_manifest.py --check` в репозитории **уже был** и вызывался в `codex-plugin.yml`, просто на ветке, куда доезжают только уже сломанные коммиты.

Это повтор: PR #126 («релиз 0.3.6 (фикс codex-манифеста)») чинил ровно тот же рассинхрон довыпуском.

Попутно всплыл второй экземпляр того же класса: корневая проекция манифеста разошлась с payload-манифестом (`e43ad86cf323` vs `d996bae35a7d`) — при коммите PR #129 в индекс попали не все перегенерированные файлы.

## Фикс

**1. Разовое** — пересобранные манифесты под `0.3.7` (заодно сходится проекция).

**2. Структурное** — новый workflow `Tests`: `pull_request: [dev, main]` + `push: [dev]`, шаги `--check` манифестов и `pytest -q`. Теперь непроверенным до main не доезжает ничего:

| Путь | Гейт |
|---|---|
| feature → dev (PR) | `tests.yml` — **был пуст** |
| прямой push в dev (в т.ч. веб-UI) | `tests.yml` — **был пуст** |
| dev → main (PR) | `tests.yml` + `codex-plugin.yml` + scanner |
| push в main | `publish.yml` + `codex-plugin.yml` |

Гейт намеренно в CI, а не в git-хуке: правка через веб-UI хуки не исполняет — то есть локальные средства этот кейс структурно не закрывают.

**3. Guard-тест** `tests/test_ci_gates.py` — фиксирует инвариант «каждый путь в main покрыт прогоном тестов», параметризован по четырём путям. Проверен мутационно: до появления `tests.yml` краснел ровно на трёх непокрытых путях, `push: [main]` проходил. Учитывает грабли YAML 1.1, где голый ключ `on:` парсится как булев `True`.

**4. DX** — красный `--check` теперь печатает, что именно делать (пересобрать + какие пути добавить в индекс), вместо голого списка расхождений.

## Проверки

`pytest -q` — **1737 passed**; `ruff check` — чист; `update_codex_plugin_manifest.py --check` — exit 0.

Отдельно: локально этот прогон сперва краснел 10 тестами уже наоборот — установленный editable-пакет имел метадату `0.3.6` (ставился до бампа), а install-тесты сверяют манифест с версией **установленного** пакета. Это артефакт локальной среды, не дефект: в CI пакет ставится после чекаута. После `pip install -e .` всё зелёное. Семантику тестов не трогал — она верна, `reviewer install codex` действительно обязан ставить плагин под версию установленного reviewer.

## Отвергнутая альтернатива

Авто-коммит пересобранных манифестов из CI: требует write-токена в CI, конфликтует с защитой веток и порождает сюрприз-коммиты. Красный гейт с внятной подсказкой честнее.
