### PR TITLE
fix(retrieval): сохранить graph-контекст при fallback reranker (PRI-178)

### DIFF
--- a/docs/superpowers/briefs/2026-07-29-PRI-178-reranker-fallback-preserve-graph-items.md
+++ b/docs/superpowers/briefs/2026-07-29-PRI-178-reranker-fallback-preserve-graph-items.md
@@ -1,0 +1,57 @@
+# Brief — PRI-178 search_codebase: детерминированный fallback при недоступном reranker
+
+https://ru.yougile.com/team/686c049c8af8/#PRI-178
+
+## Task
+
+- Данные задачи получены из reviewer store после `sync_board`; store key `ID-178`, alias `PRI-178`.
+- Проблема актуальна: в `search_base` graph-элементы добавляются после RRF-hits, а no-rerank пути возвращают начало `items[:ceiling]`; при переполнении графовый хвост теряется.
+- Исходное описание устарело: рабочий путь — `Retriever.search_base`, лимит называется `ceiling`, reranker вызывает `rerank_scored`, а общий fallback уже имеет базовый тест.
+- Полезный результат: source-aware deterministic fallback, который сохраняет лучший hybrid hit и ограниченное graph-разнообразие, не нарушая `ceiling`, фильтрацию тестов и overlap-dedup.
+- Fallback должен явно сообщать потребителю, что reranker отсутствовал или завершился ошибкой.
+
+## Related work
+
+- PRI-202 — использовать введённые там `CodebaseLimits`/`ceiling` и не менять cliff-policy успешной ветки.
+- PRI-138 — сохранять контракт `search_codebase`: dedupe, line-numbered output и bounded context.
+- PRI-194 — не смешивать с отдельным lexical fallback: PRI-178 меняет только состав уже найденных hybrid+graph кандидатов.
+
+(dropped 17: задачи о сводках, центральности, graph-инструментах и общем RAG не задают реализацию этого fallback.)
+
+## Subsystems
+
+- `reviewer/retrieval` — hybrid search, graph expansion, rerank, cliff и формирование `ContextPack`.
+- `reviewer/graph` — уже предоставляет `expand_detailed` с расстоянием и стабильным tie-break по `node_id`.
+- `tests/retrieval` — unit-контракт выдачи, degraded-paths и output shaping.
+
+## Relevant code
+
+- `reviewer/retrieval/retriever.py:123` — hybrid hits и ANN prefilter задают приоритетный RRF-порядок.
+- `reviewer/retrieval/retriever.py:134` — graph expansion добавляет fetched nodes после hits; provenance и стабильный порядок нужно сохранить.
+- `reviewer/retrieval/retriever.py:145` — test filtering и `_dedupe_overlapping` происходят до fallback.
+- `reviewer/retrieval/retriever.py:149` — ветка без reranker сейчас срезает начало списка.
+- `reviewer/retrieval/retriever.py:151` — exception из `rerank_scored` ведёт в идентичный срез.
+- `reviewer/graph/store.py:122` — `expand_detailed` возвращает `{id, rels, dist}` в порядке `(dist, id)`.
+
+(dropped 1: `Retriever.retrieve` — отдельный PR-session путь без symptomного fail-soft fallback.)
+
+## Test exemplars
+
+- `tests/retrieval/test_search_base.py:18` — `_FakeStore` задаёт hybrid и graph nodes.
+- `tests/retrieval/test_search_base.py:50` — `_FakeGraph` моделирует expansion; fake нужно перевести на `expand_detailed`.
+- `tests/retrieval/test_search_base.py:178` — no-reranker сценарий.
+- `tests/retrieval/test_search_base.py:188` — reranker exception сценарий.
+- `tests/retrieval/test_output_shaping.py:70` — форматирование `ContextPack.as_context`.
+
+(dropped 0: все тестовые опоры напрямую нужны.)
+
+## Constraints / open questions
+
+- Hybrid/RRF остаётся основным сигналом релевантности; graph получает один гарантированный слот только при `ceiling >= 2`, если hybrid уже заполнил лимит.
+- При свободных слотах graph-кандидаты заполняют остаток в порядке `(distance, node_id)`.
+- При `ceiling == 1` лучший hybrid hit не вытесняется.
+- После filtering/dedup provenance пересчитывается по `node_id`; удалённый graph-кандидат не резервирует слот.
+- Успешный `rerank_scored -> select_by_cliff`, `Retriever.retrieve`, `CodebaseLimits` и Voyage retry не меняются.
+- Base-index `main` имел `chunks=0`, поэтому code retrieval вернул пусто; ссылки на код проверены прямым чтением рабочей копии.
+
+Собран на: mid tier (gpt-5.6-terra), режим: subagent

--- a/docs/superpowers/plans/2026-07-29-pri-178-deterministic-reranker-fallback.md
+++ b/docs/superpowers/plans/2026-07-29-pri-178-deterministic-reranker-fallback.md
@@ -80,12 +80,12 @@ def expand_detailed(self, repo, node_ids, hops=2, *, branch=""):
 
 - [ ] **Step 2: Написать падающие unit-тесты чистого selector**
 
-Добавить импорт и parameterized test в `tests/retrieval/test_search_base.py`:
+Добавить parameterized test в `tests/retrieval/test_search_base.py`. Импорт находится
+внутри теста: отсутствие новой функции превращается в осмысленный pytest failure, а не
+collection error.
 
 ```python
 import pytest
-
-from reviewer.retrieval.retriever import _select_degraded_context
 
 
 @pytest.mark.parametrize(
@@ -100,6 +100,10 @@ from reviewer.retrieval.retriever import _select_degraded_context
     ],
 )
 def test_select_degraded_context(hybrid_ids, graph_ids, ceiling, expected):
+    try:
+        from reviewer.retrieval.retriever import _select_degraded_context
+    except ImportError:
+        pytest.fail("_select_degraded_context ещё не реализован")
     hybrid = [_Hit(f"{node_id}.py#f") for node_id in hybrid_ids]
     graph = [_Hit(f"{node_id}.py#f") for node_id in graph_ids]
 
@@ -116,7 +120,7 @@ Run:
 .venv/bin/pytest -q tests/retrieval/test_search_base.py::test_select_degraded_context
 ```
 
-Expected: collection error `ImportError: cannot import name '_select_degraded_context'`.
+Expected: six assertion failures with `_select_degraded_context ещё не реализован`.
 
 - [ ] **Step 4: Реализовать минимальный чистый selector**
 
@@ -379,18 +383,17 @@ git commit -m "fix(retrieval): сохранить graph-контекст без 
     ],
 )
 def test_as_context_appends_degraded_note(reason, fragment):
-    out = ContextPack(items=[_node()], degraded_reason=reason).as_context()
+    pack = ContextPack(items=[_node()])
+    pack.degraded_reason = reason
+    out = pack.as_context()
 
     assert fragment in out
     assert "deterministic hybrid+graph fallback" in out
     assert "def f():" in out
-
-
-def test_as_context_default_has_no_degraded_note():
-    out = ContextPack(items=[_node()]).as_context()
-
-    assert "fallback" not in out
 ```
+
+Существующий `test_as_context_default_unchanged` уже проверяет отсутствие лишней заметки
+для обычного `ContextPack`; новый дублирующий compatibility-тест не добавляется.
 
 - [ ] **Step 2: Запустить output-shaping тесты и подтвердить RED**
 
@@ -398,11 +401,10 @@ Run:
 
 ```bash
 .venv/bin/pytest -q \
-  tests/retrieval/test_output_shaping.py::test_as_context_appends_degraded_note \
-  tests/retrieval/test_output_shaping.py::test_as_context_default_has_no_degraded_note
+  tests/retrieval/test_output_shaping.py::test_as_context_appends_degraded_note
 ```
 
-Expected: `TypeError: ContextPack.__init__() got an unexpected keyword argument 'degraded_reason'`.
+Expected: two assertion failures: formatter ещё не добавляет degraded-note.
 
 - [ ] **Step 3: Добавить тип и безопасный formatter**
 
@@ -625,7 +627,11 @@ git commit -m "feat(retrieval): сообщать о fallback reranker"
 
 ---
 
-### Task 3: Полная регрессия и завершение ветки
+## Final verification и SDD review
+
+Эта фаза выполняется controller-ом после завершения и task-review Tasks 1–2. Она не
+dispatch-ится как отдельная implementation task: собственного diff у неё нет, а
+whole-branch review уже является обязательной частью SDD.
 
 **Files:**
 

--- a/docs/superpowers/plans/2026-07-29-pri-178-deterministic-reranker-fallback.md
+++ b/docs/superpowers/plans/2026-07-29-pri-178-deterministic-reranker-fallback.md
@@ -1,0 +1,707 @@
+# PRI-178 Deterministic Reranker Fallback Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Сделать bounded fallback `search_codebase` детерминированным, сохранить минимальное graph-разнообразие и сообщать потребителю о реальной деградации reranker.
+
+**Architecture:** `Retriever.search_base` будет получать graph neighbors через существующий ordered `GraphStore.expand_detailed`, восстанавливать этот порядок после `fetch_nodes` и разделять surviving chunks на hybrid/graph provenance. Чистый selector соберёт bounded fallback, а `ContextPack` получит типизированную причину деградации и безопасную trailing-note.
+
+**Tech Stack:** Python 3.11–3.13, dataclasses, `typing.Literal`, pytest, Neo4j-backed `GraphStore` (без изменения schema), Ruff.
+
+## Global Constraints
+
+- Язык проекта — русский: новые комментарии, docstrings и диагностический текст писать по-русски.
+- Line length — не более 100 символов; Ruff target — Python 3.11.
+- Не добавлять зависимости, настройки `CodebaseLimits`, миграции или schema changes.
+- Не менять `Retriever.retrieve`, ANN prefilter и успешный `rerank_scored -> select_by_cliff`.
+- Не менять Voyage retry `6×22s`, timeout или circuit breaker.
+- Unit-тесты не используют внешнюю сеть, Postgres, Neo4j или localhost; integration-тесты не входят в обязательный локальный прогон.
+- `ContextPack(items=...)` должен остаться обратно совместимым.
+
+---
+
+## File Map
+
+- `reviewer/retrieval/retriever.py` — provenance, ordered graph merge, чистый fallback selector, degraded metadata и rendering note.
+- `tests/retrieval/test_search_base.py` — поведение selector и оба no-rerank пути на уровне `search_base`.
+- `tests/retrieval/test_output_shaping.py` — точный контракт диагностической заметки `ContextPack.as_context`.
+- `tests/retrieval/test_retriever_branch.py` — fake graph переводится на `expand_detailed`, сохраняется branch-routing regression.
+- `docs/superpowers/specs/2026-07-29-pri-178-deterministic-reranker-fallback-design.md` — источник требований; кодовой правки не требует.
+
+---
+
+### Task 1: Детерминированный source-aware selector и ordered graph merge
+
+**Files:**
+
+- Modify: `reviewer/retrieval/retriever.py:11-159`
+- Modify: `tests/retrieval/test_search_base.py:18-206`
+- Modify: `tests/retrieval/test_retriever_branch.py:32-61`
+
+**Interfaces:**
+
+- Consumes: `GraphStore.expand_detailed(repo: str, node_ids: list[str], hops: int = 2, *, branch: str = "") -> list[dict]`, где dict содержит `id`, `rels`, `dist` и список упорядочен по `(dist, id)`.
+- Produces: `_select_degraded_context(hybrid_items: list, graph_items: list, ceiling: int) -> list`.
+- Produces: `search_base` передаёт в успешный reranker общий cleaned pool `hybrid_items + graph_items`; no-rerank пути используют `_select_degraded_context`.
+
+- [ ] **Step 1: Перевести retrieval fakes на ordered graph API**
+
+В `tests/retrieval/test_search_base.py` заменить `_FakeGraph`:
+
+```python
+class _FakeGraph:
+    def __init__(self, related=(), raise_=False):
+        self._related = list(related)
+        self.expand_calls = []
+        self._raise = raise_
+
+    def expand_detailed(self, repo, node_ids, hops=2, *, branch=""):
+        self.expand_calls.append({"repo": repo, "seeds": list(node_ids), "hops": hops,
+                                  "branch": branch})
+        if self._raise:
+            raise RuntimeError("neo4j down")
+        return list(self._related)
+```
+
+В существующих тестах передавать metadata:
+
+```python
+graph = _FakeGraph([{"id": "e.py#neighbor", "rels": ["CALLS"], "dist": 1}])
+```
+
+В `tests/retrieval/test_retriever_branch.py` оставить `expand` для `retrieve` и добавить
+отдельный метод для `search_base`:
+
+```python
+def expand_detailed(self, repo, node_ids, hops=2, *, branch=""):
+    self.branches.append(branch)
+    return []
+```
+
+- [ ] **Step 2: Написать падающие unit-тесты чистого selector**
+
+Добавить импорт и parameterized test в `tests/retrieval/test_search_base.py`:
+
+```python
+import pytest
+
+from reviewer.retrieval.retriever import _select_degraded_context
+
+
+@pytest.mark.parametrize(
+    ("hybrid_ids", "graph_ids", "ceiling", "expected"),
+    [
+        (["h1", "h2", "h3"], ["g1", "g2"], 3, ["h1", "h2", "g1"]),
+        (["h1"], ["g1", "g2"], 3, ["h1", "g1", "g2"]),
+        (["h1", "h2"], ["g1"], 1, ["h1"]),
+        ([], ["g1", "g2"], 1, ["g1"]),
+        (["h1", "h2"], [], 2, ["h1", "h2"]),
+        (["h1"], ["g1"], 0, []),
+    ],
+)
+def test_select_degraded_context(hybrid_ids, graph_ids, ceiling, expected):
+    hybrid = [_Hit(f"{node_id}.py#f") for node_id in hybrid_ids]
+    graph = [_Hit(f"{node_id}.py#f") for node_id in graph_ids]
+
+    selected = _select_degraded_context(hybrid, graph, ceiling)
+
+    assert [item.path.removesuffix(".py") for item in selected] == expected
+```
+
+- [ ] **Step 3: Запустить selector-тест и подтвердить RED**
+
+Run:
+
+```bash
+.venv/bin/pytest -q tests/retrieval/test_search_base.py::test_select_degraded_context
+```
+
+Expected: collection error `ImportError: cannot import name '_select_degraded_context'`.
+
+- [ ] **Step 4: Реализовать минимальный чистый selector**
+
+Добавить в `reviewer/retrieval/retriever.py` после `_dedupe_overlapping`:
+
+```python
+def _select_degraded_context(hybrid_items: list, graph_items: list, ceiling: int) -> list:
+    """Bounded fallback: hybrid приоритетен, graph даёт минимальное разнообразие."""
+    if ceiling <= 0:
+        return []
+    if not hybrid_items:
+        return graph_items[:ceiling]
+    if ceiling == 1:
+        return hybrid_items[:1]
+    if len(hybrid_items) < ceiling:
+        free = ceiling - len(hybrid_items)
+        return [*hybrid_items, *graph_items[:free]]
+    if graph_items:
+        return [*hybrid_items[:ceiling - 1], graph_items[0]]
+    return hybrid_items[:ceiling]
+```
+
+- [ ] **Step 5: Запустить selector-тест и подтвердить GREEN**
+
+Run:
+
+```bash
+.venv/bin/pytest -q tests/retrieval/test_search_base.py::test_select_degraded_context
+```
+
+Expected: `6 passed`.
+
+- [ ] **Step 6: Написать падающие search_base-тесты ordering и provenance**
+
+Добавить helper:
+
+```python
+def _meta(node_id, dist=1, rels=None):
+    return {"id": node_id, "dist": dist, "rels": rels or ["CALLS"]}
+```
+
+Добавить тесты:
+
+```python
+def test_search_base_restores_graph_order_after_fetch_nodes():
+    hits = [_Hit("h1.py#f")]
+    hits[0].bm25_hit = True
+    graph = _FakeGraph([_meta("g1.py#f", dist=1), _meta("g2.py#f", dist=2)])
+    store = _FakeStore(
+        hits,
+        related=[_Hit("g2.py#f"), _Hit("g1.py#f")],
+    )
+    retriever = Retriever(store, graph, _FakeEmbedder(), reranker=None)
+
+    pack = retriever.search_base("a/x", "x", limits=_cb(floor=1, ceiling=3))
+
+    assert [item.node_id for item in pack.items] == [
+        "h1.py#f", "g1.py#f", "g2.py#f",
+    ]
+
+
+def test_search_base_no_reranker_reserves_best_graph_item():
+    hits = [_Hit(f"h{i}.py#f") for i in range(1, 4)]
+    for hit in hits:
+        hit.bm25_hit = True
+    graph = _FakeGraph([_meta("g1.py#f"), _meta("g2.py#f", dist=2)])
+    store = _FakeStore(hits, related=[_Hit("g2.py#f"), _Hit("g1.py#f")])
+    retriever = Retriever(store, graph, _FakeEmbedder(), reranker=None)
+
+    pack = retriever.search_base("a/x", "x", limits=_cb(floor=1, ceiling=3))
+
+    assert [item.node_id for item in pack.items] == [
+        "h1.py#f", "h2.py#f", "g1.py#f",
+    ]
+
+
+def test_search_base_reranker_failure_uses_same_graph_reservation():
+    hits = [_Hit(f"h{i}.py#f") for i in range(1, 4)]
+    for hit in hits:
+        hit.bm25_hit = True
+    graph = _FakeGraph([_meta("g1.py#f")])
+    store = _FakeStore(hits, related=[_Hit("g1.py#f")])
+    reranker = _FakeReranker(raise_=True)
+    retriever = Retriever(store, graph, _FakeEmbedder(), reranker)
+
+    pack = retriever.search_base("a/x", "x", limits=_cb(floor=1, ceiling=3))
+
+    assert [item.node_id for item in pack.items] == [
+        "h1.py#f", "h2.py#f", "g1.py#f",
+    ]
+
+
+def test_search_base_filtered_graph_item_does_not_reserve_slot():
+    hits = [_Hit("h1.py#f"), _Hit("h2.py#f")]
+    for hit in hits:
+        hit.bm25_hit = True
+    graph = _FakeGraph([_meta("tests/test_graph.py#t")])
+    store = _FakeStore(hits, related=[_Hit("tests/test_graph.py#t")])
+    retriever = Retriever(store, graph, _FakeEmbedder(), reranker=None)
+
+    pack = retriever.search_base("a/x", "x", limits=_cb(floor=1, ceiling=2))
+
+    assert [item.node_id for item in pack.items] == ["h1.py#f", "h2.py#f"]
+
+
+def test_search_base_deduped_graph_item_does_not_reserve_slot():
+    hits = [
+        _Hit("a.py#Foo", start_line=1, end_line=50),
+        _Hit("b.py#f"),
+    ]
+    for hit in hits:
+        hit.bm25_hit = True
+    graph = _FakeGraph([_meta("a.py#Foo.method")])
+    store = _FakeStore(
+        hits,
+        related=[_Hit("a.py#Foo.method", start_line=10, end_line=20)],
+    )
+    retriever = Retriever(store, graph, _FakeEmbedder(), reranker=None)
+
+    pack = retriever.search_base("a/x", "x", limits=_cb(floor=1, ceiling=2))
+
+    assert [item.node_id for item in pack.items] == ["a.py#Foo", "b.py#f"]
+```
+
+- [ ] **Step 7: Запустить новые search_base-тесты и подтвердить RED**
+
+Run:
+
+```bash
+.venv/bin/pytest -q \
+  tests/retrieval/test_search_base.py::test_search_base_restores_graph_order_after_fetch_nodes \
+  tests/retrieval/test_search_base.py::test_search_base_no_reranker_reserves_best_graph_item \
+  tests/retrieval/test_search_base.py::test_search_base_reranker_failure_uses_same_graph_reservation \
+  tests/retrieval/test_search_base.py::test_search_base_filtered_graph_item_does_not_reserve_slot \
+  tests/retrieval/test_search_base.py::test_search_base_deduped_graph_item_does_not_reserve_slot
+```
+
+Expected: failures because `search_base` still calls `expand` and slices merged items.
+
+- [ ] **Step 8: Реализовать ordered graph merge и surviving provenance**
+
+В `search_base` заменить graph block и подготовку `items`:
+
+```python
+hybrid_ids = {hit.node_id for hit in hits}
+graph_only_ids: list[str] = []
+merged: dict[str, object] = {hit.node_id: hit for hit in hits}
+if self.graph is not None and hits:
+    try:
+        seeds = [hit.node_id for hit in hits[:ceiling]]
+        expanded = self.graph.expand_detailed(
+            repo, seeds, hops=hops, branch=branch)
+        graph_ids = [row["id"] for row in expanded]
+        fetched = self.store.fetch_nodes(
+            repo, graph_ids, "__none__", [], base_ref=bref)
+        fetched_by_id = {item.node_id: item for item in fetched}
+        related = [fetched_by_id[node_id] for node_id in graph_ids
+                   if node_id in fetched_by_id]
+        for item in related:
+            if item.node_id not in hybrid_ids:
+                graph_only_ids.append(item.node_id)
+            merged.setdefault(item.node_id, item)
+    except Exception:
+        log.warning("search_base: graph-expansion недоступен", exc_info=True)
+
+items = list(merged.values())
+if not include_tests:
+    items = [item for item in items if not _is_test_path(item.path)]
+items = _dedupe_overlapping(items)
+graph_only_id_set = set(graph_only_ids)
+hybrid_items = [item for item in items if item.node_id in hybrid_ids]
+graph_items = [item for item in items if item.node_id in graph_only_id_set]
+```
+
+Перед успешным rerank собирать cleaned pool как `items = [*hybrid_items, *graph_items]`.
+No-rerank часть Task 1 структурировать полностью (Task 2 позже добавит metadata):
+
+```python
+items = [*hybrid_items, *graph_items]
+if len(items) <= lim.floor:
+    selected = (
+        _select_degraded_context(hybrid_items, graph_items, ceiling)
+        if len(items) > ceiling
+        else items
+    )
+    return ContextPack(items=selected, max_chars=self.max_context_chars)
+
+if self.reranker is None:
+    selected = _select_degraded_context(hybrid_items, graph_items, ceiling)
+    return ContextPack(items=selected, max_chars=self.max_context_chars)
+
+try:
+    scored = self.reranker.rerank_scored(query, items)
+except Exception:
+    log.warning("search_base: rerank недоступен — deterministic fallback", exc_info=True)
+    selected = _select_degraded_context(hybrid_items, graph_items, ceiling)
+    return ContextPack(items=selected, max_chars=self.max_context_chars)
+```
+
+Успешные `select_by_cliff` и `ContextPack(tail_meta=...)` оставить без изменений.
+
+- [ ] **Step 9: Запустить Task 1 regression**
+
+Run:
+
+```bash
+.venv/bin/pytest -q tests/retrieval/test_search_base.py \
+  tests/retrieval/test_retriever_branch.py
+```
+
+Expected: all passed.
+
+- [ ] **Step 10: Проверить lint и закоммитить Task 1**
+
+Run:
+
+```bash
+.venv/bin/ruff check reviewer/retrieval/retriever.py \
+  tests/retrieval/test_search_base.py tests/retrieval/test_retriever_branch.py
+git diff --check
+```
+
+Expected: both commands exit 0.
+
+Commit:
+
+```bash
+git add reviewer/retrieval/retriever.py tests/retrieval/test_search_base.py \
+  tests/retrieval/test_retriever_branch.py
+git commit -m "fix(retrieval): сохранить graph-контекст без reranker"
+```
+
+---
+
+### Task 2: Типизированная degraded-note в ContextPack
+
+**Files:**
+
+- Modify: `reviewer/retrieval/retriever.py:1-159`
+- Modify: `tests/retrieval/test_output_shaping.py:1-85`
+- Modify: `tests/retrieval/test_search_base.py:178-206`
+
+**Interfaces:**
+
+- Consumes: `_select_degraded_context(hybrid_items: list, graph_items: list, ceiling: int) -> list` из Task 1.
+- Produces: `DegradedReason = Literal["reranker_unconfigured", "reranker_failed"]`.
+- Produces: `ContextPack.degraded_reason: DegradedReason | None`.
+- Preserves: `ContextPack(items=...)`, `tail_meta` и `as_context(line_numbers: bool = False) -> str`.
+
+- [ ] **Step 1: Написать падающие output-shaping тесты**
+
+В `tests/retrieval/test_output_shaping.py` добавить:
+
+```python
+@pytest.mark.parametrize(
+    ("reason", "fragment"),
+    [
+        ("reranker_unconfigured", "reranker не настроен"),
+        ("reranker_failed", "reranker недоступен"),
+    ],
+)
+def test_as_context_appends_degraded_note(reason, fragment):
+    out = ContextPack(items=[_node()], degraded_reason=reason).as_context()
+
+    assert fragment in out
+    assert "deterministic hybrid+graph fallback" in out
+    assert "def f():" in out
+
+
+def test_as_context_default_has_no_degraded_note():
+    out = ContextPack(items=[_node()]).as_context()
+
+    assert "fallback" not in out
+```
+
+- [ ] **Step 2: Запустить output-shaping тесты и подтвердить RED**
+
+Run:
+
+```bash
+.venv/bin/pytest -q \
+  tests/retrieval/test_output_shaping.py::test_as_context_appends_degraded_note \
+  tests/retrieval/test_output_shaping.py::test_as_context_default_has_no_degraded_note
+```
+
+Expected: `TypeError: ContextPack.__init__() got an unexpected keyword argument 'degraded_reason'`.
+
+- [ ] **Step 3: Добавить тип и безопасный formatter**
+
+В `reviewer/retrieval/retriever.py` добавить import и formatter:
+
+```python
+from typing import Literal
+
+DegradedReason = Literal["reranker_unconfigured", "reranker_failed"]
+
+_DEGRADED_NOTES: dict[DegradedReason, str] = {
+    "reranker_unconfigured": (
+        "— reranker не настроен: применён deterministic hybrid+graph fallback; "
+        "качество ранжирования снижено."
+    ),
+    "reranker_failed": (
+        "— reranker недоступен: применён deterministic hybrid+graph fallback; "
+        "качество ранжирования снижено."
+    ),
+}
+
+
+def _format_degraded_note(reason: DegradedReason | None) -> str | None:
+    return _DEGRADED_NOTES.get(reason) if reason is not None else None
+```
+
+Расширить dataclass:
+
+```python
+@dataclass
+class ContextPack:
+    items: list
+    max_chars: int = 0
+    max_tokens: int = 0
+    tail_meta: object = None
+    degraded_reason: DegradedReason | None = None
+```
+
+В конце `as_context`, после cliff-note:
+
+```python
+degraded_note = _format_degraded_note(self.degraded_reason)
+if degraded_note:
+    text = f"{text}\n\n{degraded_note}" if text else degraded_note
+```
+
+- [ ] **Step 4: Запустить output-shaping тесты и подтвердить GREEN**
+
+Run:
+
+```bash
+.venv/bin/pytest -q tests/retrieval/test_output_shaping.py
+```
+
+Expected: all passed.
+
+- [ ] **Step 5: Написать падающие reason-semantics тесты search_base**
+
+Добавить в `tests/retrieval/test_search_base.py`:
+
+```python
+def test_search_base_marks_unconfigured_reranker():
+    hits = [_Hit(f"h{i}.py#f") for i in range(1, 4)]
+    for hit in hits:
+        hit.bm25_hit = True
+    retriever = Retriever(
+        _FakeStore(hits),
+        _FakeGraph(),
+        _FakeEmbedder(),
+        reranker=None,
+    )
+
+    pack = retriever.search_base("a/x", "x", limits=_cb(floor=1, ceiling=2))
+
+    assert pack.degraded_reason == "reranker_unconfigured"
+
+
+def test_search_base_marks_failed_reranker():
+    hits = [_Hit(f"h{i}.py#f") for i in range(1, 4)]
+    for hit in hits:
+        hit.bm25_hit = True
+    retriever = Retriever(
+        _FakeStore(hits),
+        _FakeGraph(),
+        _FakeEmbedder(),
+        _FakeReranker(raise_=True),
+    )
+
+    pack = retriever.search_base("a/x", "x", limits=_cb(floor=1, ceiling=2))
+
+    assert pack.degraded_reason == "reranker_failed"
+
+
+def test_search_base_small_pool_is_not_marked_degraded():
+    hits = [_Hit("h1.py#f"), _Hit("h2.py#f")]
+    for hit in hits:
+        hit.bm25_hit = True
+    reranker = _FakeReranker()
+    retriever = Retriever(_FakeStore(hits), _FakeGraph(), _FakeEmbedder(), reranker)
+
+    pack = retriever.search_base("a/x", "x", limits=_cb(floor=4, ceiling=1))
+
+    assert pack.degraded_reason is None
+    assert reranker.calls == []
+
+
+def test_search_base_successful_rerank_is_not_marked_degraded():
+    hits = [_Hit(f"h{i}.py#f") for i in range(1, 4)]
+    for hit in hits:
+        hit.bm25_hit = True
+    retriever = Retriever(
+        _FakeStore(hits),
+        _FakeGraph(),
+        _FakeEmbedder(),
+        _FakeReranker(scores=[0.9, 0.8, 0.7]),
+    )
+
+    pack = retriever.search_base("a/x", "x", limits=_cb(floor=1, ceiling=3))
+
+    assert pack.degraded_reason is None
+```
+
+- [ ] **Step 6: Запустить reason-тесты и подтвердить RED**
+
+Run:
+
+```bash
+.venv/bin/pytest -q \
+  tests/retrieval/test_search_base.py::test_search_base_marks_unconfigured_reranker \
+  tests/retrieval/test_search_base.py::test_search_base_marks_failed_reranker \
+  tests/retrieval/test_search_base.py::test_search_base_small_pool_is_not_marked_degraded \
+  tests/retrieval/test_search_base.py::test_search_base_successful_rerank_is_not_marked_degraded
+```
+
+Expected: first two tests fail because `search_base` does not set `degraded_reason`.
+
+- [ ] **Step 7: Wire degraded reasons только в реальные fallback-пути**
+
+Структурировать no-rerank часть `search_base` так:
+
+```python
+if len(items) <= lim.floor:
+    selected = (
+        _select_degraded_context(hybrid_items, graph_items, ceiling)
+        if len(items) > ceiling
+        else items
+    )
+    return ContextPack(items=selected, max_chars=self.max_context_chars)
+
+if self.reranker is None:
+    return ContextPack(
+        items=_select_degraded_context(hybrid_items, graph_items, ceiling),
+        max_chars=self.max_context_chars,
+        degraded_reason="reranker_unconfigured",
+    )
+
+try:
+    scored = self.reranker.rerank_scored(query, items)
+except Exception:
+    log.warning("search_base: rerank недоступен — deterministic fallback", exc_info=True)
+    return ContextPack(
+        items=_select_degraded_context(hybrid_items, graph_items, ceiling),
+        max_chars=self.max_context_chars,
+        degraded_reason="reranker_failed",
+    )
+```
+
+Успешный return оставить:
+
+```python
+return ContextPack(
+    items=kept,
+    max_chars=self.max_context_chars,
+    tail_meta=tail_meta,
+)
+```
+
+- [ ] **Step 8: Запустить весь retrieval-набор**
+
+Run:
+
+```bash
+.venv/bin/pytest -q tests/retrieval
+```
+
+Expected: all passed.
+
+- [ ] **Step 9: Проверить MCP consumers**
+
+Run:
+
+```bash
+.venv/bin/pytest -q \
+  tests/mcp/test_service.py \
+  tests/mcp/test_context_limits_wiring.py
+```
+
+Expected: all passed; `search_codebase` и `definition` продолжают рендерить
+`ContextPack.as_context(line_numbers=True)`.
+
+- [ ] **Step 10: Проверить lint и закоммитить Task 2**
+
+Run:
+
+```bash
+.venv/bin/ruff check reviewer/retrieval/retriever.py \
+  tests/retrieval/test_output_shaping.py tests/retrieval/test_search_base.py
+git diff --check
+```
+
+Expected: both commands exit 0.
+
+Commit:
+
+```bash
+git add reviewer/retrieval/retriever.py \
+  tests/retrieval/test_output_shaping.py tests/retrieval/test_search_base.py
+git commit -m "feat(retrieval): сообщать о fallback reranker"
+```
+
+---
+
+### Task 3: Полная регрессия и завершение ветки
+
+**Files:**
+
+- Verify only: `reviewer/retrieval/retriever.py`
+- Verify only: `tests/retrieval/test_search_base.py`
+- Verify only: `tests/retrieval/test_output_shaping.py`
+- Verify only: `tests/retrieval/test_retriever_branch.py`
+
+**Interfaces:**
+
+- Consumes: готовые `_select_degraded_context`, `DegradedReason`, `ContextPack.degraded_reason`.
+- Produces: проверенную ветку без незакоммиченных code/test изменений.
+
+- [ ] **Step 1: Запустить полный unit-набор**
+
+Run:
+
+```bash
+.venv/bin/pytest -q
+```
+
+Expected: не меньше baseline `2643 passed, 1 skipped, 92 deselected`; новые тесты
+увеличивают число passed, ошибок нет.
+
+- [ ] **Step 2: Запустить полный Ruff**
+
+Run:
+
+```bash
+.venv/bin/ruff check .
+```
+
+Expected: exit 0.
+
+- [ ] **Step 3: Проверить diff и историю**
+
+Run:
+
+```bash
+git diff --check
+git status --short
+git log --oneline --decorate -5
+```
+
+Expected: `git diff --check` exit 0; нет незакоммиченных code/test изменений; история
+содержит docs commit и два implementation commits PRI-178.
+
+- [ ] **Step 4: Провести обязательный code review**
+
+Использовать `superpowers:requesting-code-review`. Review должен проверить:
+
+- соответствие spec и критериев PRI-178;
+- отсутствие изменений `Retriever.retrieve`, retry и `CodebaseLimits`;
+- детерминизм graph ordering;
+- bounded invariant `len(items) <= ceiling`;
+- отсутствие утечки exception/provider details в degraded-note.
+
+Если review находит проблему, исправить её через TDD, повторить targeted tests и создать
+отдельный conventional commit.
+
+- [ ] **Step 5: Повторить verification после review fixes**
+
+Run:
+
+```bash
+.venv/bin/pytest -q
+.venv/bin/ruff check .
+git diff --check
+git status --short
+```
+
+Expected: тесты и lint проходят; рабочее дерево чистое.
+
+- [ ] **Step 6: Перейти к интеграции**
+
+Использовать `superpowers:finishing-a-development-branch`, сравнить ветку с `origin/dev`
+и предложить пользователю merge/PR/сохранение worktree. После создания PR использовать
+`rag-reviewer:reviewer_finish-task`, чтобы добавить PR в PRI-178 и закрыть карточку только
+с явного подтверждения пользователя.

--- a/docs/superpowers/plans/2026-07-29-pri-178-deterministic-reranker-fallback.md
+++ b/docs/superpowers/plans/2026-07-29-pri-178-deterministic-reranker-fallback.md
@@ -388,7 +388,7 @@ def test_as_context_appends_degraded_note(reason, fragment):
     out = pack.as_context()
 
     assert fragment in out
-    assert "deterministic hybrid+graph fallback" in out
+    assert "детерминированный резервный отбор hybrid+graph" in out
     assert "def f():" in out
 ```
 
@@ -417,11 +417,13 @@ DegradedReason = Literal["reranker_unconfigured", "reranker_failed"]
 
 _DEGRADED_NOTES: dict[DegradedReason, str] = {
     "reranker_unconfigured": (
-        "— reranker не настроен: применён deterministic hybrid+graph fallback; "
+        "— reranker не настроен: применён детерминированный резервный отбор "
+        "hybrid+graph; "
         "качество ранжирования снижено."
     ),
     "reranker_failed": (
-        "— reranker недоступен: применён deterministic hybrid+graph fallback; "
+        "— reranker недоступен: применён детерминированный резервный отбор "
+        "hybrid+graph; "
         "качество ранжирования снижено."
     ),
 }

--- a/docs/superpowers/specs/2026-07-29-pri-178-deterministic-reranker-fallback-design.md
+++ b/docs/superpowers/specs/2026-07-29-pri-178-deterministic-reranker-fallback-design.md
@@ -130,7 +130,8 @@ degraded_reason: DegradedReason | None = None
 `as_context` после основного текста и cliff-note добавляет одну из двух коротких заметок:
 
 - `reranker_unconfigured` — поиск выполнен без настроенного reranker;
-- `reranker_failed` — reranker недоступен, применён deterministic hybrid+graph fallback.
+- `reranker_failed` — reranker недоступен, применён детерминированный резервный отбор
+  hybrid+graph.
 
 Текст исключения, credentials и provider details в заметку не попадают. Малый пул,
 который штатно не требует rerank, `degraded_reason` не получает. Успешный cliff-path

--- a/docs/superpowers/specs/2026-07-29-pri-178-deterministic-reranker-fallback-design.md
+++ b/docs/superpowers/specs/2026-07-29-pri-178-deterministic-reranker-fallback-design.md
@@ -1,0 +1,202 @@
+# PRI-178 — детерминированный fallback search_codebase
+
+Статус: утверждено пользователем 2026-07-29.
+
+## Цель
+
+Сохранить полезное graph-разнообразие в bounded-выдаче `Retriever.search_base`, когда
+Voyage reranker не настроен или завершился ошибкой, и явно сообщить потребителю о
+деградации качества ранжирования.
+
+## Проблема
+
+`search_base` получает упорядоченные hybrid/RRF hits, расширяет их соседями из графа и
+добавляет graph-only chunks после hits. Успешный reranker оценивает общий пул, поэтому
+источник кандидата не важен. В no-rerank ветках используется `items[:ceiling]`; если
+hybrid hits заполняют лимит, graph-only хвост исчезает.
+
+Простая долевая квота не подходит:
+
+- graph-кандидаты не имеют semantic score и не должны массово вытеснять RRF hits;
+- `GraphStore.expand` возвращает `set`, а `ChunkStore.fetch_nodes` не обещает порядок;
+- результат fallback не должен меняться из-за порядка строк БД.
+
+Fallback также не отличим от успешного ранжирования по возвращаемому `ContextPack`, хотя
+его используют session-less инструменты глобального плагина.
+
+## Scope
+
+В scope:
+
+- только `Retriever.search_base`;
+- стабильное ранжирование graph-only кандидатов существующим `expand_detailed`;
+- единый чистый selector для no-rerank путей;
+- типизированная причина degraded-mode и краткая заметка в `ContextPack.as_context`;
+- unit-тесты selection, provenance, ordering и output shaping.
+
+Вне scope:
+
+- PR-session путь `Retriever.retrieve`;
+- Voyage retry `6×22s`, timeout или circuit breaker;
+- изменение ANN prefilter, RRF, успешного rerank/cliff;
+- новые настройки `CodebaseLimits`;
+- новые зависимости или изменения схемы данных.
+
+## Архитектура
+
+### 1. Стабильное graph expansion
+
+`search_base` вызывает существующий
+`GraphStore.expand_detailed(repo, seeds, hops=hops, branch=branch)`. Метод уже возвращает
+элементы вида `{"id": str, "rels": list[str], "dist": int}` в порядке
+`(dist, node_id)`.
+
+`fetch_nodes` может вернуть chunks в другом порядке, поэтому `search_base`:
+
+1. сохраняет ordered `graph_ids` из `expand_detailed`;
+2. строит `fetched_by_id`;
+3. восстанавливает `related` обходом `graph_ids`;
+4. исключает ids, уже присутствующие среди hybrid hits.
+
+Graph error остаётся fail-soft: логируется, `graph-only=[]`, поиск продолжается по hybrid
+hits.
+
+### 2. Provenance после очистки
+
+До объединения фиксируются `hybrid_ids` и ordered `graph_only_ids`. Общий пул сохраняет
+текущий порядок `hybrid -> graph`, затем проходит существующие test filtering и
+`_dedupe_overlapping`.
+
+После очистки список снова делится по surviving `node_id`:
+
+- `hybrid_items` — surviving items с id из `hybrid_ids`;
+- `graph_items` — surviving items с id из `graph_only_ids`.
+
+Это важно для случая, когда широкий chunk удаляет вложенный chunk другого источника:
+selector видит только реально оставшиеся элементы и не резервирует пустой graph-слот.
+
+### 3. Source-aware selector
+
+В `reviewer/retrieval/retriever.py` добавляется чистая функция:
+
+```python
+def _select_degraded_context(
+    hybrid_items: list,
+    graph_items: list,
+    ceiling: int,
+) -> list:
+    ...
+```
+
+Политика:
+
+1. `ceiling <= 0` возвращает `[]`.
+2. Если hybrid items нет, graph items заполняют выдачу до `ceiling`.
+3. `ceiling == 1` возвращает первый hybrid item; graph используется только если hybrid
+   пуст.
+4. Если hybrid items меньше `ceiling`, они остаются первыми, а свободные слоты
+   заполняются ordered graph items.
+5. Если hybrid items заполняют `ceiling` и graph items существуют, selector сохраняет
+   первые `ceiling - 1` hybrid items и добавляет первый graph item.
+6. Если graph items нет, возвращаются первые `ceiling` hybrid items.
+
+Таким образом лучший RRF hit сохраняется, graph получает минимальный один слот, а
+результат всегда bounded и детерминирован.
+
+Selector применяется:
+
+- когда reranker отсутствует и пул требует ранжирования;
+- когда `rerank_scored` бросает исключение;
+- при малом пуле без вызова reranker только если `ceiling` действительно отсекает
+  элементы; этот путь использует ту же selection policy, но не считается деградацией
+  reranker.
+
+### 4. Degraded metadata
+
+В модуле retrieval объявляется:
+
+```python
+from typing import Literal
+
+DegradedReason = Literal["reranker_unconfigured", "reranker_failed"]
+```
+
+`ContextPack` получает поле:
+
+```python
+degraded_reason: DegradedReason | None = None
+```
+
+`as_context` после основного текста и cliff-note добавляет одну из двух коротких заметок:
+
+- `reranker_unconfigured` — поиск выполнен без настроенного reranker;
+- `reranker_failed` — reranker недоступен, применён deterministic hybrid+graph fallback.
+
+Текст исключения, credentials и provider details в заметку не попадают. Малый пул,
+который штатно не требует rerank, `degraded_reason` не получает. Успешный cliff-path
+также остаётся без degraded-note.
+
+## Поток данных
+
+```text
+hybrid_search -> ANN prefilter -> ordered hybrid hits
+                                 |
+                                 +-> expand_detailed -> fetch_nodes -> reorder by (dist, id)
+                                                          |
+hybrid + graph-only -> test filter -> overlap dedup -> split surviving provenance
+                                                          |
+                         +--------------------------------+------------------+
+                         |                                                   |
+                  rerank succeeds                                    no rerank / error
+                         |                                                   |
+                  select_by_cliff                              _select_degraded_context
+                         |                                                   |
+                  ContextPack(tail_meta)                 ContextPack(degraded_reason)
+```
+
+## Ошибки и совместимость
+
+- Graph failure: прежний hybrid-only fail-soft.
+- Reranker exception: прежний fail-soft без проброса ошибки, но с deterministic selection
+  и безопасной диагностической заметкой.
+- Конструкторы `ContextPack(items=...)` совместимы благодаря default `None`.
+- Формат code chunks и line-numbered output не меняется; добавляется только trailing note
+  в реальном degraded-mode.
+- Публичные MCP signatures и board/config contracts не меняются.
+
+## Тестирование
+
+`tests/retrieval/test_search_base.py`:
+
+- fake graph поддерживает `expand_detailed` и фиксирует `hops`/`branch`;
+- shuffled `fetch_nodes` восстанавливается в `(dist, node_id)` order;
+- no-reranker и exception paths сохраняют top hybrid и один graph при полном лимите;
+- свободные слоты заполняются graph items;
+- `ceiling=1` сохраняет top hybrid;
+- test-filtered или overlap-deduped graph item не резервирует слот;
+- малый пул без rerank не получает degraded reason;
+- успешный rerank/cliff не меняется.
+
+`tests/retrieval/test_output_shaping.py`:
+
+- обе degraded reasons рендерят ожидаемую безопасную заметку;
+- обычный `ContextPack` не получает заметку.
+
+Регрессия:
+
+```bash
+.venv/bin/pytest -q tests/retrieval
+.venv/bin/pytest -q tests/mcp/test_service.py tests/mcp/test_context_limits_wiring.py
+.venv/bin/ruff check reviewer/retrieval/retriever.py tests/retrieval
+.venv/bin/pytest -q
+```
+
+## Решения, принятые при self-review
+
+- Scope остаётся одной подсистемой retrieval; `expand_detailed` уже существует, поэтому
+  отдельное изменение graph API не требуется.
+- Фиксируется один минимальный graph-слот, а не произвольная доля.
+- Штатный skip reranker на малом пуле отделён от реальной деградации и не создаёт шумной
+  заметки.
+- Все edge cases (`ceiling<=0`, `ceiling=1`, пустой источник, dedup/filter) имеют
+  однозначную семантику.

--- a/reviewer/retrieval/retriever.py
+++ b/reviewer/retrieval/retriever.py
@@ -1,11 +1,32 @@
 from __future__ import annotations
 from dataclasses import dataclass
 import logging
+from typing import Literal
 
 from reviewer.index.refs import base_ref
 from reviewer.retrieval.cliff import format_tail_note, select_by_cliff
 
 log = logging.getLogger(__name__)
+
+
+DegradedReason = Literal["reranker_unconfigured", "reranker_failed"]
+
+_DEGRADED_NOTES: dict[DegradedReason, str] = {
+    "reranker_unconfigured": (
+        "— reranker не настроен: применён детерминированный резервный отбор "
+        "hybrid+graph; "
+        "качество ранжирования снижено."
+    ),
+    "reranker_failed": (
+        "— reranker недоступен: применён детерминированный резервный отбор "
+        "hybrid+graph; "
+        "качество ранжирования снижено."
+    ),
+}
+
+
+def _format_degraded_note(reason: DegradedReason | None) -> str | None:
+    return _DEGRADED_NOTES.get(reason) if reason is not None else None
 
 
 def _is_test_path(path: str) -> bool:
@@ -68,6 +89,7 @@ class ContextPack:
     max_chars: int = 0
     max_tokens: int = 0
     tail_meta: object = None        # TailMeta | None (PRI-202); ленивая заметка о хвосте
+    degraded_reason: DegradedReason | None = None
 
     def as_context(self, line_numbers: bool = False) -> str:
         parts = []
@@ -92,6 +114,9 @@ class ContextPack:
         note = format_tail_note(self.tail_meta) if self.tail_meta is not None else None
         if note:
             text = f"{text}\n\n{note}" if text else note
+        degraded_note = _format_degraded_note(self.degraded_reason)
+        if degraded_note:
+            text = f"{text}\n\n{degraded_note}" if text else degraded_note
         return text
 
 
@@ -178,15 +203,20 @@ class Retriever:
             )
             return ContextPack(items=selected, max_chars=self.max_context_chars)
         if self.reranker is None:
-            selected = _select_degraded_context(hybrid_items, graph_items, ceiling)
-            return ContextPack(items=selected, max_chars=self.max_context_chars)
+            return ContextPack(
+                items=_select_degraded_context(hybrid_items, graph_items, ceiling),
+                max_chars=self.max_context_chars,
+                degraded_reason="reranker_unconfigured",
+            )
         try:
             scored = self.reranker.rerank_scored(query, items)
         except Exception:
-            log.warning("search_base: реранкер недоступен — детерминированный запасной выбор",
-                        exc_info=True)
-            selected = _select_degraded_context(hybrid_items, graph_items, ceiling)
-            return ContextPack(items=selected, max_chars=self.max_context_chars)
+            log.warning("search_base: rerank недоступен — deterministic fallback", exc_info=True)
+            return ContextPack(
+                items=_select_degraded_context(hybrid_items, graph_items, ceiling),
+                max_chars=self.max_context_chars,
+                degraded_reason="reranker_failed",
+            )
         kept, tail_meta = select_by_cliff(
             scored, floor_n=lim.floor, ceiling_n=ceiling,
             ratio=lim.ratio, abs_floor=lim.abs_floor)

--- a/reviewer/retrieval/retriever.py
+++ b/reviewer/retrieval/retriever.py
@@ -211,7 +211,10 @@ class Retriever:
         try:
             scored = self.reranker.rerank_scored(query, items)
         except Exception:
-            log.warning("search_base: rerank недоступен — deterministic fallback", exc_info=True)
+            log.warning(
+                "search_base: реранкер недоступен — применён детерминированный резервный отбор",
+                exc_info=True,
+            )
             return ContextPack(
                 items=_select_degraded_context(hybrid_items, graph_items, ceiling),
                 max_chars=self.max_context_chars,

--- a/reviewer/retrieval/retriever.py
+++ b/reviewer/retrieval/retriever.py
@@ -47,7 +47,7 @@ def _dedupe_overlapping(items: list) -> list:
 
 
 def _select_degraded_context(hybrid_items: list, graph_items: list, ceiling: int) -> list:
-    """Bounded fallback: hybrid приоритетен, graph даёт минимальное разнообразие."""
+    """Ограниченный запасной выбор: гибридный контекст приоритетен, граф добавляет разнообразие."""
     if ceiling <= 0:
         return []
     if not hybrid_items:
@@ -183,7 +183,8 @@ class Retriever:
         try:
             scored = self.reranker.rerank_scored(query, items)
         except Exception:
-            log.warning("search_base: rerank недоступен — deterministic fallback", exc_info=True)
+            log.warning("search_base: реранкер недоступен — детерминированный запасной выбор",
+                        exc_info=True)
             selected = _select_degraded_context(hybrid_items, graph_items, ceiling)
             return ContextPack(items=selected, max_chars=self.max_context_chars)
         kept, tail_meta = select_by_cliff(

--- a/reviewer/retrieval/retriever.py
+++ b/reviewer/retrieval/retriever.py
@@ -46,6 +46,22 @@ def _dedupe_overlapping(items: list) -> list:
     return kept
 
 
+def _select_degraded_context(hybrid_items: list, graph_items: list, ceiling: int) -> list:
+    """Bounded fallback: hybrid приоритетен, graph даёт минимальное разнообразие."""
+    if ceiling <= 0:
+        return []
+    if not hybrid_items:
+        return graph_items[:ceiling]
+    if ceiling == 1:
+        return hybrid_items[:1]
+    if len(hybrid_items) < ceiling:
+        free = ceiling - len(hybrid_items)
+        return [*hybrid_items, *graph_items[:free]]
+    if graph_items:
+        return [*hybrid_items[:ceiling - 1], graph_items[0]]
+    return hybrid_items[:ceiling]
+
+
 @dataclass
 class ContextPack:
     items: list
@@ -112,8 +128,8 @@ class Retriever:
                     branch="", include_tests=False) -> ContextPack:
         """Гибрид-поиск по base-индексу ветки без PR-сессии — для /solve-task (PRI-202).
 
-        ANN-префильтр (BM25-aware) → always rerank_scored → cliff-отсечка. Граф и
-        реранкер fail-soft (откат на RRF-порядок + срез по ceiling, без заметки).
+        ANN-префильтр (BM25-aware) → rerank_scored → cliff-отсечка. Граф и
+        реранкер fail-soft: hybrid приоритетен, graph сохраняет разнообразие.
         """
         from reviewer.policy.context_limits import CodebaseLimits
         lim = limits or CodebaseLimits()
@@ -128,31 +144,48 @@ class Retriever:
         hits = [h for h in hits if getattr(h, "bm25_hit", False)
                 or (getattr(h, "ann_distance", None) is not None
                     and h.ann_distance <= lim.ann_distance_max)]
-        merged: dict[str, object] = {}
-        for h in hits:
-            merged.setdefault(h.node_id, h)
+        hybrid_ids = {hit.node_id for hit in hits}
+        graph_only_ids: list[str] = []
+        merged: dict[str, object] = {hit.node_id: hit for hit in hits}
         if self.graph is not None and hits:
             try:
-                seeds = [h.node_id for h in hits[:ceiling]]
-                related_ids = self.graph.expand(repo, seeds, hops=hops, branch=branch)
-                related = self.store.fetch_nodes(repo, list(related_ids), "__none__", [],
-                                                 base_ref=bref)
-                for it in related:
-                    merged.setdefault(it.node_id, it)   # graph-items префильтр не трогает
+                seeds = [hit.node_id for hit in hits[:ceiling]]
+                expanded = self.graph.expand_detailed(repo, seeds, hops=hops, branch=branch)
+                graph_ids = [row["id"] for row in expanded]
+                fetched = self.store.fetch_nodes(repo, graph_ids, "__none__", [], base_ref=bref)
+                fetched_by_id = {item.node_id: item for item in fetched}
+                related = [fetched_by_id[node_id] for node_id in graph_ids
+                           if node_id in fetched_by_id]
+                for item in related:
+                    if item.node_id not in hybrid_ids:
+                        graph_only_ids.append(item.node_id)
+                    merged.setdefault(item.node_id, item)
             except Exception:
                 log.warning("search_base: graph-expansion недоступен", exc_info=True)
         items = list(merged.values())
         if not include_tests:
-            items = [it for it in items if not _is_test_path(it.path)]
+            items = [item for item in items if not _is_test_path(item.path)]
         items = _dedupe_overlapping(items)
-        # Fail-soft: нет реранкера/пусто/мелкий пул → RRF-порядок, срез по ceiling, без заметки
-        if self.reranker is None or len(items) <= lim.floor:
-            return ContextPack(items=items[:ceiling], max_chars=self.max_context_chars)
+        graph_only_id_set = set(graph_only_ids)
+        hybrid_items = [item for item in items if item.node_id in hybrid_ids]
+        graph_items = [item for item in items if item.node_id in graph_only_id_set]
+        items = [*hybrid_items, *graph_items]
+        if len(items) <= lim.floor:
+            selected = (
+                _select_degraded_context(hybrid_items, graph_items, ceiling)
+                if len(items) > ceiling
+                else items
+            )
+            return ContextPack(items=selected, max_chars=self.max_context_chars)
+        if self.reranker is None:
+            selected = _select_degraded_context(hybrid_items, graph_items, ceiling)
+            return ContextPack(items=selected, max_chars=self.max_context_chars)
         try:
             scored = self.reranker.rerank_scored(query, items)
         except Exception:
-            log.warning("search_base: rerank недоступен — RRF-порядок", exc_info=True)
-            return ContextPack(items=items[:ceiling], max_chars=self.max_context_chars)
+            log.warning("search_base: rerank недоступен — deterministic fallback", exc_info=True)
+            selected = _select_degraded_context(hybrid_items, graph_items, ceiling)
+            return ContextPack(items=selected, max_chars=self.max_context_chars)
         kept, tail_meta = select_by_cliff(
             scored, floor_n=lim.floor, ceiling_n=ceiling,
             ratio=lim.ratio, abs_floor=lim.abs_floor)

--- a/tests/retrieval/test_output_shaping.py
+++ b/tests/retrieval/test_output_shaping.py
@@ -71,6 +71,23 @@ def test_as_context_default_unchanged():
     assert out == "// a.py#f (a.py:10-11)\ndef f():\n    pass"
 
 
+@pytest.mark.parametrize(
+    ("reason", "fragment"),
+    [
+        ("reranker_unconfigured", "reranker не настроен"),
+        ("reranker_failed", "reranker недоступен"),
+    ],
+)
+def test_as_context_appends_degraded_note(reason, fragment):
+    pack = ContextPack(items=[_node()])
+    pack.degraded_reason = reason
+    out = pack.as_context()
+
+    assert fragment in out
+    assert "детерминированный резервный отбор hybrid+graph" in out
+    assert "def f():" in out
+
+
 def test_as_context_with_line_numbers():
     out = ContextPack(items=[_node()]).as_context(line_numbers=True)
     assert "// a.py#f (a.py:10-11)" in out

--- a/tests/retrieval/test_retriever_branch.py
+++ b/tests/retrieval/test_retriever_branch.py
@@ -37,6 +37,10 @@ class FakeGraph:
         self.branches.append(branch)
         return set()
 
+    def expand_detailed(self, repo, node_ids, hops=2, *, branch=""):
+        self.branches.append(branch)
+        return []
+
 
 class FakeEmb:
     def embed_query(self, q):

--- a/tests/retrieval/test_search_base.py
+++ b/tests/retrieval/test_search_base.py
@@ -1,3 +1,5 @@
+import pytest
+
 from reviewer.policy.context_limits import CodebaseLimits
 from reviewer.retrieval.retriever import ContextPack, Retriever
 
@@ -48,16 +50,17 @@ class _FakeEmbedder:
 
 
 class _FakeGraph:
-    def __init__(self, related_ids=(), raise_=False):
-        self._ids = set(related_ids)
+    def __init__(self, related=(), raise_=False):
+        self._related = list(related)
         self.expand_calls = []
         self._raise = raise_
 
-    def expand(self, repo, node_ids, hops=2, *, branch=""):
-        self.expand_calls.append({"repo": repo, "seeds": list(node_ids), "hops": hops})
+    def expand_detailed(self, repo, node_ids, hops=2, *, branch=""):
+        self.expand_calls.append({"repo": repo, "seeds": list(node_ids), "hops": hops,
+                                  "branch": branch})
         if self._raise:
             raise RuntimeError("neo4j down")
-        return set(self._ids)
+        return list(self._related)
 
 
 class _FakeReranker:
@@ -82,12 +85,42 @@ def _cb(**kw):
                                     abs_floor=0.3, candidate_pool=30, ann_distance_max=0.65), **kw})
 
 
+def _meta(node_id, dist=1, rels=None):
+    return {"id": node_id, "dist": dist, "rels": rels or ["CALLS"]}
+
+
+@pytest.mark.parametrize(
+    ("hybrid_ids", "graph_ids", "ceiling", "expected"),
+    [
+        (["h1", "h2", "h3"], ["g1", "g2"], 3, ["h1", "h2", "g1"]),
+        (["h1"], ["g1", "g2"], 3, ["h1", "g1", "g2"]),
+        (["h1", "h2"], ["g1"], 1, ["h1"]),
+        ([], ["g1", "g2"], 1, ["g1"]),
+        (["h1", "h2"], [], 2, ["h1", "h2"]),
+        (["h1"], ["g1"], 0, []),
+    ],
+)
+def test_select_degraded_context(hybrid_ids, graph_ids, ceiling, expected):
+    try:
+        from reviewer.retrieval.retriever import _select_degraded_context
+    except ImportError:
+        pytest.fail("_select_degraded_context ещё не реализован")
+    hybrid = [_Hit(f"{node_id}.py#f") for node_id in hybrid_ids]
+    graph = [_Hit(f"{node_id}.py#f") for node_id in graph_ids]
+
+    selected = _select_degraded_context(hybrid, graph, ceiling)
+
+    assert [item.path.removesuffix(".py") for item in selected] == expected
+
+
 def test_search_base_is_base_only_and_seeds_graph_from_hits():
     hits = [_Hit("a.py#f1"), _Hit("b.py#f2"), _Hit("c.py#f3"), _Hit("d.py#f4")]
     for h in hits:
         h.bm25_hit = True
     related = [_Hit("e.py#neighbor")]
-    store, graph, reranker, emb = (_FakeStore(hits, related), _FakeGraph({"e.py#neighbor"}),
+    store, graph, reranker, emb = (_FakeStore(hits, related),
+                                    _FakeGraph([{"id": "e.py#neighbor", "rels": ["CALLS"],
+                                                 "dist": 1}]),
                                     _FakeReranker(), _FakeEmbedder())
     r = Retriever(store, graph, emb, reranker, max_context_chars=8000)
     pack = r.search_base("a/x", "logout", limits=_cb())
@@ -199,8 +232,88 @@ def test_search_base_reranker_failure_falls_back_to_rrf():
 def test_search_base_seeds_graph_with_configured_hops():
     hits = [_Hit("a.py#f1")]
     hits[0].bm25_hit = True
-    graph = _FakeGraph({"e.py#n"})
+    graph = _FakeGraph([{"id": "e.py#n", "rels": ["CALLS"], "dist": 1}])
     store = _FakeStore(hits, related=[_Hit("e.py#n")])
     r = Retriever(store, graph, _FakeEmbedder(), _FakeReranker())
     r.search_base("a/x", "x", limits=_cb(), hops=2)
     assert graph.expand_calls[0]["hops"] == 2
+
+
+def test_search_base_restores_graph_order_after_fetch_nodes():
+    hits = [_Hit("h1.py#f")]
+    hits[0].bm25_hit = True
+    graph = _FakeGraph([_meta("g1.py#f", dist=1), _meta("g2.py#f", dist=2)])
+    store = _FakeStore(
+        hits,
+        related=[_Hit("g2.py#f"), _Hit("g1.py#f")],
+    )
+    retriever = Retriever(store, graph, _FakeEmbedder(), reranker=None)
+
+    pack = retriever.search_base("a/x", "x", limits=_cb(floor=1, ceiling=3))
+
+    assert [item.node_id for item in pack.items] == [
+        "h1.py#f", "g1.py#f", "g2.py#f",
+    ]
+
+
+def test_search_base_no_reranker_reserves_best_graph_item():
+    hits = [_Hit(f"h{i}.py#f") for i in range(1, 4)]
+    for hit in hits:
+        hit.bm25_hit = True
+    graph = _FakeGraph([_meta("g1.py#f"), _meta("g2.py#f", dist=2)])
+    store = _FakeStore(hits, related=[_Hit("g2.py#f"), _Hit("g1.py#f")])
+    retriever = Retriever(store, graph, _FakeEmbedder(), reranker=None)
+
+    pack = retriever.search_base("a/x", "x", limits=_cb(floor=1, ceiling=3))
+
+    assert [item.node_id for item in pack.items] == [
+        "h1.py#f", "h2.py#f", "g1.py#f",
+    ]
+
+
+def test_search_base_reranker_failure_uses_same_graph_reservation():
+    hits = [_Hit(f"h{i}.py#f") for i in range(1, 4)]
+    for hit in hits:
+        hit.bm25_hit = True
+    graph = _FakeGraph([_meta("g1.py#f")])
+    store = _FakeStore(hits, related=[_Hit("g1.py#f")])
+    reranker = _FakeReranker(raise_=True)
+    retriever = Retriever(store, graph, _FakeEmbedder(), reranker)
+
+    pack = retriever.search_base("a/x", "x", limits=_cb(floor=1, ceiling=3))
+
+    assert [item.node_id for item in pack.items] == [
+        "h1.py#f", "h2.py#f", "g1.py#f",
+    ]
+
+
+def test_search_base_filtered_graph_item_does_not_reserve_slot():
+    hits = [_Hit("h1.py#f"), _Hit("h2.py#f")]
+    for hit in hits:
+        hit.bm25_hit = True
+    graph = _FakeGraph([_meta("tests/test_graph.py#t")])
+    store = _FakeStore(hits, related=[_Hit("tests/test_graph.py#t")])
+    retriever = Retriever(store, graph, _FakeEmbedder(), reranker=None)
+
+    pack = retriever.search_base("a/x", "x", limits=_cb(floor=1, ceiling=2))
+
+    assert [item.node_id for item in pack.items] == ["h1.py#f", "h2.py#f"]
+
+
+def test_search_base_deduped_graph_item_does_not_reserve_slot():
+    hits = [
+        _Hit("a.py#Foo", start_line=1, end_line=50),
+        _Hit("b.py#f"),
+    ]
+    for hit in hits:
+        hit.bm25_hit = True
+    graph = _FakeGraph([_meta("a.py#Foo.method")])
+    store = _FakeStore(
+        hits,
+        related=[_Hit("a.py#Foo.method", start_line=10, end_line=20)],
+    )
+    retriever = Retriever(store, graph, _FakeEmbedder(), reranker=None)
+
+    pack = retriever.search_base("a/x", "x", limits=_cb(floor=1, ceiling=2))
+
+    assert [item.node_id for item in pack.items] == ["a.py#Foo", "b.py#f"]

--- a/tests/retrieval/test_search_base.py
+++ b/tests/retrieval/test_search_base.py
@@ -229,6 +229,67 @@ def test_search_base_reranker_failure_falls_back_to_rrf():
     assert pack.tail_meta is None        # заметка не пишется при фолбэке
 
 
+def test_search_base_marks_unconfigured_reranker():
+    hits = [_Hit(f"h{i}.py#f") for i in range(1, 4)]
+    for hit in hits:
+        hit.bm25_hit = True
+    retriever = Retriever(
+        _FakeStore(hits),
+        _FakeGraph(),
+        _FakeEmbedder(),
+        reranker=None,
+    )
+
+    pack = retriever.search_base("a/x", "x", limits=_cb(floor=1, ceiling=2))
+
+    assert pack.degraded_reason == "reranker_unconfigured"
+
+
+def test_search_base_marks_failed_reranker():
+    hits = [_Hit(f"h{i}.py#f") for i in range(1, 4)]
+    for hit in hits:
+        hit.bm25_hit = True
+    retriever = Retriever(
+        _FakeStore(hits),
+        _FakeGraph(),
+        _FakeEmbedder(),
+        _FakeReranker(raise_=True),
+    )
+
+    pack = retriever.search_base("a/x", "x", limits=_cb(floor=1, ceiling=2))
+
+    assert pack.degraded_reason == "reranker_failed"
+
+
+def test_search_base_small_pool_is_not_marked_degraded():
+    hits = [_Hit("h1.py#f"), _Hit("h2.py#f")]
+    for hit in hits:
+        hit.bm25_hit = True
+    reranker = _FakeReranker()
+    retriever = Retriever(_FakeStore(hits), _FakeGraph(), _FakeEmbedder(), reranker)
+
+    pack = retriever.search_base("a/x", "x", limits=_cb(floor=4, ceiling=1))
+
+    assert pack.degraded_reason is None
+    assert reranker.calls == []
+
+
+def test_search_base_successful_rerank_is_not_marked_degraded():
+    hits = [_Hit(f"h{i}.py#f") for i in range(1, 4)]
+    for hit in hits:
+        hit.bm25_hit = True
+    retriever = Retriever(
+        _FakeStore(hits),
+        _FakeGraph(),
+        _FakeEmbedder(),
+        _FakeReranker(scores=[0.9, 0.8, 0.7]),
+    )
+
+    pack = retriever.search_base("a/x", "x", limits=_cb(floor=1, ceiling=3))
+
+    assert pack.degraded_reason is None
+
+
 def test_search_base_seeds_graph_with_configured_hops():
     hits = [_Hit("a.py#f1")]
     hits[0].bm25_hit = True

--- a/tests/retrieval/test_search_base.py
+++ b/tests/retrieval/test_search_base.py
@@ -71,10 +71,13 @@ class _FakeReranker:
         self._raise = raise_
 
     def rerank_scored(self, query, items):
-        self.calls.append({"n": len(items)})
+        items = list(items)
+        self.calls.append({
+            "n": len(items),
+            "node_ids": [item.node_id for item in items],
+        })
         if self._raise:
             raise RuntimeError("voyage down")
-        items = list(items)
         scores = self._scores or [1.0 - i * 0.01 for i in range(len(items))]
         paired = list(zip(items, scores[:len(items)]))
         return sorted(paired, key=lambda p: p[1], reverse=True)
@@ -288,6 +291,41 @@ def test_search_base_successful_rerank_is_not_marked_degraded():
     pack = retriever.search_base("a/x", "x", limits=_cb(floor=1, ceiling=3))
 
     assert pack.degraded_reason is None
+
+
+def test_search_base_successful_reranker_receives_cleaned_source_order():
+    hits = [
+        _Hit("h1.py#f"),
+        _Hit("a.py#Foo", start_line=1, end_line=50),
+    ]
+    for hit in hits:
+        hit.bm25_hit = True
+    graph = _FakeGraph([
+        _meta("g1.py#f"),
+        _meta("tests/test_graph.py#t", dist=2),
+        _meta("a.py#Foo.method", dist=3),
+        _meta("g2.py#f", dist=4),
+    ])
+    store = _FakeStore(
+        hits,
+        related=[
+            _Hit("g2.py#f"),
+            _Hit("a.py#Foo.method", start_line=10, end_line=20),
+            _Hit("g1.py#f"),
+            _Hit("tests/test_graph.py#t"),
+        ],
+    )
+    reranker = _FakeReranker()
+    retriever = Retriever(store, graph, _FakeEmbedder(), reranker)
+
+    retriever.search_base("a/x", "x", limits=_cb(floor=1, ceiling=4))
+
+    assert reranker.calls[0]["node_ids"] == [
+        "h1.py#f",
+        "a.py#Foo",
+        "g1.py#f",
+        "g2.py#f",
+    ]
 
 
 def test_search_base_seeds_graph_with_configured_hops():


### PR DESCRIPTION
Задача: [PRI-178](https://ru.yougile.com/team/686c049c8af8/#PRI-178)
<!-- reviewer:task-link -->

## Проблема

При отсутствующем или упавшем reranker `Retriever.search_base` применял позиционный срез объединённого пула. Hybrid-кандидаты шли первыми, поэтому graph-expanded контекст мог полностью исчезать из результата.

Исходная формулировка PRI-178 ссылалась на устаревшие имена и предлагала произвольную квоту. Перед реализацией задача была актуализирована под текущий retrieval-контракт.

## Решение

- fallback использует общий детерминированный selector;
- при `ceiling >= 2` сохраняются лучший hybrid-кандидат и один лучший graph-only кандидат;
- остальные места заполняются hybrid, затем graph, без дублей и с жёстким соблюдением ceiling;
- graph-кандидаты восстанавливаются в порядке `GraphStore.expand_detailed`, независимо от порядка bulk-fetch;
- provenance определяется после test-фильтрации и overlap-dedupe;
- `ContextPack.degraded_reason` различает ненастроенный и упавший reranker;
- `as_context()` добавляет безопасную русскую degraded-note;
- успешный rerank, cliff selection, ANN, `Retriever.retrieve` и Voyage retry не изменены.

## Проверка

- `.venv/bin/pytest -q` — 2661 passed, 1 skipped, 92 deselected
- `.venv/bin/ruff check .` — clean
- `git diff --check` — clean
- независимое итоговое ревью — Ready to merge: Yes, Critical/Important findings отсутствуют

## Документы

- brief, design spec и implementation plan добавлены в `docs/superpowers/`
- regression-тест закрепляет точный порядок cleaned pool для успешного reranker после shuffled fetch, filtering и dedupe

Task: PRI-178