### PR TITLE
docs(readme): исправить команду установки и путь compose-файла

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,15 +28,23 @@ You need Python 3.11–3.13, [uv](https://docs.astral.sh/uv/), Docker, a Voyage 
 version-control system (VCS) token if reviewer should read or publish pull-request reviews. The
 stores run locally; embedding and reranking requests go to Voyage.
 
-1. Install the launcher, download the repository's Compose file, start the stores, and configure
-   reviewer:
+1. Install the launcher, download the repository's Compose file into reviewer's config directory,
+   start the stores, and configure reviewer:
 
    ```bash
-   uv tool install --from rag-reviewer reviewer
-   curl -O https://raw.githubusercontent.com/mimfort/rag_for_git/main/docker-compose.yml
-   docker compose up -d
+   uv tool install rag-reviewer
+   mkdir -p ~/.config/rag-reviewer
+   curl -o ~/.config/rag-reviewer/docker-compose.yml \
+     https://raw.githubusercontent.com/mimfort/rag_for_git/main/docker-compose.yml
+   docker compose -f ~/.config/rag-reviewer/docker-compose.yml up -d
    reviewer init
    ```
+
+   The Compose file lives next to the env file in `$XDG_CONFIG_HOME/rag-reviewer/`
+   (`~/.config/rag-reviewer/` by default), so one store stack serves every repository and the
+   Compose project name stays the same no matter which repository you are standing in. Plain
+   `curl -O` writes into the current directory instead; inside a clone of this repository it
+   overwrites the tracked `docker-compose.yml`.
 
 2. See the supported AI clients and connect one:
 
@@ -94,8 +102,10 @@ reviewer env on every workstation instead of using the loopback Compose defaults
 1. **On the shared host, start the stores and configure secrets for the service account.**
 
    ```bash
-   curl -O https://raw.githubusercontent.com/mimfort/rag_for_git/main/docker-compose.yml
-   docker compose up -d
+   mkdir -p ~/.config/rag-reviewer
+   curl -o ~/.config/rag-reviewer/docker-compose.yml \
+     https://raw.githubusercontent.com/mimfort/rag_for_git/main/docker-compose.yml
+   docker compose -f ~/.config/rag-reviewer/docker-compose.yml up -d
    reviewer init
    ```
 
@@ -224,9 +234,14 @@ For the module-level map and invariants, see [CLAUDE.md](CLAUDE.md).
 Persistent CLI:
 
 ```bash
-uv tool install --from rag-reviewer reviewer
+uv tool install rag-reviewer
 reviewer update
 ```
+
+`uv tool install` takes the package name and installs both of its commands, `reviewer` and
+`reviewer-mcp`. Its `--from` option only pins a different source for the same package
+(`--from rag-reviewer==0.4.2`, `--from git+…`); `--from PACKAGE COMMAND` is `uvx` syntax and
+`uv tool install` rejects it.
 
 Temporary/latest invocation:
 
@@ -505,7 +520,7 @@ uncommitted files directly from disk.
 
 | Symptom | Likely cause | Next action |
 |---|---|---|
-| `reviewer check` reports Postgres/Neo4j unavailable | Default stores are not running or DSNs differ | Run `docker compose up -d`, then repeat `reviewer check` |
+| `reviewer check` reports Postgres/Neo4j unavailable | Default stores are not running or DSNs differ | Run `docker compose -f ~/.config/rag-reviewer/docker-compose.yml up -d`, then repeat `reviewer check` |
 | Voyage returns 429 | Free-tier RPM/TPM quota is exhausted | Wait for the quota window; rerun incremental indexing rather than deleting the index |
 | PR is skipped | Its target branch is outside `REVIEW_BRANCHES`, or draft policy skips it | Inspect `prepare_review` reason and update policy only if the target is intentional |
 | Task lookup is empty | Board is disabled/unconfigured or the corpus is cold | Validate [board setup](docs/board-providers.md), then run `reviewer_sync-tasks` |

--- a/README.ru.md
+++ b/README.ru.md
@@ -28,15 +28,23 @@ inline-комментарии, привязанные к изменённым с
 системы контроля версий (VCS), если reviewer должен читать или публиковать ревью. Хранилища
 работают локально; запросы эмбеддингов и реранкинга отправляются в Voyage.
 
-1. Установите launcher, скачайте Compose-файл репозитория, поднимите хранилища и настройте
-   reviewer:
+1. Установите launcher, скачайте Compose-файл репозитория в каталог конфигурации reviewer,
+   поднимите хранилища и настройте reviewer:
 
    ```bash
-   uv tool install --from rag-reviewer reviewer
-   curl -O https://raw.githubusercontent.com/mimfort/rag_for_git/main/docker-compose.yml
-   docker compose up -d
+   uv tool install rag-reviewer
+   mkdir -p ~/.config/rag-reviewer
+   curl -o ~/.config/rag-reviewer/docker-compose.yml \
+     https://raw.githubusercontent.com/mimfort/rag_for_git/main/docker-compose.yml
+   docker compose -f ~/.config/rag-reviewer/docker-compose.yml up -d
    reviewer init
    ```
+
+   Compose-файл лежит рядом с env-файлом в `$XDG_CONFIG_HOME/rag-reviewer/` (по умолчанию
+   `~/.config/rag-reviewer/`), поэтому один набор хранилищ обслуживает все репозитории, а имя
+   Compose-проекта не зависит от каталога, из которого вы запускаете команду. Голый `curl -O`
+   пишет в текущий каталог; внутри клона этого репозитория он перезапишет версионируемый
+   `docker-compose.yml`.
 
 2. Посмотрите поддерживаемые AI-клиенты и подключите нужный:
 
@@ -94,8 +102,10 @@ reviewer env на каждой машине вместо loopback defaults из 
 1. **На shared host поднимите хранилища и настройте секреты service account.**
 
    ```bash
-   curl -O https://raw.githubusercontent.com/mimfort/rag_for_git/main/docker-compose.yml
-   docker compose up -d
+   mkdir -p ~/.config/rag-reviewer
+   curl -o ~/.config/rag-reviewer/docker-compose.yml \
+     https://raw.githubusercontent.com/mimfort/rag_for_git/main/docker-compose.yml
+   docker compose -f ~/.config/rag-reviewer/docker-compose.yml up -d
    reviewer init
    ```
 
@@ -227,9 +237,14 @@ PR → prepare_review → base + overlay retrieval → skill analysis
 Постоянный CLI:
 
 ```bash
-uv tool install --from rag-reviewer reviewer
+uv tool install rag-reviewer
 reviewer update
 ```
+
+`uv tool install` принимает имя пакета и ставит обе его команды — `reviewer` и `reviewer-mcp`.
+Опция `--from` здесь лишь уточняет источник того же пакета (`--from rag-reviewer==0.4.2`,
+`--from git+…`); форма `--from PACKAGE COMMAND` относится к `uvx`, и `uv tool install` её
+отвергает.
 
 Временный/latest запуск:
 
@@ -507,7 +522,7 @@ Base indexes отслеживают committed refs, а не working-tree edits. 
 
 | Симптом | Вероятная причина | Следующее действие |
 |---|---|---|
-| `reviewer check` не видит Postgres/Neo4j | Stores не запущены или DSN отличается | Запустите `docker compose up -d`, затем повторите `reviewer check` |
+| `reviewer check` не видит Postgres/Neo4j | Stores не запущены или DSN отличается | Запустите `docker compose -f ~/.config/rag-reviewer/docker-compose.yml up -d`, затем повторите `reviewer check` |
 | Voyage отвечает 429 | Исчерпан free-tier RPM/TPM | Дождитесь quota window; повторите incremental index, не удаляя существующий |
 | PR пропущен | Target branch вне `REVIEW_BRANCHES` или draft policy его исключает | Прочитайте reason `prepare_review`; меняйте policy только для намеренной target branch |
 | Task lookup пуст | Board отключён/не настроен или corpus не прогрет | Проверьте [board setup](docs/board-providers.md), затем запустите `reviewer_sync-tasks` |

--- a/tests/docs/test_readme_onboarding.py
+++ b/tests/docs/test_readme_onboarding.py
@@ -32,8 +32,8 @@ SECTION_PAIRS = CONTENT_PAIRS + (
 )
 
 PARITY_MARKERS = (
-    "uv tool install --from rag-reviewer reviewer",
-    "docker compose up -d",
+    "uv tool install rag-reviewer",
+    "docker compose -f ~/.config/rag-reviewer/docker-compose.yml up -d",
     "reviewer init",
     "reviewer install",
     "reviewer check",
@@ -196,8 +196,8 @@ def test_quick_start_downloads_compose_and_indexes_before_checking():
         _assert_in_order(
             section,
             (
-                "curl -O https://raw.githubusercontent.com/mimfort/rag_for_git/main/docker-compose.yml",
-                "docker compose up -d",
+                "curl -o ~/.config/rag-reviewer/docker-compose.yml",
+                "docker compose -f ~/.config/rag-reviewer/docker-compose.yml up -d",
                 "reviewer init",
                 "reviewer index /path/to/repo --ref main",
                 "reviewer check",


### PR DESCRIPTION
Команда из quickstart не работает:

```
$ uv tool install --from rag-reviewer reviewer
error: Package name (`rag-reviewer`) provided with `--from` does not match install request (`reviewer`)
```

У `uv tool install` позиционный аргумент — имя пакета, а `--from` уточняет лишь источник того же пакета. Форма `--from PACKAGE COMMAND` принадлежит `uvx`. Заменено на `uv tool install rag-reviewer`, который ставит обе команды пакета (`reviewer` и `reviewer-mcp`), плюс добавлено пояснение про `--from`. `README.md` идёт в PyPI как long description (`pyproject.toml:5`), поэтому неверная инструкция видна на странице проекта.

Compose-файл теперь скачивается в каталог конфигурации reviewer (`$XDG_CONFIG_HOME/rag-reviewer/`) рядом с `.env`, а стек поднимается с `-f`. Причины: один набор хранилищ на все репозитории, стабильное имя Compose-проекта независимо от каталога запуска, и голый `curl -O` внутри клона этого репозитория затирал версионируемый `docker-compose.yml`.

Guard-тест onboarding прибивал старые строки литералами — обновлён, теперь фиксирует размещение compose в каталоге конфигурации.

Проверка: `pytest tests/docs/` — 26 passed.