### PR TITLE
release: 0.3.7 (обратный линк задачи в PR + гейт CI на dev)

### DIFF
--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "rag-reviewer",
-  "version": "0.3.6+codex.e43ad86cf323",
+  "version": "0.3.7+codex.1d1b50f164ef",
   "description": "Agentic PR review: hybrid RAG + code graph via MCP, review skills for Codex",
   "repository": "https://github.com/mimfort/rag_for_git",
   "license": "MIT",

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,29 @@
+name: Tests
+
+# Гейт на пути feature → dev → main. Релизные workflow (publish, codex-plugin)
+# висят только на main, поэтому без этого прогона поломка, попавшая в dev,
+# всплывает лишь после мержа в main и блокирует публикацию.
+on:
+  pull_request:
+    branches: [dev, main]
+  push:
+    branches: [dev]
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1  # v6.3.0
+        with:
+          python-version: "3.11"
+      - run: pip install -e ".[dev,web]"
+      # Раньше полного прогона: рассинхрон сгенерированных манифестов плагина
+      # с версией pyproject даёт здесь одну внятную строку вместо десятка
+      # падений в тестах install.
+      - run: python scripts/update_codex_plugin_manifest.py --check
+      - run: pytest -q

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "rag-reviewer",
-  "version": "0.3.6",
+  "version": "0.3.7",
   "description": "Agentic PR review: hybrid RAG + code graph via MCP, review skills for Claude Code"
 }

--- a/plugin/.codex-plugin/plugin.json
+++ b/plugin/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "rag-reviewer",
-  "version": "0.3.6+codex.d996bae35a7d",
+  "version": "0.3.7+codex.1d1b50f164ef",
   "description": "Agentic PR review: hybrid RAG + code graph via MCP, review skills for Codex",
   "repository": "https://github.com/mimfort/rag_for_git",
   "license": "MIT",

--- a/scripts/update_codex_plugin_manifest.py
+++ b/scripts/update_codex_plugin_manifest.py
@@ -15,6 +15,17 @@ def main() -> int:
     if errors:
         for error in errors:
             print(error)
+        if args.check:
+            # Манифесты плагина — сгенерированный артефакт, но лежат в git: их
+            # читает marketplace прямо из репозитория. Значит версию pyproject
+            # они не наследуют автоматически, и после бампа их надо пересобрать.
+            print(
+                "\nМанифесты плагина рассинхронизированы с pyproject. Почини так:\n"
+                "  python scripts/update_codex_plugin_manifest.py\n"
+                "  git add .codex-plugin plugin/.codex-plugin plugin/.claude-plugin "
+                "plugin/assets\n"
+                "и закоммить результат."
+            )
         return 1
     if not args.check:
         print("Codex plugin manifests synchronized")

--- a/tests/test_ci_gates.py
+++ b/tests/test_ci_gates.py
@@ -1,0 +1,80 @@
+"""Гейты CI покрывают ветки, через которые код доезжает до main.
+
+Инвариант: ни один коммит не попадает в main непроверенным. Разработка идёт в dev,
+поэтому прогон тестов обязан висеть и на PR в dev, и на прямых push в dev — иначе
+поломка обнаруживается только после мержа dev → main, где она блокирует publish
+(так и произошло с рассинхроном версии манифеста 0.3.6 vs pyproject 0.3.7).
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+WORKFLOWS = Path(__file__).resolve().parents[1] / ".github" / "workflows"
+
+
+def _triggers(workflow: dict) -> dict:
+    """Секция триггеров workflow.
+
+    В YAML голый ключ ``on:`` — булев литерал, поэтому safe_load кладёт его как
+    ``True``, а не как строку "on" (грабля YAML 1.1).
+    """
+    return workflow.get("on", workflow.get(True)) or {}
+
+
+def _runs_full_test_suite(workflow: dict) -> bool:
+    for job in (workflow.get("jobs") or {}).values():
+        for step in job.get("steps") or []:
+            if "pytest -q" in str(step.get("run", "")):
+                return True
+    return False
+
+
+def _branches(triggers: dict, event: str) -> set[str]:
+    spec = triggers.get(event)
+    if not isinstance(spec, dict):
+        return set()
+    return set(spec.get("branches") or [])
+
+
+@pytest.fixture(scope="module")
+def workflows() -> list[dict]:
+    loaded = []
+    for path in sorted(WORKFLOWS.glob("*.yml")):
+        loaded.append(yaml.safe_load(path.read_text(encoding="utf-8")))
+    return loaded
+
+
+@pytest.mark.parametrize(
+    ("event", "branch"),
+    [
+        ("pull_request", "dev"),   # feature → dev
+        ("pull_request", "main"),  # dev → main
+        ("push", "dev"),           # прямой коммит в dev (в т.ч. правка через веб-UI)
+        ("push", "main"),          # финальный гейт перед публикацией
+    ],
+)
+def test_full_test_suite_gates_every_path_into_main(workflows, event, branch):
+    gating = [w for w in workflows if _runs_full_test_suite(w)]
+    assert gating, "ни один workflow не запускает полный прогон pytest -q"
+    covered = any(branch in _branches(_triggers(w), event) for w in gating)
+    assert covered, f"{event} в ветку {branch} не покрыт прогоном тестов"
+
+
+def test_manifest_sync_is_checked_before_merge(workflows):
+    # Рассинхрон сгенерированных манифестов плагина с версией pyproject ловится
+    # раньше и внятнее полного прогона: отдельным шагом с понятной подсказкой.
+    checking = [
+        w
+        for w in workflows
+        if any(
+            "update_codex_plugin_manifest.py --check" in str(step.get("run", ""))
+            for job in (w.get("jobs") or {}).values()
+            for step in job.get("steps") or []
+        )
+    ]
+    assert checking, "проверка синхронности манифестов не запускается в CI"
+    covered = any("dev" in _branches(_triggers(w), "pull_request") for w in checking)
+    assert covered, "проверка манифестов не гейтит PR в dev"


### PR DESCRIPTION
## Релиз 0.3.7

Промоут dev → main. Разблокирует публикацию `rag-reviewer==0.3.7` на PyPI: предыдущий прогон `Publish to PyPI` лёг на рассинхроне версий (`pyproject 0.3.7` vs манифесты плагина `0.3.6`).

### Что входит (PR #131)

**Починка publish.** Манифесты плагина пересобраны под `0.3.7`; заодно сошлась корневая проекция манифеста с payload-манифестом (в PR #129 в индекс попали не все перегенерированные файлы).

**Закрыт класс дефекта.** Все воркфлоу висели только на `main`, а разработка идёт в `dev` — проверки стояли за той границей, которую ломающий коммит пересекает последней, поэтому рассинхрон всплывал уже после мержа в main (так было и с PR #126). Новый воркфлоу `Tests`: `pull_request: [dev, main]` + `push: [dev]`, шаги `update_codex_plugin_manifest.py --check` и `pytest -q`.

**Guard от регресса.** `tests/test_ci_gates.py` фиксирует инвариант «каждый путь в main покрыт прогоном тестов», параметризован по четырём путям.

**DX.** Красный `--check` печатает готовую инструкцию по починке вместо голого списка расхождений.

### Фича релиза (PR #129)

Кликабельная ссылка на задачу в теле PR: `finish_task` теперь дописывает `Задача: [PRI-N](url)` в начало тела PR (GitHub + GitLab, идемпотентно по скрытому маркеру, fail-soft). Связь PR ↔ задача стала двусторонней.

### Проверки

`pytest -q` — 1737 passed; `ruff check` чист; `--check` манифестов exit 0. Воркфлоу `Tests` отработал зелёным на PR #131 (52s) — первый PR в dev, который вообще получил чеки.

После мержа `publish.yml` выкатит `rag-reviewer 0.3.7` на PyPI.
