### PR TITLE
feat: add layered home repository config (PRI-221)

### DIFF
--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "rag-reviewer",
-  "version": "0.4.2+codex.d174a66ebfd3",
+  "version": "0.4.2+codex.c474f3e9135e",
   "description": "Agentic PR review: hybrid RAG + code graph via MCP, review skills for Codex",
   "repository": "https://github.com/mimfort/rag_for_git",
   "license": "MIT",

--- a/.superpowers/sdd/2026-07-30-pri-221-home-repository-config-layer/final-fix-report.md
+++ b/.superpowers/sdd/2026-07-30-pri-221-home-repository-config-layer/final-fix-report.md
@@ -1,0 +1,98 @@
+# PRI-221 final fix report
+
+## Revision
+
+- Starting SHA: `89e839b468ab6c28257489479bb323ed55b7eb98`.
+- Final fix commit: this report's commit, `fix: harden layered config integration`
+  (resolve with `git rev-parse HEAD` on `feature/pri-221-home-config`).
+
+## Scope and files
+
+- `reviewer/config/layers.py`: known-key home validation, type-sensitive
+  semantic comparison, immutable migration snapshot, pre-publication effective
+  validation, dotted paths, and hardened destination traversal/publication.
+- `reviewer/entrypoints/cli.py`: migration receives the already-created
+  `Settings` instance for canonical effective-policy validation.
+- `reviewer/mcp/service.py`: policy fail-soft logs no longer serialize raw
+  exception tracebacks.
+- `tests/conftest.py`: every test gets an empty per-test
+  `XDG_CONFIG_HOME`; integration policy setup explicitly depends on it.
+- Focused regressions and removal of local duplicate home fixtures:
+  `tests/config/test_layers.py`,
+  `tests/entrypoints/test_config_commands.py`,
+  `tests/entrypoints/test_index_ignore.py`,
+  `tests/mcp/test_context_limits_wiring.py`,
+  `tests/mcp/test_subsystem_summaries.py`,
+  `tests/mcp/test_summary_depth_overrides.py`,
+  `tests/services/test_prepare_ignore.py`, and
+  `tests/services/test_review_service.py`.
+- `.superpowers/sdd/2026-07-30-pri-221-home-repository-config-layer/`
+  `final-fix-report.md`: RED/GREEN, verification, review, and open concerns.
+
+## RED evidence
+
+Each production group was preceded by a focused failing run:
+
+1. Home semantic validation/redaction: five failures showed an invalid known
+   value merging despite shadowing, strict mode not raising, MCP aborting on an
+   invalid home value, a committed literal appearing in `exc_info`, and
+   `config show` accepting invalid home data.
+2. Migration snapshot/validation/equality: seven failures showed recursive
+   `bool == int == float` no-ops, repeated committed fetches for create/no-op,
+   and invalid candidate/simulated effective data reaching publication.
+3. Paths/filesystem: dotted `api.v2` resolved to `api.yml`; a symlinked owner
+   redirected publication; FIFO/socket entries reached `open`.
+4. Test isolation: a child pytest process launched with a conflicting operator
+   home changed `ReviewService.prepare` from committed `vendor` to
+   `home-vendor`.
+5. Exception-chain redaction: a malformed YAML literal appeared in
+   `traceback.format_exception(HomeConfigError)`.
+6. Final review compatibility: `categories: null` was quarantined even though
+   `ReviewPolicy.load_data` treats it as a supported clear/reset value.
+
+## GREEN evidence
+
+- Focused layer/config/policy/prepare/index/MCP suite:
+  `207 passed in 2.57s`.
+- Additional final sanitization group: `63 passed in 0.50s`.
+- Full non-integration suite:
+  `2720 passed, 1 skipped, 93 deselected, 1 warning in 59.88s`.
+- `.venv/bin/ruff check .`: passed.
+- `git diff --check`: passed.
+
+## Result
+
+- Invalid known values quarantine their entire home file before merge,
+  including values shadowed by later layers; runtime warnings and strict
+  exceptions identify only the source and never the literal. Unknown future
+  keys remain mergeable.
+- Migration fetches committed YAML exactly once and reuses that text for all
+  resolver paths, validates candidate/pre/post effective state before the
+  exclusive final publish, and performs recursive type-sensitive comparisons.
+- Repository names with dots are collision-free. Existing non-regular
+  destinations are rejected before open. Components below the configured root
+  are traversed with `O_DIRECTORY`/`O_NOFOLLOW` directory descriptors when
+  supported, with a checked cross-platform fallback; ancestors outside the
+  configured root remain allowed.
+- Unit, integration, and subprocess tests begin with an empty temporary XDG
+  home unless a test explicitly supplies a home layer.
+
+## Final review
+
+- Accepted: allow `categories: null` in the standalone known-key validator;
+  added runtime/strict and migration coverage.
+- Rejected: re-resolving and rolling back after publication. PRI-221
+  explicitly requires candidate/pre/post validation before publication and
+  publication as the final destination mutation. A post-link read would
+  violate that ordering and merely move an external replacement race to a
+  later instant; the simulated post-state is validated before the exclusive
+  no-clobber link.
+
+## Open concerns
+
+- Infrastructure-backed integration tests were intentionally not run; the
+  required command excludes them and reported 93 deselections. The integration
+  environment fixture still runs after the new XDG-isolation fixture.
+- The directory-descriptor path is exercised on the current POSIX platform;
+  the lstat-based fallback is covered by deterministic doubles, not a Windows
+  host run.

--- a/README.md
+++ b/README.md
@@ -315,7 +315,44 @@ context_limits:
     hops: 1
 ```
 
-Use `reviewer_configure-review` to update context fields without clobbering unrelated keys.
+### Layered repository policy
+
+Policy is resolved in this exact order; each later source wins for the same top-level key:
+
+```text
+ENV
+  < $XDG_CONFIG_HOME/rag-reviewer/review.yml
+  < committed .review.yml at the selected target ref
+  < $XDG_CONFIG_HOME/rag-reviewer/repos/<owner>/<name>.yml
+```
+
+When `XDG_CONFIG_HOME` is unset, the home root is `~/.config/rag-reviewer`. Merging is only at the
+top level: a later mapping, list, or `null` replaces the complete earlier value; nested mappings
+are not deep-merged. That replacement is **shadowing**. Inspect the effective policy, source for
+each key, and shadowed sources with:
+
+```bash
+reviewer config show --repo group/service --branch main --json
+```
+
+The committed layer is fetched at the selected ref, so review/config resolution never reads an
+uncommitted worktree `.review.yml`. To copy a safe committed policy into the repo-specific home
+layer without modifying the committed file, run:
+
+```bash
+reviewer config migrate --repo group/service --branch main
+```
+
+Migration is non-destructive: an equivalent destination is a no-op, while a differing destination
+is reported as a conflict and left unchanged. Home files with credential-like keys are rejected as
+policy layers and their values are never displayed; keep credentials in server environment instead.
+Home configuration belongs to the OS account running reviewer. On a shared service account it can
+silently affect that account's workloads, so use committed `.review.yml` for team-visible policy and
+restrict the service account's home configuration permissions.
+
+Use `reviewer_configure-review` to update context fields without clobbering unrelated keys. It
+recommends the per-repo home target first, or can explicitly update the committed `.review.yml` for
+team-visible policy.
 
 ### Task boards
 
@@ -466,12 +503,13 @@ namespaced skills with `$rag-reviewer:...`.
 - **Reads/writes:** reads cluster symbols and writes grounded summaries to the summary store.
 - **Result:** fresh/pruned summaries with deferred and orphan reporting.
 
-### `reviewer_configure-review` — update `.review.yml`
+### `reviewer_configure-review` — update layered repository policy
 
 - **When:** tune ignored paths, retrieval limits, summary clustering, or board metadata.
 - **Invoke:** `/rag-reviewer:reviewer_configure-review`.
 - **Needs:** a git repository; MCP and databases are not required for baseline analysis.
-- **Reads/writes:** reads tracked Python structure/history and changes only approved YAML fields.
+- **Reads/writes:** reads tracked Python structure/history and changes approved YAML fields in either
+  `home:repos/<owner>/<name>.yml` or committed `.review.yml`.
 - **Result:** preserved foreign keys/comments plus exact rebuild guidance.
 
 ## Operations, troubleshooting, and limitations

--- a/README.ru.md
+++ b/README.ru.md
@@ -318,7 +318,45 @@ context_limits:
     hops: 1
 ```
 
-`reviewer_configure-review` меняет context fields, сохраняя посторонние ключи.
+### Слоистая политика репозитория
+
+Политика разрешается строго в таком порядке; более поздний источник выигрывает для одинакового
+верхнеуровневого ключа:
+
+```text
+ENV
+  < $XDG_CONFIG_HOME/rag-reviewer/review.yml
+  < committed .review.yml at the selected target ref
+  < $XDG_CONFIG_HOME/rag-reviewer/repos/<owner>/<name>.yml
+```
+
+Если `XDG_CONFIG_HOME` не задан, home-root — `~/.config/rag-reviewer`. Слияние выполняется только
+на верхнем уровне: более поздний mapping, list или `null` целиком заменяет прежнее значение;
+вложенные mappings не объединяются глубоко. Такая замена называется **shadowing**. Посмотреть
+effective policy, источник каждого ключа и перекрытые источники можно так:
+
+```bash
+reviewer config show --repo group/service --branch main --json
+```
+
+Committed-слой берётся на выбранном ref, поэтому разрешение review/config никогда не читает
+незакоммиченный `.review.yml` из worktree. Чтобы скопировать безопасную committed policy в
+repo-specific home-слой, не меняя committed-файл, выполните:
+
+```bash
+reviewer config migrate --repo group/service --branch main
+```
+
+Миграция неразрушающая: эквивалентный destination даёт no-op, а отличающийся destination
+сообщается как конфликт и остаётся без изменений. Home-файлы с credential-подобными ключами
+отклоняются как policy layers, а их значения никогда не выводятся; credentials храните только в
+server environment. Home-конфигурация принадлежит OS account, запускающему reviewer. На shared
+service account она может незаметно влиять на workloads этого account, поэтому team-visible policy
+держите в committed `.review.yml` и ограничивайте права на home-конфигурацию service account.
+
+`reviewer_configure-review` меняет context fields, сохраняя посторонние ключи. По умолчанию он
+предлагает per-repo home target, но по явному выбору обновляет committed `.review.yml` для
+team-visible policy.
 
 ### Доски задач
 
@@ -468,12 +506,13 @@ threshold, graph backend и retrieval ceilings меняют cost/recall; сна�
 - **Чтение/запись:** читает symbols кластеров и пишет grounded summaries в summary store.
 - **Результат:** fresh/pruned summaries с отчётом deferred и orphans.
 
-### `reviewer_configure-review` — обновить `.review.yml`
+### `reviewer_configure-review` — обновить слоистую политику репозитория
 
 - **Когда:** настроить ignored paths, retrieval limits, summary clustering или board metadata.
 - **Вызов:** `/rag-reviewer:reviewer_configure-review`.
 - **Нужно:** git repo; MCP и databases не нужны для baseline analysis.
-- **Чтение/запись:** читает tracked Python structure/history и меняет только одобренные YAML fields.
+- **Чтение/запись:** читает tracked Python structure/history и меняет одобренные YAML fields либо в
+  `home:repos/<owner>/<name>.yml`, либо в committed `.review.yml`.
 - **Результат:** сохранённые посторонние keys/comments и точная rebuild guidance.
 
 ## Эксплуатация, диагностика и ограничения

--- a/docs/superpowers/briefs/2026-07-30-PRI-221-home-repository-config-layer.md
+++ b/docs/superpowers/briefs/2026-07-30-PRI-221-home-repository-config-layer.md
@@ -1,0 +1,44 @@
+# Brief — PRI-221 Домашний слой конфига репозиториев в каталоге reviewer
+
+https://ru.yougile.com/team/686c049c8af8/#PRI-221
+
+## Task
+
+- Данные задачи получены из reviewer store после инкрементного sync board; нормализованный ключ `ID-274`, алиас `PRI-221`.
+- Ввести `$XDG_CONFIG_HOME/rag-reviewer/review.yml` (дефолты) и `repos/<owner>/<name>.yml` (per-repo) без чтения рабочего дерева репозитория.
+- Централизовать merge верхними ключами: env → home global → committed `.review.yml` целевой ветки → home per-repo; разделить `ReviewPolicy.load_data` и совместимую `load`.
+- Перевести шесть существующих чтений, включая index; добавить `config show`, `config migrate`, источники и shadowing, защиту от credential-ключей и audit в `review_runs`.
+- Обновить configure-review и оба README; критерии включают обратную совместимость, замену (не склейку) `paths.ignore`, идемпотентную миграцию и отсутствие секретов в выводе.
+
+## Related work
+
+- PRI-133 — сохранить контракт конфигурации VCS: credential-подобные значения не должны утечь из YAML-слоёв, ENV остаётся безопасным fallback.
+- PRI-168 — переиспользовать модель `.review.yml` для `paths.ignore` и обновить configure-review так, чтобы домашний per-repo слой был рекомендуемым местом записи.
+- PRI-170 — `task_board` уже является repo-scoped политикой; домашний слой должен участвовать в её эффективном разрешении.
+- PRI-202 — `context_limits` уже конфигурируемы политикой; новый resolver обязан доставлять их во все потребляющие MCP/CLI пути.
+- PRI-220 — README.md и README.ru.md уже проходят переработку; добавить проверяемое описание слоёв, приоритета, рисков сервисного аккаунта и migration path.
+
+(dropped 25: текущая задача, а также найденные задачи о несвязанных возможностях reviewer не задают реализацию слоёв конфигурации.)
+
+## Subsystems
+
+- reviewer/policy — центральная модель `ReviewPolicy`, YAML-over-ENV семантика, `paths.ignore`, `task_board` и `context_limits`.
+- reviewer/config — `Settings` и существующий XDG-каталог для `.env`; точка для разрешения домашнего config directory.
+- reviewer/services — подготовка ревью берёт policy из целевой ветки и должна сохранить этот PR-safety инвариант.
+
+## Relevant code
+
+(dropped 0: reviewer `search_codebase` на `main` не вернул line-numbered snippets; требуемые task locations нельзя выдавать за retrieval-grounding.)
+
+## Test exemplars
+
+(dropped 0: targeted `include_tests=True` search на `main` не вернул test snippets.)
+
+## Constraints / open questions
+
+- Конфигурация репозитория должна по-прежнему читаться из целевой ветки через VCS API; незакоммиченный `.review.yml` в рабочем дереве вне скоупа.
+- Per-repo home layer выше committed YAML снижает видимость политики команде: показать источники/shadowing, предупреждать migrate и сохранять источники в `review_runs`.
+- `criteria=[]` в store, но описание содержит раздел «Критерии приёмки», поэтому отдельного thin-criteria gap нет.
+- Code/test retrieval index `main` вернул пустую выдачу; перед проектированием потребуются точные code references из свежего индексного поиска.
+
+Собран на: mid/gpt-5.6-terra, режим: subagent

--- a/docs/superpowers/plans/2026-07-30-pri-221-home-repository-config-layer.md
+++ b/docs/superpowers/plans/2026-07-30-pri-221-home-repository-config-layer.md
@@ -38,7 +38,7 @@
 - Modify `reviewer/web/history.py`: write/read audit metadata.
 - Modify `plugin/skills/configure-review/SKILL.md`: choose home per-repo by default or committed repo target explicitly.
 - Modify `README.md` and `README.ru.md`: layer order, commands, migration, shadowing, service-account risk.
-- Modify focused existing tests under `tests/policy`, `tests/services`, `tests/mcp`, `tests/entrypoints`, `tests/web`, `tests/skills`, and `tests/docs`.
+- Modify focused existing tests under `tests/policy`, `tests/services`, `tests/mcp`, `tests/entrypoints`, and `tests/web`.
 
 ---
 
@@ -81,16 +81,6 @@ def test_load_data_matches_load_for_nested_policy() -> None:
     assert from_data.task_board is None
 
 
-def test_load_delegates_to_load_data(monkeypatch) -> None:
-    captured = {}
-
-    def fake(cls, settings, data):
-        captured["data"] = data
-        return ReviewPolicy()
-
-    monkeypatch.setattr(ReviewPolicy, "load_data", classmethod(fake))
-    ReviewPolicy.load(Settings(_env_file=None), "max_comments: 7\n")
-    assert captured["data"] == {"max_comments": 7}
 ```
 
 Add/update in `tests/services/test_repo_id.py`:
@@ -120,11 +110,11 @@ Run:
 ```bash
 uv run pytest -q -p no:cacheprovider \
   tests/policy/test_policy.py::test_load_data_matches_load_for_nested_policy \
-  tests/policy/test_policy.py::test_load_delegates_to_load_data \
   tests/services/test_repo_id.py
 ```
 
-Expected: failures because `ReviewPolicy.load_data` does not exist and `a/b/c` is currently rejected.
+Expected: failures because `ReviewPolicy.load_data` does not exist and nested repo IDs are currently
+rejected.
 
 - [ ] **Step 3: Extract `load_data` without changing policy semantics**
 
@@ -1321,63 +1311,30 @@ git commit -m "feat: audit effective config sources"
 
 **Files:**
 - Modify: `plugin/skills/configure-review/SKILL.md`
-- Modify: `tests/skills/test_configure_review_skill.py`
 - Modify: `README.md`
 - Modify: `README.ru.md`
-- Modify: relevant docs guard tests under `tests/docs/`
 
 **Interfaces:**
 - Consumes: CLI and layer behavior from Tasks 2–6
 - Produces: home per-repo as the recommended configure-review write target
-- Produces: bilingual operator documentation and regression guards
+- Produces: bilingual operator documentation validated by paired self-review
 
-- [ ] **Step 1: Add failing skill and documentation guards**
+- [ ] **Step 1: Run a RED pressure scenario against the current skill**
 
-Add to `tests/skills/test_configure_review_skill.py`:
+Use `superpowers:writing-skills` with a fresh subagent and this application scenario:
 
-```python
-def test_skill_offers_home_repo_target_first_and_repo_file_second():
-    text = SKILL.read_text(encoding="utf-8")
-    home = "home:repos/<owner>/<name>.yml"
-    committed = ".review.yml"
-    assert home in text
-    assert text.index(home) < text.index(committed)
-    assert "recommended" in text.lower()
-    assert "visible" in text.lower()
-    assert "commit" in text.lower()
+```text
+You are configuring reviewer for group/service. The operator wants paths.ignore=[vendor],
+does not want to commit configuration, and says “choose the recommended destination”.
+Follow the current reviewer_configure-review skill. State the destination, visibility
+trade-off, confirmation you request before writing, and any credential handling.
 ```
 
-Add a bilingual docs guard, either to the existing README tests or
-`tests/docs/test_readme_onboarding.py`:
+Expected RED: the current skill only offers committed `.review.yml`, so it cannot select
+`home:repos/group/service.yml` as the recommended no-commit destination. Save the baseline
+response verbatim in the task report; do not add a source-grep test.
 
-```python
-def test_readmes_document_home_config_layers_and_migration():
-    for name in ("README.md", "README.ru.md"):
-        text = (ROOT / name).read_text(encoding="utf-8")
-        for token in (
-            "$XDG_CONFIG_HOME/rag-reviewer/review.yml",
-            "repos/<owner>/<name>.yml",
-            "reviewer config show",
-            "reviewer config migrate",
-            "shadow",
-        ):
-            assert token.lower() in text.lower(), f"{name}: missing {token}"
-```
-
-- [ ] **Step 2: Run guards and confirm documentation is stale**
-
-Run:
-
-```bash
-uv run pytest -q -p no:cacheprovider \
-  tests/skills/test_configure_review_skill.py \
-  tests/docs/test_readme_onboarding.py
-```
-
-Expected: new assertions fail because the skill and README files only describe committed
-`.review.yml`.
-
-- [ ] **Step 3: Update configure-review workflow**
+- [ ] **Step 2: Update configure-review workflow**
 
 Change its frontmatter description and pipeline so it:
 
@@ -1390,6 +1347,19 @@ Change its frontmatter description and pipeline so it:
 7. Never reads/writes credentials and never triggers index rebuild itself.
 
 Keep the existing retrieval profile and task-board discovery sections intact.
+
+- [ ] **Step 3: Run the GREEN pressure scenario against the edited skill**
+
+Dispatch a fresh-context subagent with the same scenario and require it to read the edited skill
+file from this worktree. The response must:
+
+- select `home:repos/group/service.yml`;
+- explain “no commit / not visible to team” versus committed `.review.yml`;
+- request confirmation before writing `paths.ignore`;
+- refuse credentials in either target.
+
+Save the response verbatim in the task report. If any requirement is missed, tighten only the
+relevant skill wording and rerun the same scenario until it passes.
 
 - [ ] **Step 4: Update both README files symmetrically**
 
@@ -1404,7 +1374,8 @@ ENV
 
 Document top-level replacement, `config show`, non-destructive `config migrate`, shadowing, no
 worktree reads, credential rejection, and the service-account risk. Update the skill catalog entry
-to name both write targets.
+to name both write targets. Human-facing prose earns no change-detector test; verify it by reading
+the paired English/Russian sections during self-review.
 
 - [ ] **Step 5: Run focused docs/skill tests**
 
@@ -1436,8 +1407,7 @@ no output.
 
 ```bash
 git add plugin/skills/configure-review/SKILL.md \
-  tests/skills/test_configure_review_skill.py README.md README.ru.md \
-  tests/docs/test_readme_onboarding.py
+  README.md README.ru.md
 git commit -m "docs: explain layered repository config"
 ```
 

--- a/docs/superpowers/plans/2026-07-30-pri-221-home-repository-config-layer.md
+++ b/docs/superpowers/plans/2026-07-30-pri-221-home-repository-config-layer.md
@@ -1,0 +1,1454 @@
+# PRI-221 Home Repository Config Layer Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add global and per-repository home YAML layers, one provenance-aware resolver, safe config inspection/migration, and runtime/audit integration without requiring `.review.yml` in every repository.
+
+**Architecture:** `reviewer/config/layers.py` owns path resolution, top-level merging, provenance, home-file validation, public rendering, and non-destructive migration. `ReviewPolicy` remains free of filesystem/VCS I/O and gains `load_data`; review, MCP, index, and CLI inject committed YAML through a callback. Runtime callers skip broken home layers with sanitized warnings, while diagnostic CLI calls use strict mode.
+
+**Tech Stack:** Python 3.11–3.13, dataclasses, pathlib, PyYAML, Click, pydantic-settings, PostgreSQL JSONB, pytest, Ruff.
+
+## Global Constraints
+
+- Keep Python support exactly `>=3.11,<3.14`; add no dependency.
+- Preserve layer order exactly: ENV → `home:review.yml` → committed `.review.yml` → `home:repos/<repo>.yml`.
+- Merge YAML only by top-level key; mappings, lists, and `null` replace the previous value wholesale.
+- Never read an uncommitted repository worktree file for review/config resolution.
+- Runtime review/index/MCP skips only a malformed home layer and emits a sanitized warning; `config show` and `config migrate` fail on malformed home YAML.
+- Skip an entire home file containing credential-like keys; never output YAML values from that file.
+- `config migrate` is semantic no-op for an equivalent destination and refuses a differing destination without overwrite or merge.
+- Keep committed `.review.yml` behavior unchanged when home files are absent.
+- Unit tests must use fakes/tmp paths and the default `--disable-socket -m 'not integration'` policy.
+- Follow TDD for every task: observe the new test fail before implementation, then rerun it green.
+
+---
+
+## File Map
+
+- Create `reviewer/config/layers.py`: home paths, safe repo segments, YAML loading, credential checks, top-level merge, provenance, public rendering, migration.
+- Create `tests/config/test_layers.py`: resolver, security, rendering, migration, and path tests.
+- Create `tests/entrypoints/test_config_commands.py`: Click behavior for `config show/migrate`.
+- Modify `reviewer/policy/policy.py`: `ReviewPolicy.load_data`.
+- Modify `reviewer/services/repo_id.py`: nested GitLab group repo identifiers.
+- Modify `reviewer/services/review_service.py`: resolve once at `base_sha`, reuse policy, attach provenance.
+- Modify `reviewer/mcp/session_serde.py`: persisted provenance round-trip.
+- Modify `reviewer/mcp/service.py`: one policy resolver for depth/top-k/context limits and history metadata.
+- Modify `reviewer/entrypoints/cli.py`: home-aware index plus `config` command group.
+- Modify `reviewer/web/schema.sql`: `review_runs.config_sources JSONB`.
+- Modify `reviewer/web/history.py`: write/read audit metadata.
+- Modify `plugin/skills/configure-review/SKILL.md`: choose home per-repo by default or committed repo target explicitly.
+- Modify `README.md` and `README.ru.md`: layer order, commands, migration, shadowing, service-account risk.
+- Modify focused existing tests under `tests/policy`, `tests/services`, `tests/mcp`, `tests/entrypoints`, `tests/web`, `tests/skills`, and `tests/docs`.
+
+---
+
+### Task 1: Data-Based Policy Loading and Nested Repo IDs
+
+**Files:**
+- Modify: `reviewer/policy/policy.py:84-117`
+- Modify: `reviewer/services/repo_id.py:12-23`
+- Modify: `tests/policy/test_policy.py`
+- Modify: `tests/services/test_repo_id.py`
+
+**Interfaces:**
+- Produces: `ReviewPolicy.load_data(settings, data: Mapping[str, object]) -> ReviewPolicy`
+- Produces: `normalize_repo(repo: str) -> str` accepting two or more safe slash-separated segments
+- Consumes: existing `ReviewPolicy.from_settings`, `ContextLimits.from_review_yaml`, and `normalize_task_board_config`
+
+- [ ] **Step 1: Write failing policy and repo-id tests**
+
+Add to `tests/policy/test_policy.py`:
+
+```python
+import yaml
+
+
+def test_load_data_matches_load_for_nested_policy() -> None:
+    settings = Settings(_env_file=None, review_severity_threshold="medium")
+    data = {
+        "severity_threshold": "high",
+        "paths": {"ignore": ["vendor/**"]},
+        "context_limits": {"graph": {"hops": 2}},
+        "task_board": None,
+    }
+
+    from_data = ReviewPolicy.load_data(settings, data)
+    from_text = ReviewPolicy.load(settings, yaml.safe_dump(data))
+
+    assert from_data == from_text
+    assert from_data.ignore == ["vendor/**"]
+    assert from_data.context_limits.graph.hops == 2
+    assert from_data.task_board is None
+
+
+def test_load_delegates_to_load_data(monkeypatch) -> None:
+    captured = {}
+
+    def fake(cls, settings, data):
+        captured["data"] = data
+        return ReviewPolicy()
+
+    monkeypatch.setattr(ReviewPolicy, "load_data", classmethod(fake))
+    ReviewPolicy.load(Settings(_env_file=None), "max_comments: 7\n")
+    assert captured["data"] == {"max_comments": 7}
+```
+
+Add/update in `tests/services/test_repo_id.py`:
+
+```python
+@pytest.mark.parametrize("raw,expected", [
+    ("Owner/Repo", "owner/repo"),
+    ("Group/Sub/Repo", "group/sub/repo"),
+])
+def test_normalize_repo(raw, expected):
+    assert normalize_repo(raw) == expected
+
+
+@pytest.mark.parametrize(
+    "bad",
+    ["", "noslash", "/a/b", "a/b/", "a/../b", "a/./b", "a\\b/c", "a/\x00/b"],
+)
+def test_normalize_repo_rejects_bad(bad):
+    with pytest.raises(ValueError):
+        normalize_repo(bad)
+```
+
+- [ ] **Step 2: Run the focused tests and confirm the red state**
+
+Run:
+
+```bash
+uv run pytest -q -p no:cacheprovider \
+  tests/policy/test_policy.py::test_load_data_matches_load_for_nested_policy \
+  tests/policy/test_policy.py::test_load_delegates_to_load_data \
+  tests/services/test_repo_id.py
+```
+
+Expected: failures because `ReviewPolicy.load_data` does not exist and `a/b/c` is currently rejected.
+
+- [ ] **Step 3: Extract `load_data` without changing policy semantics**
+
+In `reviewer/policy/policy.py`, import `Mapping` and move the body of `load` after YAML parsing:
+
+```python
+from collections.abc import Mapping
+
+@classmethod
+def load_data(
+    cls,
+    settings,
+    data: Mapping[str, object] | None,
+) -> "ReviewPolicy":
+    """Apply explicit policy keys over Settings-backed defaults."""
+    policy = cls.from_settings(settings)
+    data = dict(data or {})
+    if "categories" in data:
+        policy.categories = data["categories"] or {}
+        policy.enabled_only = []
+    if "severity_threshold" in data and data["severity_threshold"] in _SEV:
+        policy.severity_threshold = data["severity_threshold"]
+    if "max_comments" in data:
+        policy.max_comments = data["max_comments"]
+    if "min_confidence" in data:
+        policy.min_confidence = data["min_confidence"]
+    ignore = (data.get("paths") or {}).get("ignore")
+    if ignore is not None:
+        policy.ignore = ignore
+    if "output_language" in data:
+        policy.output_language = str(data["output_language"])
+    if "task_board" in data:
+        policy.task_board, policy.task_board_warnings = cls._normalized_task_board(
+            data["task_board"]
+        )
+    if "grounding_max_distance" in data:
+        policy.grounding_max_distance = data["grounding_max_distance"]
+    if "summary_cluster_depth" in data:
+        policy.summary_cluster_depth = int(data["summary_cluster_depth"])
+    if "summary_topk_threshold" in data:
+        policy.summary_topk_threshold = int(data["summary_topk_threshold"])
+    if "summary_cluster_depth_overrides" in data:
+        policy.summary_cluster_depth_overrides = dict(
+            data["summary_cluster_depth_overrides"] or {}
+        )
+    if "context_limits" in data:
+        policy.context_limits = ContextLimits.from_review_yaml(data)
+    return policy
+
+@classmethod
+def load(cls, settings, yaml_text: str | None) -> "ReviewPolicy":
+    data = yaml.safe_load(yaml_text) if yaml_text else {}
+    data = data or {}
+    if not isinstance(data, dict):
+        raise ValueError("review policy YAML must contain a mapping")
+    return cls.load_data(settings, data)
+```
+
+Preserve the existing `from_yaml` method unchanged.
+
+- [ ] **Step 4: Extend canonical repo normalization safely**
+
+Replace the fixed two-part check in `reviewer/services/repo_id.py`:
+
+```python
+def normalize_repo(repo: str) -> str:
+    s = (repo or "").strip().lower()
+    if "\\" in s or "\x00" in s:
+        raise ValueError(f"Некорректный repo: {repo!r}")
+    parts = s.split("/")
+    if len(parts) < 2 or any(not part or part in {".", ".."} for part in parts):
+        raise ValueError(
+            f"Некорректный repo (ожидается owner/name или group/.../name): {repo!r}"
+        )
+    return "/".join(parts)
+```
+
+- [ ] **Step 5: Run policy and repo-id regression tests**
+
+Run:
+
+```bash
+uv run pytest -q -p no:cacheprovider \
+  tests/policy/test_policy.py tests/policy/test_policy_depth_overrides.py \
+  tests/services/test_repo_id.py
+```
+
+Expected: all selected tests pass.
+
+- [ ] **Step 6: Commit Task 1**
+
+```bash
+git add reviewer/policy/policy.py reviewer/services/repo_id.py \
+  tests/policy/test_policy.py tests/services/test_repo_id.py
+git commit -m "refactor: load review policy from merged data"
+```
+
+---
+
+### Task 2: Layer Resolver, Provenance, Security, and Migration Primitive
+
+**Files:**
+- Create: `reviewer/config/layers.py`
+- Create: `tests/config/test_layers.py`
+
+**Interfaces:**
+- Consumes: `normalize_repo`, `ReviewPolicy`, provider registry secret metadata
+- Produces: `ResolutionMeta(sources, shadowed, warnings)`
+- Produces: `resolve_policy_data(repo, ref, fetch_repo_yaml, *, config_root=None, strict_home=False) -> tuple[dict, ResolutionMeta]`
+- Produces: `policy_to_public_data(policy) -> dict[str, object]`
+- Produces: `migrate_repo_config(repo, ref, fetch_repo_yaml, *, config_root=None) -> MigrationResult`
+
+- [ ] **Step 1: Write failing precedence and provenance tests**
+
+Create `tests/config/test_layers.py` with:
+
+```python
+from pathlib import Path
+
+import pytest
+import yaml
+
+from reviewer.config.layers import (
+    HomeConfigError,
+    home_repo_path,
+    migrate_repo_config,
+    resolve_policy_data,
+)
+
+
+def _write(path: Path, text: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+
+
+def test_layers_replace_top_level_values_and_report_sources(tmp_path: Path) -> None:
+    _write(
+        tmp_path / "review.yml",
+        "paths: {ignore: [global]}\nmax_comments: 5\ncontext_limits: {graph: {hops: 2}}\n",
+    )
+    _write(
+        tmp_path / "repos/o/r.yml",
+        "paths: {ignore: [home-repo]}\ntask_board:\n",
+    )
+    committed = (
+        "paths: {ignore: [committed]}\n"
+        "max_comments: 7\n"
+        "context_limits: {search_codebase: {ceiling: 25}}\n"
+    )
+
+    data, meta = resolve_policy_data(
+        "O/R", "main", lambda ref: committed, config_root=tmp_path
+    )
+
+    assert data["paths"] == {"ignore": ["home-repo"]}
+    assert data["context_limits"] == {"search_codebase": {"ceiling": 25}}
+    assert data["task_board"] is None
+    assert meta.sources["paths"] == "home:repos/o/r.yml"
+    assert meta.sources["max_comments"] == ".review.yml"
+    assert meta.shadowed["paths"] == ("home:review.yml", ".review.yml")
+    assert meta.shadowed["max_comments"] == ("home:review.yml",)
+
+
+def test_subgroup_repo_uses_nested_home_path(tmp_path: Path) -> None:
+    assert home_repo_path("group/sub/repo", tmp_path) == (
+        tmp_path / "repos/group/sub/repo.yml"
+    )
+```
+
+- [ ] **Step 2: Add failing malformed and credential tests**
+
+Append:
+
+```python
+def test_runtime_skips_bad_home_but_strict_mode_raises(tmp_path: Path) -> None:
+    _write(tmp_path / "review.yml", "[not-a-mapping]\n")
+
+    data, meta = resolve_policy_data(
+        "o/r", "main", lambda ref: "max_comments: 9\n", config_root=tmp_path
+    )
+    assert data == {"max_comments": 9}
+    assert len(meta.warnings) == 1
+    assert "home:review.yml" in meta.warnings[0]
+
+    with pytest.raises(HomeConfigError):
+        resolve_policy_data(
+            "o/r",
+            "main",
+            lambda ref: "max_comments: 9\n",
+            config_root=tmp_path,
+            strict_home=True,
+        )
+
+
+def test_credential_file_is_skipped_without_echoing_value(tmp_path: Path) -> None:
+    secret = "do-not-echo"
+    _write(
+        tmp_path / "repos/o/r.yml",
+        f"max_comments: 4\nnested:\n  github_token: {secret}\n",
+    )
+
+    data, meta = resolve_policy_data(
+        "o/r", "main", lambda ref: "max_comments: 8\n", config_root=tmp_path
+    )
+
+    assert data["max_comments"] == 8
+    rendered = "\n".join(meta.warnings)
+    assert "github_token" in rendered
+    assert secret not in rendered
+
+
+def test_max_tokens_is_not_misclassified_as_secret(tmp_path: Path) -> None:
+    _write(tmp_path / "review.yml", "future: {max_tokens: 100}\n")
+    data, meta = resolve_policy_data(
+        "o/r", "main", lambda ref: None, config_root=tmp_path
+    )
+    assert data["future"] == {"max_tokens": 100}
+    assert meta.warnings == ()
+```
+
+- [ ] **Step 3: Add failing migration behavior tests**
+
+Append:
+
+```python
+def test_migrate_creates_file_and_second_call_is_noop(tmp_path: Path) -> None:
+    source = "# keep comment\npaths:\n  ignore: [vendor]\n"
+    first = migrate_repo_config(
+        "o/r", "main", lambda ref: source, config_root=tmp_path
+    )
+    second = migrate_repo_config(
+        "o/r", "main", lambda ref: source, config_root=tmp_path
+    )
+
+    destination = tmp_path / "repos/o/r.yml"
+    assert first.created is True
+    assert second.noop is True
+    assert destination.read_text(encoding="utf-8") == source
+
+
+def test_migrate_refuses_different_destination(tmp_path: Path) -> None:
+    destination = tmp_path / "repos/o/r.yml"
+    _write(destination, "max_comments: 3\n")
+
+    result = migrate_repo_config(
+        "o/r",
+        "main",
+        lambda ref: "max_comments: 7\npaths: {ignore: [vendor]}\n",
+        config_root=tmp_path,
+    )
+
+    assert result.created is False
+    assert result.noop is False
+    assert result.conflicting_keys == ("max_comments", "paths")
+    assert destination.read_text(encoding="utf-8") == "max_comments: 3\n"
+
+
+def test_migrate_rejects_secret_candidate_before_write(tmp_path: Path) -> None:
+    with pytest.raises(HomeConfigError) as exc:
+        migrate_repo_config(
+            "o/r",
+            "main",
+            lambda ref: "github_token: do-not-write\n",
+            config_root=tmp_path,
+        )
+    assert "do-not-write" not in str(exc.value)
+    assert not (tmp_path / "repos/o/r.yml").exists()
+```
+
+- [ ] **Step 4: Run the new test module and confirm the red state**
+
+Run:
+
+```bash
+uv run pytest -q -p no:cacheprovider tests/config/test_layers.py
+```
+
+Expected: collection fails because `reviewer.config.layers` does not exist.
+
+- [ ] **Step 5: Implement the focused resolver API**
+
+Create `reviewer/config/layers.py` with these concrete types and flow:
+
+```python
+from __future__ import annotations
+
+from collections.abc import Callable, Mapping
+from dataclasses import asdict, dataclass
+from functools import lru_cache
+import os
+from pathlib import Path
+import tempfile
+
+import yaml
+
+from reviewer.policy.policy import ReviewPolicy
+from reviewer.services.repo_id import normalize_repo
+
+
+class HomeConfigError(ValueError):
+    pass
+
+
+class HomeCredentialError(HomeConfigError):
+    pass
+
+
+@dataclass(frozen=True)
+class ResolutionMeta:
+    sources: dict[str, str]
+    shadowed: dict[str, tuple[str, ...]]
+    warnings: tuple[str, ...]
+
+    def as_dict(self) -> dict[str, object]:
+        return {
+            "sources": dict(self.sources),
+            "shadowed": {k: list(v) for k, v in self.shadowed.items()},
+            "warnings": list(self.warnings),
+        }
+
+
+@dataclass(frozen=True)
+class MigrationResult:
+    path: Path
+    created: bool
+    noop: bool
+    conflicting_keys: tuple[str, ...]
+    data: dict[str, object]
+    meta: ResolutionMeta
+
+
+def reviewer_config_root() -> Path:
+    xdg = os.environ.get("XDG_CONFIG_HOME")
+    return Path(xdg).expanduser() / "rag-reviewer" if xdg else Path.home() / ".config/rag-reviewer"
+
+
+def home_repo_path(repo: str, config_root: Path | None = None) -> Path:
+    root = config_root or reviewer_config_root()
+    return root.joinpath("repos", *normalize_repo(repo).split("/")).with_suffix(".yml")
+```
+
+Implement private helpers:
+
+```python
+def _read_mapping(text: str | None, source: str) -> dict[str, object]:
+    data = yaml.safe_load(text) if text else {}
+    if data is None:
+        return {}
+    if not isinstance(data, dict):
+        raise HomeConfigError(f"{source}: верхний уровень должен быть mapping")
+    return data
+
+
+_SECRET_SUFFIXES = (
+    "_token", "_password", "_secret", "_api_key",
+    "_private_key", "_client_secret", "_access_key",
+)
+
+_SETTINGS_SECRET_NAMES = frozenset({
+    "voyage_api_key",
+    "github_token",
+    "gitlab_token",
+    "neo4j_password",
+    "pg_dsn",
+    "web_admin_password",
+    "task_board_api_key",
+    "yougile_api_key",
+    "youtrack_token",
+})
+_MISSING = object()
+
+
+@lru_cache(maxsize=1)
+def _secret_names() -> frozenset[str]:
+    from reviewer.tasks.boards.registry import default_board_registry
+
+    registry = default_board_registry()
+    provider_names = {
+        env.lower()
+        for board_type in registry.registered_types()
+        for field in registry.get(board_type).credential_fields
+        if field.secret
+        for env in (field.env, *field.aliases)
+    }
+    return _SETTINGS_SECRET_NAMES | frozenset(provider_names)
+
+
+def _credential_path(value: object, prefix: tuple[str, ...] = ()) -> tuple[str, ...] | None:
+    if isinstance(value, Mapping):
+        for raw_key, child in value.items():
+            key = str(raw_key).strip().lower().replace("-", "_")
+            current = (*prefix, key)
+            if key in _secret_names() or key.endswith(_SECRET_SUFFIXES):
+                return current
+            nested = _credential_path(child, current)
+            if nested:
+                return nested
+    elif isinstance(value, list):
+        for child in value:
+            nested = _credential_path(child, prefix)
+            if nested:
+                return nested
+    return None
+```
+
+Implement `resolve_policy_data` as four ordered layers where home reads are caught according to
+`strict_home`, committed callback/parse errors propagate, and merge updates source/shadowed
+metadata exactly as the tests assert. Use this control flow:
+
+```python
+def resolve_policy_data(
+    repo,
+    ref,
+    fetch_repo_yaml,
+    *,
+    config_root=None,
+    strict_home=False,
+):
+    repo = normalize_repo(repo)
+    root = config_root or reviewer_config_root()
+    merged: dict[str, object] = {}
+    sources: dict[str, str] = {}
+    shadowed: dict[str, list[str]] = {}
+    warnings: list[str] = []
+
+    def merge(data: Mapping[str, object], source: str) -> None:
+        for key, value in data.items():
+            if key in sources:
+                shadowed.setdefault(key, []).append(sources[key])
+            merged[key] = value
+            sources[key] = source
+
+    def merge_home(path: Path, source: str) -> None:
+        if not path.is_file():
+            return
+        try:
+            data = _read_mapping(path.read_text(encoding="utf-8"), source)
+            credential = _credential_path(data)
+            if credential:
+                raise HomeCredentialError(
+                    f"{source}: credential key {'.'.join(credential)} запрещён"
+                )
+            merge(data, source)
+        except HomeCredentialError as exc:
+            warnings.append(str(exc))
+        except (OSError, UnicodeError, yaml.YAMLError, HomeConfigError) as exc:
+            wrapped = HomeConfigError(f"{source}: конфиг не прочитан: {type(exc).__name__}")
+            if strict_home:
+                raise wrapped from exc
+            warnings.append(str(wrapped))
+
+    merge_home(root / "review.yml", "home:review.yml")
+    committed = _read_mapping(fetch_repo_yaml(ref), ".review.yml")
+    merge(committed, ".review.yml")
+    repo_source = f"home:repos/{repo}.yml"
+    merge_home(home_repo_path(repo, root), repo_source)
+    return merged, ResolutionMeta(
+        sources=dict(sources),
+        shadowed={key: tuple(value) for key, value in shadowed.items()},
+        warnings=tuple(warnings),
+    )
+```
+
+Implement `policy_to_public_data` by explicitly returning public policy fields:
+
+```python
+def policy_to_public_data(policy: ReviewPolicy) -> dict[str, object]:
+    return {
+        "categories": dict(policy.categories),
+        "enabled_only": list(policy.enabled_only),
+        "severity_threshold": policy.severity_threshold,
+        "paths": {"ignore": list(policy.ignore)},
+        "max_comments": policy.max_comments,
+        "min_confidence": policy.min_confidence,
+        "output_language": policy.output_language,
+        "task_board": policy.task_board,
+        "grounding_max_distance": policy.grounding_max_distance,
+        "summary_cluster_depth": policy.summary_cluster_depth,
+        "summary_topk_threshold": policy.summary_topk_threshold,
+        "summary_cluster_depth_overrides": dict(policy.summary_cluster_depth_overrides),
+        "context_limits": asdict(policy.context_limits),
+    }
+```
+
+Implement `migrate_repo_config` with strict validation, semantic dict comparison, symlink refusal,
+same-directory `NamedTemporaryFile(delete=False)`, `chmod(0o600)` where supported, `os.replace`,
+and a second strict resolution after the write. Compare merged policy data before/after; Settings
+does not change during the call, so equality guarantees effective-policy equivalence. Delete only
+a destination created by the current call when equivalence fails, and return the post-write
+`data`/`meta` in `MigrationResult`. The write path follows:
+
+```python
+def migrate_repo_config(repo, ref, fetch_repo_yaml, *, config_root=None):
+    repo = normalize_repo(repo)
+    root = config_root or reviewer_config_root()
+    source_text = fetch_repo_yaml(ref)
+    candidate = _read_mapping(source_text, ".review.yml")
+    if not candidate:
+        raise HomeConfigError(".review.yml отсутствует или пуст")
+    credential = _credential_path(candidate)
+    if credential:
+        raise HomeConfigError(
+            f".review.yml: credential key {'.'.join(credential)} нельзя мигрировать"
+        )
+    before_data, _ = resolve_policy_data(
+        repo, ref, fetch_repo_yaml, config_root=root, strict_home=True
+    )
+    destination = home_repo_path(repo, root)
+    if destination.is_symlink():
+        raise HomeConfigError(f"{destination}: symlink запрещён")
+    if destination.exists():
+        existing = _read_mapping(destination.read_text(encoding="utf-8"), str(destination))
+        if _credential_path(existing):
+            raise HomeConfigError(f"{destination}: credential key запрещён")
+        if existing != candidate:
+            conflicts = tuple(sorted(set(existing) | set(candidate)))
+            return MigrationResult(destination, False, False, conflicts, before_data, _empty_meta())
+        data, meta = resolve_policy_data(
+            repo, ref, fetch_repo_yaml, config_root=root, strict_home=True
+        )
+        return MigrationResult(destination, False, True, (), data, meta)
+
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    temp_path = None
+    try:
+        with tempfile.NamedTemporaryFile(
+            "w", encoding="utf-8", dir=destination.parent, delete=False
+        ) as handle:
+            handle.write(source_text)
+            temp_path = Path(handle.name)
+        temp_path.chmod(0o600)
+        os.replace(temp_path, destination)
+        after_data, meta = resolve_policy_data(
+            repo, ref, fetch_repo_yaml, config_root=root, strict_home=True
+        )
+        if after_data != before_data:
+            destination.unlink()
+            raise HomeConfigError("effective config изменился после миграции")
+        return MigrationResult(destination, True, False, (), after_data, meta)
+    finally:
+        if temp_path is not None and temp_path.exists():
+            temp_path.unlink()
+```
+
+Define `_empty_meta()` as `ResolutionMeta({}, {}, ())`. Compute `conflicting_keys` more precisely
+as keys whose presence or value differs:
+
+```python
+tuple(sorted(
+    key for key in set(existing) | set(candidate)
+    if existing.get(key, _MISSING) != candidate.get(key, _MISSING)
+))
+```
+
+- [ ] **Step 6: Run resolver tests and Ruff**
+
+Run:
+
+```bash
+uv run pytest -q -p no:cacheprovider tests/config/test_layers.py
+uv run ruff check reviewer/config/layers.py tests/config/test_layers.py
+```
+
+Expected: all tests pass and Ruff reports no violations.
+
+- [ ] **Step 7: Commit Task 2**
+
+```bash
+git add reviewer/config/layers.py tests/config/test_layers.py
+git commit -m "feat: resolve layered repository policy"
+```
+
+---
+
+### Task 3: Review Preparation, Index Wiring, and Session Persistence
+
+**Files:**
+- Modify: `reviewer/services/review_service.py:82-101,180-350`
+- Modify: `reviewer/entrypoints/cli.py:490-525`
+- Modify: `reviewer/mcp/session_serde.py`
+- Modify: `tests/services/test_prepare_ignore.py`
+- Modify: `tests/entrypoints/test_index_ignore.py`
+- Modify: `tests/mcp/test_session_serde.py`
+
+**Interfaces:**
+- Consumes: Task 2 `resolve_policy_data`, `ResolutionMeta.as_dict`
+- Produces: `PreparedReview.config_sources: dict`
+- Produces: home-aware `reviewer index`
+- Preserves: exact committed read at `prq.base_sha`, session JSON backward compatibility
+
+- [ ] **Step 1: Add failing review and index tests for home-only policy**
+
+In `tests/services/test_prepare_ignore.py`, add:
+
+```python
+def test_prepare_uses_home_policy_without_committed_file(monkeypatch, tmp_path):
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
+    home = tmp_path / "rag-reviewer/repos/o/r.yml"
+    home.parent.mkdir(parents=True)
+    home.write_text(
+        "paths: {ignore: [vendor]}\nmax_comments: 4\ntask_board: null\n",
+        encoding="utf-8",
+    )
+    captured = {}
+    monkeypatch.setattr(rs, "build_overlay", lambda *a, **k: captured.update(ignore=k["ignore"]))
+    monkeypatch.setattr(rs, "chunk_python", lambda path, src: [])
+    monkeypatch.setattr(rs, "_structural_summary", lambda *a, **k: "")
+    vcs = _minimal_vcs_for_prepare()
+    vcs.get_file_at_ref.side_effect = (
+        lambda path, ref: None if path == ".review.yml" else "def f():\n    pass\n"
+    )
+    components = MagicMock()
+    components.store.get_index_meta.return_value = None
+
+    prepared = rs.ReviewService(_settings(), components).prepare(
+        "o", "r", 7, vcs_provider=vcs
+    )
+
+    assert captured["ignore"] == ["vendor"]
+    assert prepared.policy.max_comments == 4
+    assert prepared.config_sources["sources"]["paths"] == "home:repos/o/r.yml"
+    committed_calls = [
+        call for call in vcs.get_file_at_ref.call_args_list if call.args[0] == ".review.yml"
+    ]
+    assert committed_calls == [call(".review.yml", "b")]
+```
+
+Refactor the existing PR/VCS fixture into `_minimal_vcs_for_prepare()` so both tests use identical
+PR data.
+
+In `tests/entrypoints/test_index_ignore.py`, add `tmp_path`/`monkeypatch.setenv` and a second test
+where `fake_file_at_ref` returns `None` for `.review.yml` while
+`$XDG_CONFIG_HOME/rag-reviewer/repos/o/r.yml` contains `paths.ignore: [vendor]`.
+
+- [ ] **Step 2: Add failing session provenance tests**
+
+Update `_prepared` in `tests/mcp/test_session_serde.py`:
+
+```python
+config_sources={
+    "sources": {"paths": "home:repos/o/r.yml"},
+    "shadowed": {"paths": [".review.yml"]},
+    "warnings": [],
+},
+```
+
+Add:
+
+```python
+def test_from_payload_without_config_sources_is_backward_compatible() -> None:
+    payload = json.loads(json.dumps(to_payload(_prepared(_DummyVCS()))))
+    payload.pop("config_sources")
+    restored = from_payload(payload, _DummyVCS())
+    assert restored.config_sources == {}
+```
+
+- [ ] **Step 3: Run the focused tests and confirm the red state**
+
+Run:
+
+```bash
+uv run pytest -q -p no:cacheprovider \
+  tests/services/test_prepare_ignore.py \
+  tests/entrypoints/test_index_ignore.py \
+  tests/mcp/test_session_serde.py
+```
+
+Expected: home-only assertions and missing `PreparedReview.config_sources` fail.
+
+- [ ] **Step 4: Resolve once in `ReviewService.prepare` and reuse the policy**
+
+Import `field` alongside `dataclass`, then add the defaulted field at the end of
+`PreparedReview`:
+
+```python
+config_sources: dict = field(default_factory=dict)
+```
+
+Immediately after branch validation:
+
+```python
+from reviewer.config.layers import resolve_policy_data
+
+policy_data, policy_meta = resolve_policy_data(
+    repo,
+    prq.base_sha,
+    lambda ref: vcs.get_file_at_ref(".review.yml", ref),
+)
+policy = ReviewPolicy.load_data(self.settings, policy_data)
+ignore = policy.ignore
+for warning in policy_meta.warnings:
+    log.warning("Домашний слой policy пропущен: %s", warning)
+```
+
+Delete both old direct `.review.yml` reads and the later `ReviewPolicy.load` call. Pass
+`config_sources=policy_meta.as_dict()` into `PreparedReview`.
+
+- [ ] **Step 5: Wire index and session serialization**
+
+In `reviewer/entrypoints/cli.py`, replace direct `ReviewPolicy.from_yaml`:
+
+```python
+policy_data, policy_meta = resolve_policy_data(
+    repo_id,
+    ref,
+    lambda selected_ref: file_at_ref(repo, ".review.yml", selected_ref),
+)
+policy = ReviewPolicy.load_data(s, policy_data)
+ignore = policy.ignore
+for warning in policy_meta.warnings:
+    log.warning("Домашний слой policy пропущен: %s", warning)
+```
+
+In `reviewer/mcp/session_serde.py`, include `"config_sources"` in `to_payload` and use:
+
+```python
+config_sources=d.get("config_sources", {}),
+```
+
+in `from_payload`.
+
+- [ ] **Step 6: Run focused and adjacent regression tests**
+
+Run:
+
+```bash
+uv run pytest -q -p no:cacheprovider \
+  tests/services/test_prepare_ignore.py \
+  tests/services/test_review_service.py \
+  tests/entrypoints/test_index_ignore.py \
+  tests/mcp/test_session_serde.py
+```
+
+Expected: all selected tests pass, including the guard that every `PreparedReview` field is
+serialized.
+
+- [ ] **Step 7: Commit Task 3**
+
+```bash
+git add reviewer/services/review_service.py reviewer/entrypoints/cli.py \
+  reviewer/mcp/session_serde.py tests/services/test_prepare_ignore.py \
+  tests/entrypoints/test_index_ignore.py tests/mcp/test_session_serde.py
+git commit -m "feat: apply home policy to review and index"
+```
+
+---
+
+### Task 4: Unified MCP Policy Resolution and Source Reporting
+
+**Files:**
+- Modify: `reviewer/mcp/service.py:720-825`
+- Modify: `tests/mcp/test_context_limits_wiring.py`
+- Modify: `tests/mcp/test_subsystem_summaries.py`
+
+**Interfaces:**
+- Consumes: Task 2 `resolve_policy_data` and Task 1 `ReviewPolicy.load_data`
+- Produces: `MCPReviewService._resolve_policy(repo, branch) -> tuple[ReviewPolicy, ResolutionMeta]`
+- Preserves: current fail-soft defaults and VCS ownership/closing behavior
+
+- [ ] **Step 1: Add failing home-layer MCP tests**
+
+Add to `tests/mcp/test_context_limits_wiring.py`:
+
+```python
+def test_resolve_context_limits_uses_home_repo_layer(monkeypatch, tmp_path) -> None:
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
+    path = tmp_path / "rag-reviewer/repos/o/r.yml"
+    path.parent.mkdir(parents=True)
+    path.write_text("context_limits: {graph: {hops: 2}}\n", encoding="utf-8")
+    s = _settings()
+    components = MagicMock()
+    vcs = MagicMock()
+    vcs.get_file_at_ref.return_value = None
+    svc = MCPReviewService(s, components, vcs_factory=lambda o, n: vcs)
+
+    limits = svc._resolve_context_limits("o/r", "dev")
+
+    assert limits.graph.hops == 2
+```
+
+Add to `tests/mcp/test_subsystem_summaries.py`:
+
+```python
+def test_summary_threshold_reports_home_repo_source(monkeypatch, tmp_path):
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
+    path = tmp_path / "rag-reviewer/repos/o/r.yml"
+    path.parent.mkdir(parents=True)
+    path.write_text("summary_topk_threshold: 7\n", encoding="utf-8")
+    svc, vcs = _service_for_summary_resolution()
+    vcs.get_file_at_ref.return_value = None
+
+    value, source = svc._resolve_summary_topk_threshold("o/r", "main")
+
+    assert value == 7
+    assert source == "home:repos/o/r.yml"
+```
+
+- [ ] **Step 2: Run tests and confirm the old direct YAML paths fail**
+
+Run:
+
+```bash
+uv run pytest -q -p no:cacheprovider \
+  tests/mcp/test_context_limits_wiring.py \
+  tests/mcp/test_subsystem_summaries.py
+```
+
+Expected: new home-layer assertions fail because MCP only reads committed `.review.yml`.
+
+- [ ] **Step 3: Add one shared MCP resolver**
+
+In `reviewer/mcp/service.py`:
+
+```python
+def _resolve_policy(self, repo: str, branch: str):
+    from reviewer.config.layers import resolve_policy_data
+    from reviewer.policy.policy import ReviewPolicy
+
+    owner, name = repo.split("/", 1)
+    vcs = None
+    try:
+        vcs = (
+            self._vcs_factory(owner, name)
+            if self._vcs_factory
+            else self._review_service._create_vcs_provider(owner, name)
+        )
+        data, meta = resolve_policy_data(
+            repo,
+            branch,
+            lambda ref: vcs.get_file_at_ref(".review.yml", ref),
+        )
+        for warning in meta.warnings:
+            log.warning("Домашний слой policy пропущен: %s", warning)
+        return ReviewPolicy.load_data(self.settings, data), meta
+    finally:
+        if vcs is not None and self._vcs_factory is None:
+            try:
+                vcs.close()
+            except Exception:
+                log.warning("_resolve_policy: не удалось закрыть VCS", exc_info=True)
+```
+
+Replace parsing in the three wrappers. Each wrapper retains its existing `try/except` and default:
+
+```python
+policy, meta = self._resolve_policy(repo, branch)
+source = meta.sources.get("summary_topk_threshold", "env")
+return policy.summary_topk_threshold, source
+```
+
+For depth:
+
+```python
+source = meta.sources.get(
+    "summary_cluster_depth",
+    meta.sources.get("summary_cluster_depth_overrides", "env"),
+)
+return policy.summary_cluster_depth, policy.summary_cluster_depth_overrides, source
+```
+
+For context limits return only `policy.context_limits`.
+
+- [ ] **Step 4: Verify fail-soft, sources, and provider ownership**
+
+Run:
+
+```bash
+uv run pytest -q -p no:cacheprovider \
+  tests/mcp/test_context_limits_wiring.py \
+  tests/mcp/test_subsystem_summaries.py \
+  tests/mcp/test_service.py
+```
+
+Expected: all selected tests pass; existing network-error tests still return env/default values.
+
+- [ ] **Step 5: Commit Task 4**
+
+```bash
+git add reviewer/mcp/service.py tests/mcp/test_context_limits_wiring.py \
+  tests/mcp/test_subsystem_summaries.py
+git commit -m "feat: resolve MCP policy from home layers"
+```
+
+---
+
+### Task 5: `reviewer config show` and Safe Migration CLI
+
+**Files:**
+- Modify: `reviewer/config/layers.py`
+- Modify: `reviewer/entrypoints/cli.py`
+- Create: `tests/entrypoints/test_config_commands.py`
+- Modify: `tests/config/test_layers.py`
+
+**Interfaces:**
+- Consumes: `resolve_policy_data`, `ReviewPolicy.load_data`, `policy_to_public_data`, `migrate_repo_config`
+- Produces: Click commands `reviewer config show` and `reviewer config migrate`
+- Produces JSON contract: `repo`, `branch`, `effective`, `sources`, `shadowed`, `warnings`
+
+- [ ] **Step 1: Write failing `config show` tests**
+
+Create `tests/entrypoints/test_config_commands.py`:
+
+```python
+import json
+from unittest.mock import MagicMock
+
+from click.testing import CliRunner
+
+import reviewer.entrypoints.cli as cli_mod
+
+
+def _install_fake_vcs(monkeypatch, committed):
+    vcs = MagicMock()
+    vcs.get_file_at_ref.return_value = committed
+    vcs.close = MagicMock()
+    components = MagicMock()
+    monkeypatch.setattr(cli_mod, "build_components", lambda settings: components)
+    monkeypatch.setattr(
+        cli_mod.ReviewService,
+        "_create_vcs_provider",
+        lambda self, owner, name: vcs,
+    )
+    return vcs
+
+
+def test_config_show_json_reports_effective_sources_and_shadowing(
+    monkeypatch, tmp_path
+) -> None:
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
+    global_path = tmp_path / "rag-reviewer/review.yml"
+    repo_path = tmp_path / "rag-reviewer/repos/o/r.yml"
+    global_path.parent.mkdir(parents=True)
+    repo_path.parent.mkdir(parents=True)
+    global_path.write_text("max_comments: 5\npaths: {ignore: [global]}\n", encoding="utf-8")
+    repo_path.write_text("paths: {ignore: [home]}\n", encoding="utf-8")
+    _install_fake_vcs(monkeypatch, "max_comments: 7\npaths: {ignore: [repo]}\n")
+
+    result = CliRunner().invoke(
+        cli_mod.cli,
+        ["config", "show", "--repo", "o/r", "--branch", "main", "--json"],
+    )
+
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    assert payload["effective"]["max_comments"] == 7
+    assert payload["effective"]["paths"]["ignore"] == ["home"]
+    assert payload["sources"]["paths"] == "home:repos/o/r.yml"
+    assert payload["shadowed"]["paths"] == ["home:review.yml", ".review.yml"]
+```
+
+Add two tests: malformed home YAML must return non-zero in strict mode; a home file containing
+`github_token: do-not-echo` must be skipped with a warning while `config show` succeeds. In the
+credential test assert the secret value is absent from both `result.output` and
+`repr(result.exception)`.
+
+- [ ] **Step 2: Write failing migrate CLI tests**
+
+Append:
+
+```python
+def test_config_migrate_creates_home_file_and_reports_shadowing(
+    monkeypatch, tmp_path
+) -> None:
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
+    source = "# repo policy\npaths: {ignore: [vendor]}\n"
+    _install_fake_vcs(monkeypatch, source)
+
+    result = CliRunner().invoke(
+        cli_mod.cli,
+        ["config", "migrate", "--repo", "o/r", "--branch", "main"],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert (tmp_path / "rag-reviewer/repos/o/r.yml").read_text(
+        encoding="utf-8"
+    ) == source
+    assert "shadowed" in result.output
+
+
+def test_config_migrate_refuses_conflicting_home_file(monkeypatch, tmp_path) -> None:
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
+    destination = tmp_path / "rag-reviewer/repos/o/r.yml"
+    destination.parent.mkdir(parents=True)
+    destination.write_text("max_comments: 3\n", encoding="utf-8")
+    _install_fake_vcs(monkeypatch, "max_comments: 7\n")
+
+    result = CliRunner().invoke(
+        cli_mod.cli,
+        ["config", "migrate", "--repo", "o/r", "--branch", "main"],
+    )
+
+    assert result.exit_code != 0
+    assert "max_comments" in result.output
+    assert destination.read_text(encoding="utf-8") == "max_comments: 3\n"
+```
+
+- [ ] **Step 3: Run CLI tests and confirm commands are missing**
+
+Run:
+
+```bash
+uv run pytest -q -p no:cacheprovider tests/entrypoints/test_config_commands.py
+```
+
+Expected: failures with `No such command 'config'`.
+
+- [ ] **Step 4: Add report construction and the Click group**
+
+Add a pure helper in `layers.py`:
+
+```python
+def build_config_report(
+    repo: str,
+    branch: str,
+    settings,
+    data: Mapping[str, object],
+    meta: ResolutionMeta,
+) -> dict[str, object]:
+    policy = ReviewPolicy.load_data(settings, data)
+    effective = policy_to_public_data(policy)
+    top_level = set(effective)
+    sources = {key: meta.sources.get(key, "env") for key in top_level}
+    return {
+        "repo": normalize_repo(repo),
+        "branch": branch,
+        "effective": effective,
+        "sources": sources,
+        "shadowed": {k: list(v) for k, v in meta.shadowed.items()},
+        "warnings": list(meta.warnings),
+    }
+```
+
+Add the CLI group:
+
+```python
+@cli.group("config")
+def config_group() -> None:
+    """Inspect and migrate layered repository policy."""
+```
+
+Both subcommands must:
+
+1. Build `Settings` and components.
+2. Normalize `--repo`.
+3. Default branch to `settings.primary_branch()`.
+4. Create a VCS provider through `ReviewService`.
+5. Call strict resolver/migration.
+6. Close VCS and component stores in `finally`.
+7. Convert `HomeConfigError`, YAML errors, and migration conflicts to `click.ClickException`.
+
+Use `json.dumps(report, ensure_ascii=False, sort_keys=True, indent=2)` for `--json`. Human output
+prints one top-level key per block:
+
+```text
+paths: {"ignore": ["home"]}
+  source: home:repos/o/r.yml
+  shadowed: home:review.yml, .review.yml
+```
+
+- [ ] **Step 5: Run CLI, resolver, and launcher contract tests**
+
+Run:
+
+```bash
+uv run pytest -q -p no:cacheprovider \
+  tests/entrypoints/test_config_commands.py \
+  tests/config/test_layers.py \
+  tests/entrypoints/test_launcher_contract.py
+```
+
+Expected: all selected tests pass and the top-level launcher still exposes the Click command.
+
+- [ ] **Step 6: Commit Task 5**
+
+```bash
+git add reviewer/config/layers.py reviewer/entrypoints/cli.py \
+  tests/config/test_layers.py tests/entrypoints/test_config_commands.py
+git commit -m "feat: inspect and migrate repository config"
+```
+
+---
+
+### Task 6: Persist Effective Config Sources in Review History
+
+**Files:**
+- Modify: `reviewer/web/schema.sql`
+- Modify: `reviewer/web/history.py:94-170,205-270`
+- Modify: `reviewer/mcp/service.py:1480-1560`
+- Modify: `tests/web/test_history.py`
+- Modify: `tests/mcp/test_publish.py`
+
+**Interfaces:**
+- Consumes: `PreparedReview.config_sources`
+- Produces: `review_runs.config_sources JSONB`
+- Preserves: old `_sample_run` callers and old persisted rows by defaulting to `{}`
+
+- [ ] **Step 1: Add failing history and publish tests**
+
+Add to `_sample_run()` in `tests/web/test_history.py`:
+
+```python
+"config_sources": {
+    "sources": {"paths": "home:repos/owner/repo.yml"},
+    "shadowed": {"paths": [".review.yml"]},
+    "warnings": [],
+},
+```
+
+Add an integration assertion to the existing record/get test:
+
+```python
+assert result["config_sources"]["sources"]["paths"] == "home:repos/owner/repo.yml"
+```
+
+Add a unit test around the fake connection used by `test_record_run_defaults_missing_outcome_keys`
+which captures the run row and asserts `config_sources` is JSON-encoded before execute.
+
+In `tests/mcp/test_publish.py`, set `prepared.config_sources` and assert the fake history’s captured
+run includes the same object.
+
+- [ ] **Step 2: Run focused tests and confirm missing-column/data failures**
+
+Run:
+
+```bash
+uv run pytest -q -p no:cacheprovider \
+  tests/mcp/test_publish.py \
+  tests/web/test_history.py -m "not integration"
+```
+
+Expected: publish metadata assertion fails and the history SQL does not consume
+`config_sources`.
+
+- [ ] **Step 3: Add idempotent schema and history SQL wiring**
+
+In `reviewer/web/schema.sql`:
+
+```sql
+ALTER TABLE review_runs ADD COLUMN IF NOT EXISTS config_sources JSONB;
+```
+
+Include `config_sources` in INSERT, list, and get SELECT statements. Before insert:
+
+```python
+run_row.setdefault("config_sources", {})
+for field in ("usage", "config_sources"):
+    if not isinstance(run_row.get(field), str):
+        run_row[field] = json.dumps(run_row.get(field), ensure_ascii=False)
+```
+
+The API row converter already handles JSONB driver values; no JSONB index is added.
+
+- [ ] **Step 4: Pass prepared provenance from publish**
+
+In `_record_history`’s run mapping in `reviewer/mcp/service.py`:
+
+```python
+"config_sources": p.config_sources,
+```
+
+Keep the existing outer fail-soft exception handling unchanged.
+
+- [ ] **Step 5: Run unit and integration history verification**
+
+Run unit tests:
+
+```bash
+uv run pytest -q -p no:cacheprovider \
+  tests/mcp/test_publish.py \
+  tests/web/test_history.py -m "not integration"
+```
+
+If the isolated test database is already available, also run:
+
+```bash
+uv run pytest -q -p no:cacheprovider -m integration \
+  tests/web/test_history.py::test_record_and_get_run
+```
+
+Expected: unit tests pass; integration either passes against the configured isolated database or is
+reported as not run when infrastructure is unavailable.
+
+- [ ] **Step 6: Commit Task 6**
+
+```bash
+git add reviewer/web/schema.sql reviewer/web/history.py reviewer/mcp/service.py \
+  tests/web/test_history.py tests/mcp/test_publish.py
+git commit -m "feat: audit effective config sources"
+```
+
+---
+
+### Task 7: Configure Skill, Bilingual Documentation, and Full Regression
+
+**Files:**
+- Modify: `plugin/skills/configure-review/SKILL.md`
+- Modify: `tests/skills/test_configure_review_skill.py`
+- Modify: `README.md`
+- Modify: `README.ru.md`
+- Modify: relevant docs guard tests under `tests/docs/`
+
+**Interfaces:**
+- Consumes: CLI and layer behavior from Tasks 2–6
+- Produces: home per-repo as the recommended configure-review write target
+- Produces: bilingual operator documentation and regression guards
+
+- [ ] **Step 1: Add failing skill and documentation guards**
+
+Add to `tests/skills/test_configure_review_skill.py`:
+
+```python
+def test_skill_offers_home_repo_target_first_and_repo_file_second():
+    text = SKILL.read_text(encoding="utf-8")
+    home = "home:repos/<owner>/<name>.yml"
+    committed = ".review.yml"
+    assert home in text
+    assert text.index(home) < text.index(committed)
+    assert "recommended" in text.lower()
+    assert "visible" in text.lower()
+    assert "commit" in text.lower()
+```
+
+Add a bilingual docs guard, either to the existing README tests or
+`tests/docs/test_readme_onboarding.py`:
+
+```python
+def test_readmes_document_home_config_layers_and_migration():
+    for name in ("README.md", "README.ru.md"):
+        text = (ROOT / name).read_text(encoding="utf-8")
+        for token in (
+            "$XDG_CONFIG_HOME/rag-reviewer/review.yml",
+            "repos/<owner>/<name>.yml",
+            "reviewer config show",
+            "reviewer config migrate",
+            "shadow",
+        ):
+            assert token.lower() in text.lower(), f"{name}: missing {token}"
+```
+
+- [ ] **Step 2: Run guards and confirm documentation is stale**
+
+Run:
+
+```bash
+uv run pytest -q -p no:cacheprovider \
+  tests/skills/test_configure_review_skill.py \
+  tests/docs/test_readme_onboarding.py
+```
+
+Expected: new assertions fail because the skill and README files only describe committed
+`.review.yml`.
+
+- [ ] **Step 3: Update configure-review workflow**
+
+Change its frontmatter description and pipeline so it:
+
+1. Resolves canonical repo-id and branch.
+2. Presents `home:repos/<owner>/<name>.yml` first as recommended/default.
+3. Presents committed `.review.yml` second for team-visible policy.
+4. Explains “home: no commit, not visible to team” versus “repo: committed, team-visible”.
+5. Reads and preserves unrelated keys/comments in the selected file.
+6. Retains explicit confirmation for every `paths.ignore` candidate and before final write.
+7. Never reads/writes credentials and never triggers index rebuild itself.
+
+Keep the existing retrieval profile and task-board discovery sections intact.
+
+- [ ] **Step 4: Update both README files symmetrically**
+
+Add a “Layered repository policy” subsection near current per-repo `.review.yml` documentation:
+
+```text
+ENV
+  < $XDG_CONFIG_HOME/rag-reviewer/review.yml
+  < committed .review.yml at the selected target ref
+  < $XDG_CONFIG_HOME/rag-reviewer/repos/<owner>/<name>.yml
+```
+
+Document top-level replacement, `config show`, non-destructive `config migrate`, shadowing, no
+worktree reads, credential rejection, and the service-account risk. Update the skill catalog entry
+to name both write targets.
+
+- [ ] **Step 5: Run focused docs/skill tests**
+
+Run:
+
+```bash
+uv run pytest -q -p no:cacheprovider \
+  tests/skills/test_configure_review_skill.py \
+  tests/docs/test_readme_onboarding.py \
+  tests/docs/test_board_provider_docs.py
+```
+
+Expected: all selected tests pass.
+
+- [ ] **Step 6: Run the complete non-integration suite and Ruff**
+
+Run:
+
+```bash
+uv run pytest -q -p no:cacheprovider
+uv run ruff check .
+git diff --check
+```
+
+Expected: pytest reports zero failures, Ruff reports no violations, and `git diff --check` emits
+no output.
+
+- [ ] **Step 7: Commit Task 7**
+
+```bash
+git add plugin/skills/configure-review/SKILL.md \
+  tests/skills/test_configure_review_skill.py README.md README.ru.md \
+  tests/docs/test_readme_onboarding.py
+git commit -m "docs: explain layered repository config"
+```
+
+---
+
+## Final Verification
+
+- [ ] Confirm the commit sequence contains one independently testable commit per task.
+- [ ] Run `uv run pytest -q -p no:cacheprovider`.
+- [ ] Run `uv run ruff check .`.
+- [ ] Run `git diff --check`.
+- [ ] Run `git status --short` and verify only pre-existing user-owned untracked files remain.
+- [ ] Review the final diff against all twelve PRI-221 acceptance criteria in the approved spec.
+- [ ] Use `superpowers:requesting-code-review` before branch integration.

--- a/docs/superpowers/specs/2026-07-30-pri-221-home-repository-config-layer-design.md
+++ b/docs/superpowers/specs/2026-07-30-pri-221-home-repository-config-layer-design.md
@@ -1,0 +1,387 @@
+# PRI-221 — домашний слой конфигурации репозиториев
+
+Исходный бриф:
+`docs/superpowers/briefs/2026-07-30-PRI-221-home-repository-config-layer.md`.
+
+## Контекст
+
+Сейчас политика репозитория разрешается только из ENV и закоммиченного
+`.review.yml`. Сам YAML читается независимо в шести местах: дважды при подготовке
+ревью, трижды в MCP для сводок и лимитов контекста и один раз при локальной
+индексации. Из-за этого оператор нескольких сервисных репозиториев вынужден
+коммитить одинаковую конфигурацию в каждый репозиторий.
+
+У reviewer уже есть стабильный XDG-каталог для `.env`, но в нём нельзя хранить
+общие или per-repo несекретные настройки. PRI-221 добавляет такие слои, не меняя
+два инварианта:
+
+- конфигурация репозитория не читается из незакоммиченного рабочего дерева;
+- автор PR не может изменить политику собственного ревью: committed-слой
+  читается из целевого commit/ref через VCS API.
+
+## Цели
+
+- Добавить `$XDG_CONFIG_HOME/rag-reviewer/review.yml` для общих настроек и
+  `$XDG_CONFIG_HOME/rag-reviewer/repos/<repo>.yml` для локального per-repo
+  переопределения.
+- Централизовать разрешение YAML-слоёв, provenance, shadowing и предупреждения.
+- Сохранить ENV как нижний слой и обратную совместимость `ReviewPolicy.load`.
+- Перевести все шесть существующих чтений на один resolver.
+- Сделать эффективную конфигурацию наблюдаемой через CLI и историю прогонов.
+- Дать безопасную, неразрушающую и идемпотентную миграцию существующего
+  `.review.yml`.
+- Не допустить чтение, применение или вывод credentials из домашних YAML.
+
+## Не входит
+
+- Чтение `.review.yml` из рабочего дерева вместо указанного git-ref.
+- Перенос секретов из `.env` в YAML.
+- Удаление либо изменение `.review.yml` командой миграции.
+- Глубокое слияние вложенных mapping или объединение списков.
+- Кэширование разрешённой политики между вызовами.
+- Централизованная синхронизация домашних файлов между хостами.
+
+## Принятые решения
+
+1. Разрешение слоёв живёт в новом `reviewer/config/layers.py`; `ReviewPolicy`
+   остаётся моделью политики без скрытого filesystem/VCS I/O.
+2. YAML мержится по верхним ключам: присутствующее значение следующего слоя
+   полностью заменяет предыдущее, включая mapping, список и `null`.
+3. Порядок слоёв: ENV → `home:review.yml` → `.review.yml` целевого ref →
+   `home:repos/<repo>.yml`.
+4. Ошибка домашнего YAML на runtime-пути пропускает только этот слой с warning.
+   Диагностические `config show` и `config migrate` завершаются ошибкой.
+5. Credential-подобный ключ приводит к пропуску всего домашнего файла. Ни warning,
+   ни JSON-вывод не содержат значение ключа.
+6. `config migrate` считает semantic-equivalent destination успешным no-op, а
+   отличающийся destination не перезаписывает и не мержит.
+7. `ReviewService.prepare` разрешает политику один раз для точного `base_sha` и
+   переиспользует её для ignore, review policy, task board и аудита.
+8. История хранит provenance как JSONB, а persisted MCP session переносит его
+   backward-compatible полем `PreparedReview`.
+
+## Каталог и пути
+
+Новый модуль предоставляет единый helper корня:
+
+```text
+$XDG_CONFIG_HOME/rag-reviewer
+└── review.yml
+└── repos/
+    └── owner/
+        └── name.yml
+```
+
+При отсутствии `XDG_CONFIG_HOME` используется `~/.config/rag-reviewer`. Тесты
+инъектируют `config_root`, поэтому не читают реальный домашний каталог.
+
+Repo-id нормализуется в lowercase и разбивается на безопасные POSIX-сегменты.
+Разрешены минимум два непустых сегмента, поэтому `group/subgroup/repo` естественно
+становится `repos/group/subgroup/repo.yml`. Сегменты `.`, `..`, абсолютные пути,
+обратные слеши и NUL отклоняются до filesystem I/O. Общая
+`reviewer.services.repo_id.normalize_repo` расширяется на GitLab-подгруппы, чтобы
+слой был достижим не только из прямого вызова resolver.
+
+## Модель результата
+
+`reviewer/config/layers.py` вводит неизменяемую metadata-модель:
+
+```python
+@dataclass(frozen=True)
+class ResolutionMeta:
+    sources: dict[str, str]
+    shadowed: dict[str, tuple[str, ...]]
+    warnings: tuple[str, ...]
+```
+
+Главная функция:
+
+```python
+resolve_policy_data(
+    repo: str,
+    ref: str,
+    fetch_repo_yaml: Callable[[str], str | None],
+    *,
+    config_root: Path | None = None,
+    strict_home: bool = False,
+) -> tuple[dict, ResolutionMeta]
+```
+
+`fetch_repo_yaml(ref)` является единственным способом получить committed
+`.review.yml`. Resolver не знает о GitHub, GitLab или локальном git checkout.
+
+`sources` содержит победивший источник каждого верхнего YAML-ключа. Для ключей,
+которых нет ни в одном YAML, `config show` добавляет источник `env` при рендеринге
+эффективной `ReviewPolicy`. Стабильные labels:
+
+- `env`;
+- `home:review.yml`;
+- `.review.yml`;
+- `home:repos/<repo>.yml`.
+
+`shadowed[key]` перечисляет ранее встретившиеся источники в порядке слоёв. Источник
+считается затенённым даже при равном значении: это важно для объяснения будущих
+изменений после миграции. Metadata содержит только имена ключей и источников.
+
+## Загрузка и слияние
+
+Каждый YAML должен декодироваться в mapping либо быть пустым. Скаляр или список на
+верхнем уровне является ошибкой слоя. Merge выполняется обычным присваиванием
+верхнего ключа:
+
+```python
+for key, value in layer.items():
+    if key in merged:
+        shadowed[key].append(sources[key])
+    merged[key] = value
+    sources[key] = layer_source
+```
+
+В частности:
+
+- `paths.ignore` заменяется вместе со всем ключом `paths`;
+- `context_limits` не deep-merge'ится между файлами;
+- `task_board: null` явно выключает доску;
+- неизвестные ключи сохраняются в merged data для forward compatibility, но
+  игнорируются `ReviewPolicy.load_data` и не попадают в effective output
+  `config show`, потому что фактически не влияют на политику.
+
+Ошибка чтения, декодирования или валидации домашнего слоя:
+
+- при `strict_home=False` добавляет безопасный warning и пропускает слой;
+- при `strict_home=True` поднимает типизированную `HomeConfigError`.
+
+Ошибки callback или committed `.review.yml` не маскируются самим resolver. Поэтому
+при отсутствии домашних файлов сохраняется текущая семантика каждого потребителя:
+ReviewService/index могут завершиться ошибкой, а существующие MCP fail-soft wrappers
+сведут её к дефолту.
+
+## Защита credentials
+
+Проверка домашних слоёв рекурсивно анализирует только имена ключей. Запрещены:
+
+- secret env names и aliases из registry board providers;
+- точные имена секретных полей `Settings`;
+- нормализованные suffix-формы `_token`, `_password`, `_secret`, `_api_key`,
+  `_private_key`, `_client_secret`, `_access_key`.
+
+Проверка не считает credential обычные лимиты вроде `max_tokens`: совпадение должно
+быть точным либо по singular suffix. При обнаружении запрещённого пути весь домашний
+слой пропускается. Warning сообщает source и путь ключа, но не сериализует значение
+или соседние данные.
+
+Committed `.review.yml` сохраняет нынешнюю совместимость. Его `task_board`
+по-прежнему проходит существующую registry-driven проверку credentials в
+`normalize_task_board_config`; общий новый denylist применяется только к домашним
+слоям.
+
+## `ReviewPolicy`
+
+В `reviewer/policy/policy.py` добавляется:
+
+```python
+ReviewPolicy.load_data(settings, data: Mapping[str, object]) -> ReviewPolicy
+```
+
+Метод начинает с `from_settings(settings)` и применяет присутствующие ключи той же
+логикой, что текущий `load`. `load(settings, yaml_text)` только парсит YAML и
+делегирует в `load_data`. Поведение `from_yaml`, публичные поля и существующие тесты
+остаются совместимыми.
+
+Для CLI вводится детерминированный serializer effective policy обратно в публичную
+YAML-shaped форму. Он не использует `Settings.model_dump()` и потому физически не
+может вывести токены, пароли, DSN или другие server settings.
+
+## Интеграция runtime
+
+### Подготовка ревью
+
+После получения PR и проверки tracked branch `ReviewService.prepare` вызывает
+resolver один раз:
+
+- repo — канонический repo-id;
+- ref — `prq.base_sha`, чтобы ignore и полная policy относились к одному commit;
+- callback — `vcs.get_file_at_ref(".review.yml", ref)`.
+
+Полученная `ReviewPolicy` используется для base index sync, graph patch, overlay,
+review gate и task-board extraction. Второе чтение `.review.yml` по `base_ref`
+удаляется. `PreparedReview.config_sources` получает JSON-friendly metadata.
+
+### MCP session-less paths
+
+`MCPReviewService` получает общий helper `_resolve_policy(repo, branch)`, который
+владеет lifecycle VCS provider и возвращает `(policy, meta)`. Его используют:
+
+- `_resolve_summary_depth`;
+- `_resolve_summary_topk_threshold`;
+- `_resolve_context_limits`.
+
+Существующие fail-soft fallback и закрытие provider сохраняются. Source для
+`summary_topk_threshold` берётся из одноимённого верхнего ключа. Для legacy tuple
+depth/overrides источник выбирается детерминированно: источник
+`summary_cluster_depth`, если ключ задан; иначе источник overrides, если задан
+только он; иначе `env`. Если оба ключа пришли из разных слоёв, `config show`
+остаётся полной картиной, а legacy строка намеренно отражает источник depth.
+
+### Локальная индексация
+
+`reviewer index` уже вычисляет канонический `repo_id` и git-ref. Resolver получает
+callback на `file_at_ref(local_repo, ".review.yml", ref)`. Фильтрация файлов и
+`update_base(ignore=...)` используют `ReviewPolicy.ignore` из всех слоёв. Рабочий
+файл вне указанного ref не читается.
+
+## CLI `reviewer config`
+
+Добавляется Click group `config` с командами `show` и `migrate`. CLI отвечает только
+за параметры, открытие/закрытие VCS provider, форматирование и преобразование
+типизированных ошибок в `click.ClickException`; merge и migration decisions живут
+в `reviewer/config/layers.py`.
+
+### `config show`
+
+```text
+reviewer config show --repo owner/name --branch main [--json]
+```
+
+Branch по умолчанию — `Settings.primary_branch()`. Committed YAML читается через
+тот же VCS provider, что runtime-review; локальный checkout не требуется.
+
+Human output показывает каждый верхний ключ, эффективное значение, winning source
+и затенённые источники. JSON имеет стабильную форму:
+
+```json
+{
+  "repo": "owner/name",
+  "branch": "main",
+  "effective": {},
+  "sources": {},
+  "shadowed": {},
+  "warnings": []
+}
+```
+
+`effective` строится только из публичной модели политики. Serializer явно
+перечисляет policy fields и никогда не сериализует `Settings` целиком или неизвестные
+YAML-ключи. Домашний файл с credentials пропускается с warning; значение credential
+не попадает ни в human, ни в JSON output.
+
+### `config migrate`
+
+```text
+reviewer config migrate --repo owner/name --branch main
+```
+
+Алгоритм:
+
+1. Строго загрузить домашние слои и committed `.review.yml`.
+2. Ошибиться, если committed файл отсутствует, пуст, не является mapping либо не
+   проходит credential-проверку как будущий домашний файл; секретный payload даже
+   временно не записывается в домашний каталог.
+3. Вычислить canonical effective values до миграции.
+4. Определить `repos/<repo>.yml` и проверить отсутствие symlink/path traversal.
+5. Если destination существует и semantic-equal committed mapping — напечатать
+   успешный no-op.
+6. Если destination существует и отличается — ничего не писать, перечислить только
+   конфликтующие верхние ключи и завершиться non-zero.
+7. Если destination отсутствует — атомарно записать исходный committed YAML через
+   temporary file в том же каталоге и `os.replace`; новый файл получает mode `0600`.
+8. Повторно разрешить policy и сравнить canonical effective values до/после.
+9. При несовпадении удалить только что созданный destination и завершиться ошибкой.
+10. Напечатать итог `config show` и предупреждение, что оставшийся `.review.yml`
+    затенён по перечисленным ключам.
+
+Команда не редактирует, не удаляет и не коммитит repository file. Сравнение
+идемпотентности семантическое, поэтому различия комментариев и форматирования сами
+по себе не вызывают конфликт.
+
+## Аудит и persisted sessions
+
+В `PreparedReview` добавляется поле с default:
+
+```python
+config_sources: dict = field(default_factory=dict)
+```
+
+`session_serde.to_payload` пишет поле, а `from_payload` читает через `.get`, поэтому
+старые persisted sessions остаются восстанавливаемыми.
+
+В `reviewer/web/schema.sql` добавляется идемпотентная колонка
+`review_runs.config_sources JSONB`. `ReviewHistory.record_run` и MCP publish path
+передают объект:
+
+```json
+{
+  "sources": {},
+  "shadowed": {},
+  "warnings": []
+}
+```
+
+Warning-тексты уже санитизированы и не содержат YAML values. History API возвращает
+поле вместе с деталями прогона; отдельный индекс для JSONB не нужен.
+
+## `configure-review` и документация
+
+Skill `reviewer_configure-review` сначала определяет repo-id и спрашивает цель
+записи:
+
+1. `home:repos/<repo>.yml` — рекомендуемый default, действует без коммита, но не
+   виден команде;
+2. `.review.yml` указанного git-ref — явный командный вариант, виден в git.
+
+После выбора остальной анализ структуры/churn и подтверждение `paths.ignore`
+остаются прежними. Skill сохраняет неизвестные ключи выбранного файла и никогда не
+переносит credentials.
+
+`README.md` и `README.ru.md` описывают:
+
+- пути и приоритет четырёх слоёв;
+- top-level replacement;
+- `config show` и `config migrate`;
+- shadowing после миграции;
+- отсутствие чтения рабочего дерева;
+- риск service-account deployment, где один домашний каталог влияет на все сессии
+  хоста.
+
+## Тестирование
+
+### Unit
+
+- `ReviewPolicy.load_data` эквивалентен старому `load` для всех текущих ключей.
+- Порядок четырёх слоёв, `null`, неизвестные ключи и top-level replacement.
+- `paths.ignore` и `context_limits` заменяются, а не deep-merge'ятся.
+- Точные `sources` и `shadowed`, включая равные значения.
+- XDG/default paths, subgroup repo-id и path-traversal rejection.
+- Malformed/non-mapping YAML в runtime и strict режимах.
+- Credential detection не выводит значения и не ловит `max_tokens`.
+
+### Runtime wiring
+
+- ReviewService без committed `.review.yml` получает ignore/policy/task-board из
+  home и использует один committed fetch для exact base SHA.
+- Per-repo home перебивает committed policy.
+- MCP depth/top-k/context limits используют resolver и сохраняют fail-soft.
+- `reviewer index` исключает пути только из домашнего слоя.
+- Отсутствие домашних файлов сохраняет существующие результаты и ошибки.
+
+### CLI и persistence
+
+- `config show` human/JSON, source labels, shadowing и sanitization.
+- `config migrate`: create, semantic no-op, conflict refusal, atomic rollback,
+  symlink refusal и неизменность repository file.
+- `PreparedReview` round-trip со старым и новым payload.
+- Идемпотентная schema migration и запись/чтение `config_sources`.
+- Обновлённый configure-review prompt и двуязычные documentation guards.
+
+## Порядок поставки
+
+1. Чистый layers resolver, provenance и policy `load_data`.
+2. ReviewService и index wiring.
+3. MCP resolver и source reporting.
+4. CLI `config show` и `config migrate`.
+5. Session/history audit.
+6. Configure-review и двуязычная документация.
+
+Каждый этап начинается с failing unit/integration test. Реализация не создаёт
+внешних сетевых зависимостей в тестах: VCS callback, config root, filesystem и
+history connections инъектируются либо заменяются fake-объектами.

--- a/plugin/.codex-plugin/plugin.json
+++ b/plugin/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "rag-reviewer",
-  "version": "0.4.2+codex.d174a66ebfd3",
+  "version": "0.4.2+codex.c474f3e9135e",
   "description": "Agentic PR review: hybrid RAG + code graph via MCP, review skills for Codex",
   "repository": "https://github.com/mimfort/rag_for_git",
   "license": "MIT",

--- a/plugin/skills/configure-review/SKILL.md
+++ b/plugin/skills/configure-review/SKILL.md
@@ -1,37 +1,50 @@
 ---
 name: reviewer_configure-review
-description: Configure or update a repo's .review.yml context layer and generic task-board metadata without secrets. Use when the user asks to set up or tune review config, context depth, ignored tracked paths, retrieval limits, or board selection.
+description: Use when configuring or changing a repository's layered review policy, ignored tracked paths, retrieval limits, summary depth, or non-secret task-board metadata.
 ---
 
 # Configure Review
 
-Always answer the user in Russian. Update only the requested `.review.yml` values; **Never clobber**
-foreign keys such as `categories`. This skill is standalone: no reviewer MCP, database, or board
-connection is required for the baseline.
+Always answer the user in Russian. Update only the requested policy values; **Never clobber** foreign
+keys such as `categories`. This skill is standalone: no reviewer MCP, database, or board connection
+is required for the baseline.
 
 ## Scope
 
 Manage `summary_cluster_depth`, `summary_cluster_depth_overrides`, `summary_topk_threshold`,
 `paths.ignore`, `context_limits`, and the optional `task_board` block. An empty `task_board:`
-disables the board for this repository. Never put credential values in `.review.yml`.
+disables the board for this repository. Never read, request, display, or write credential values in
+either policy target.
 
 Untracked `.venv`, `node_modules`, `__pycache__`, `dist`, and `build` are gitignored and never
 enter the index. Do not use a filesystem walk to find them.
 
 ## Pipeline
 
-1. Resolve the repository and branch, verify it with `git rev-parse --git-dir`, and read the
-   existing `.review.yml` without changing unrelated keys or comments.
-2. Scan only tracked Python files:
+1. Resolve the canonical lowercase repository id and the target branch. Present these targets in
+   this order and ask the user to select one:
+   - **Recommended/default:** `home:repos/<owner>/<name>.yml`, stored at
+     `$XDG_CONFIG_HOME/rag-reviewer/repos/<owner>/<name>.yml` (or
+     `~/.config/rag-reviewer/...` when `XDG_CONFIG_HOME` is unset). It needs no commit and is not
+     visible to the team.
+   - **Team-visible:** committed `.review.yml` at the selected target ref. It is committed and
+     visible to the team; read it from that ref, never from an uncommitted worktree file.
+   For a nested id such as `group/service`, use `home:repos/group/service.yml`. A home policy is
+   owned by the OS account running reviewer: on a shared service account it can affect that
+   account's workloads, so use committed policy for team-owned settings.
+2. After the target is selected, verify the repository with `git rev-parse --git-dir` and read the
+   selected file, preserving unrelated keys and comments. Do not inspect or copy credentials.
+3. Scan only tracked Python files:
    ```bash
    git -C <path> ls-tree -r --name-only <branch> | grep '\.py$'
    ```
    Count directory prefixes at depths 1–3. This is not a filesystem walk.
-3. Measure churn with `git log --since="6 months ago" --name-only --pretty=format: -- '*.py'`.
+4. Measure churn with `git log --since="6 months ago" --name-only --pretty=format: -- '*.py'`.
    If history is too short or unavailable, say so and recommend from structure alone.
-4. Propose depth and ignore changes. Ask the user about every candidate for `paths.ignore` and
-   **never write it silently**. Follow the exact rebuild map below; suggest but **do NOT run** a
-   follow-up skill.
+5. Propose depth and ignore changes. Ask the user about every candidate for `paths.ignore` and
+   **never write it silently**. Assemble a draft that preserves the selected file's unrelated
+   keys/comments, then request final confirmation before writing it. Follow the exact rebuild map
+   below; suggest but **do NOT run** a follow-up skill.
 
 ## Rebuild guidance
 

--- a/reviewer/config/layers.py
+++ b/reviewer/config/layers.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 from collections.abc import Callable, Mapping
 from dataclasses import asdict, dataclass
 from functools import lru_cache
+import json
+import math
 import os
 from pathlib import Path
 import stat
@@ -223,6 +225,101 @@ def policy_to_public_data(policy: ReviewPolicy) -> dict[str, object]:
     }
 
 
+def _is_int(value: object) -> bool:
+    return isinstance(value, int) and not isinstance(value, bool)
+
+
+def _is_number(value: object) -> bool:
+    return (
+        isinstance(value, (int, float))
+        and not isinstance(value, bool)
+        and math.isfinite(value)
+    )
+
+
+def _validate_mapping_shape(
+    value: object, shape: Mapping[str, Callable[[object], bool]]
+) -> None:
+    if not isinstance(value, Mapping) or set(value) != set(shape):
+        raise TypeError("invalid public mapping")
+    if any(not validator(value[key]) for key, validator in shape.items()):
+        raise TypeError("invalid public mapping value")
+
+
+def _validate_public_policy_data(effective: Mapping[str, object]) -> None:
+    """Проверить полную публичную форму до любого CLI-rendering."""
+    expected = {
+        "categories", "enabled_only", "severity_threshold", "paths", "max_comments",
+        "min_confidence", "output_language", "task_board", "grounding_max_distance",
+        "summary_cluster_depth", "summary_topk_threshold",
+        "summary_cluster_depth_overrides", "context_limits",
+    }
+    if set(effective) != expected:
+        raise TypeError("incomplete public policy")
+    categories = effective["categories"]
+    if not isinstance(categories, Mapping) or any(
+        not isinstance(key, str) or not isinstance(value, bool)
+        for key, value in categories.items()
+    ):
+        raise TypeError("invalid categories")
+    enabled_only = effective["enabled_only"]
+    if not isinstance(enabled_only, list) or not all(isinstance(item, str) for item in enabled_only):
+        raise TypeError("invalid enabled_only")
+    if effective["severity_threshold"] not in {"low", "medium", "high", "critical"}:
+        raise TypeError("invalid severity")
+    _validate_mapping_shape(effective["paths"], {"ignore": lambda value: (
+        isinstance(value, list) and all(isinstance(item, str) for item in value)
+    )})
+    if not _is_int(effective["max_comments"]) or not _is_number(effective["min_confidence"]):
+        raise TypeError("invalid review limits")
+    if not isinstance(effective["output_language"], str):
+        raise TypeError("invalid output language")
+    if effective["task_board"] is not None and not isinstance(effective["task_board"], Mapping):
+        raise TypeError("invalid task board")
+    for key in (
+        "grounding_max_distance",
+        "summary_cluster_depth",
+        "summary_topk_threshold",
+    ):
+        if not _is_int(effective[key]):
+            raise TypeError("invalid integer policy value")
+    overrides = effective["summary_cluster_depth_overrides"]
+    if not isinstance(overrides, Mapping) or any(
+        not isinstance(key, str) or not _is_int(value) for key, value in overrides.items()
+    ):
+        raise TypeError("invalid summary overrides")
+    _validate_mapping_shape(effective["context_limits"], {
+        "search_codebase": lambda value: _validate_context_limits(
+            value,
+            {
+                "floor": _is_int,
+                "ceiling": _is_int,
+                "ratio": _is_number,
+                "abs_floor": _is_number,
+                "candidate_pool": _is_int,
+                "ann_distance_max": _is_number,
+            },
+        ),
+        "search_tasks": lambda value: _validate_context_limits(
+            value, {"floor": _is_int, "ceiling": _is_int}
+        ),
+        "graph": lambda value: _validate_context_limits(
+            value, {"hops": _is_int, "callers_topk": _is_int}
+        ),
+    })
+    json.dumps(effective, ensure_ascii=False, sort_keys=True, allow_nan=False)
+
+
+def _validate_context_limits(
+    value: object, shape: Mapping[str, Callable[[object], bool]]
+) -> bool:
+    try:
+        _validate_mapping_shape(value, shape)
+    except TypeError:
+        return False
+    return True
+
+
 def build_config_report(
     repo: str,
     branch: str,
@@ -234,7 +331,8 @@ def build_config_report(
     try:
         policy = ReviewPolicy.load_data(settings, data)
         effective = policy_to_public_data(policy)
-    except (AttributeError, KeyError, TypeError, ValueError) as exc:
+        _validate_public_policy_data(effective)
+    except (AttributeError, KeyError, OverflowError, RecursionError, TypeError, ValueError) as exc:
         raise HomeConfigError("effective policy: недопустимые значения") from exc
     sources = {key: meta.sources.get(key, "env") for key in effective}
     return {
@@ -253,6 +351,11 @@ def _empty_meta() -> ResolutionMeta:
 
 def _read_destination_mapping(path: Path, source: str) -> dict[str, object] | None:
     """Прочитать существующий regular destination, не следуя symlink на POSIX."""
+    try:
+        if stat.S_ISLNK(os.lstat(path).st_mode):
+            raise HomeConfigError(f"{source}: symlink запрещён")
+    except FileNotFoundError:
+        return None
     flags = os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0)
     try:
         descriptor = os.open(path, flags)
@@ -298,7 +401,24 @@ def _existing_migration_result(
     return MigrationResult(destination, False, True, (), data, meta)
 
 
-def _publish_new_config(destination: Path, content: str) -> bool:
+def _path_identity(path: Path) -> tuple[int, int] | None:
+    try:
+        stat_result = os.lstat(path)
+    except FileNotFoundError:
+        return None
+    return stat_result.st_dev, stat_result.st_ino
+
+
+def _remove_owned_destination(destination: Path, identity: tuple[int, int]) -> None:
+    """Удалить destination только пока оно всё ещё inode нашей публикации."""
+    if _path_identity(destination) == identity:
+        try:
+            destination.unlink()
+        except FileNotFoundError:
+            pass
+
+
+def _publish_new_config(destination: Path, content: str) -> tuple[int, int] | None:
     """Опубликовать новый config без перезаписи уже созданного destination."""
     temp_path: Path | None = None
     try:
@@ -313,8 +433,11 @@ def _publish_new_config(destination: Path, content: str) -> bool:
         try:
             os.link(temp_path, destination)
         except FileExistsError:
-            return False
-        return True
+            return None
+        identity = _path_identity(destination)
+        if identity is None:
+            raise HomeConfigError("destination исчез после публикации")
+        return identity
     finally:
         if temp_path is not None and temp_path.exists():
             temp_path.unlink()
@@ -351,16 +474,21 @@ def migrate_repo_config(
         )
 
     destination.parent.mkdir(parents=True, exist_ok=True)
-    if not _publish_new_config(destination, source_text or ""):
+    identity = _publish_new_config(destination, source_text or "")
+    if identity is None:
         existing = _read_destination_mapping(destination, source)
         if existing is None:
             raise HomeConfigError(f"{source}: destination исчез во время миграции")
         return _existing_migration_result(
             destination, existing, candidate, repo, ref, fetch_repo_yaml, root, before_data
         )
-    after_data, meta = resolve_policy_data(
-        repo, ref, fetch_repo_yaml, config_root=root, strict_home=True
-    )
-    if after_data != before_data:
-        raise HomeConfigError("effective config изменился после миграции")
+    try:
+        after_data, meta = resolve_policy_data(
+            repo, ref, fetch_repo_yaml, config_root=root, strict_home=True
+        )
+        if after_data != before_data:
+            raise HomeConfigError("effective config изменился после миграции")
+    except Exception:
+        _remove_owned_destination(destination, identity)
+        raise
     return MigrationResult(destination, True, False, (), after_data, meta)

--- a/reviewer/config/layers.py
+++ b/reviewer/config/layers.py
@@ -1,0 +1,280 @@
+"""Trusted resolution for committed and user-home review-policy layers."""
+from __future__ import annotations
+
+from collections.abc import Callable, Mapping
+from dataclasses import asdict, dataclass
+from functools import lru_cache
+import os
+from pathlib import Path
+import tempfile
+
+import yaml
+
+from reviewer.policy.policy import ReviewPolicy
+from reviewer.services.repo_id import normalize_repo
+
+
+class HomeConfigError(ValueError):
+    """A home configuration cannot safely participate in resolution."""
+
+
+class HomeCredentialError(HomeConfigError):
+    """A home configuration contains a credential-shaped key."""
+
+
+@dataclass(frozen=True)
+class ResolutionMeta:
+    sources: dict[str, str]
+    shadowed: dict[str, tuple[str, ...]]
+    warnings: tuple[str, ...]
+
+    def as_dict(self) -> dict[str, object]:
+        return {
+            "sources": dict(self.sources),
+            "shadowed": {key: list(value) for key, value in self.shadowed.items()},
+            "warnings": list(self.warnings),
+        }
+
+
+@dataclass(frozen=True)
+class MigrationResult:
+    path: Path
+    created: bool
+    noop: bool
+    conflicting_keys: tuple[str, ...]
+    data: dict[str, object]
+    meta: ResolutionMeta
+
+
+def reviewer_config_root() -> Path:
+    xdg = os.environ.get("XDG_CONFIG_HOME")
+    return (
+        Path(xdg).expanduser() / "rag-reviewer"
+        if xdg
+        else Path.home() / ".config/rag-reviewer"
+    )
+
+
+def home_repo_path(repo: str, config_root: Path | None = None) -> Path:
+    root = config_root or reviewer_config_root()
+    return root.joinpath("repos", *normalize_repo(repo).split("/")).with_suffix(".yml")
+
+
+def _read_mapping(text: str | None, source: str) -> dict[str, object]:
+    data = yaml.safe_load(text) if text else {}
+    if data is None:
+        return {}
+    if not isinstance(data, dict):
+        raise HomeConfigError(f"{source}: верхний уровень должен быть mapping")
+    return data
+
+
+_SECRET_SUFFIXES = (
+    "_token",
+    "_password",
+    "_secret",
+    "_api_key",
+    "_private_key",
+    "_client_secret",
+    "_access_key",
+)
+
+_SETTINGS_SECRET_NAMES = frozenset({
+    "voyage_api_key",
+    "github_token",
+    "gitlab_token",
+    "neo4j_password",
+    "pg_dsn",
+    "web_admin_password",
+    "task_board_api_key",
+    "yougile_api_key",
+    "youtrack_token",
+})
+_MISSING = object()
+
+
+@lru_cache(maxsize=1)
+def _secret_names() -> frozenset[str]:
+    from reviewer.tasks.boards.registry import default_board_registry
+
+    registry = default_board_registry()
+    provider_names = {
+        env.lower()
+        for board_type in registry.registered_types()
+        for field in registry.get(board_type).credential_fields
+        if field.secret
+        for env in (field.env, *field.aliases)
+    }
+    return _SETTINGS_SECRET_NAMES | frozenset(provider_names)
+
+
+def _credential_path(
+    value: object,
+    prefix: tuple[str, ...] = (),
+    ancestors: frozenset[int] = frozenset(),
+) -> tuple[str, ...] | None:
+    if isinstance(value, Mapping):
+        if id(value) in ancestors:
+            raise HomeConfigError("циклическая YAML структура запрещена")
+        ancestors = ancestors | {id(value)}
+        for raw_key, child in value.items():
+            key = str(raw_key).strip().lower().replace("-", "_")
+            current = (*prefix, key)
+            if key in _secret_names() or key.endswith(_SECRET_SUFFIXES):
+                return current
+            nested = _credential_path(child, current, ancestors)
+            if nested:
+                return nested
+    elif isinstance(value, list):
+        if id(value) in ancestors:
+            raise HomeConfigError("циклическая YAML структура запрещена")
+        ancestors = ancestors | {id(value)}
+        for child in value:
+            nested = _credential_path(child, prefix, ancestors)
+            if nested:
+                return nested
+    return None
+
+
+def resolve_policy_data(
+    repo: str,
+    ref: str,
+    fetch_repo_yaml: Callable[[str], str | None],
+    *,
+    config_root: Path | None = None,
+    strict_home: bool = False,
+) -> tuple[dict[str, object], ResolutionMeta]:
+    """Resolve global home, committed, and repository home policy layers."""
+    repo = normalize_repo(repo)
+    root = config_root or reviewer_config_root()
+    merged: dict[str, object] = {}
+    sources: dict[str, str] = {}
+    shadowed: dict[str, list[str]] = {}
+    warnings: list[str] = []
+
+    def merge(data: Mapping[str, object], source: str) -> None:
+        for key, value in data.items():
+            if key in sources:
+                shadowed.setdefault(key, []).append(sources[key])
+            merged[key] = value
+            sources[key] = source
+
+    def merge_home(path: Path, source: str) -> None:
+        if not path.is_file():
+            return
+        try:
+            data = _read_mapping(path.read_text(encoding="utf-8"), source)
+            credential = _credential_path(data)
+            if credential:
+                raise HomeCredentialError(
+                    f"{source}: credential key {'.'.join(credential)} запрещён"
+                )
+            merge(data, source)
+        except HomeCredentialError as exc:
+            warnings.append(str(exc))
+        except (OSError, UnicodeError, yaml.YAMLError, HomeConfigError) as exc:
+            wrapped = HomeConfigError(
+                f"{source}: конфиг не прочитан: {type(exc).__name__}"
+            )
+            if strict_home:
+                raise wrapped from exc
+            warnings.append(str(wrapped))
+
+    merge_home(root / "review.yml", "home:review.yml")
+    committed = _read_mapping(fetch_repo_yaml(ref), ".review.yml")
+    merge(committed, ".review.yml")
+    repo_source = f"home:repos/{repo}.yml"
+    merge_home(home_repo_path(repo, root), repo_source)
+    return merged, ResolutionMeta(
+        sources=dict(sources),
+        shadowed={key: tuple(value) for key, value in shadowed.items()},
+        warnings=tuple(warnings),
+    )
+
+
+def policy_to_public_data(policy: ReviewPolicy) -> dict[str, object]:
+    """Return the serialized public fields of an effective review policy."""
+    return {
+        "categories": dict(policy.categories),
+        "enabled_only": list(policy.enabled_only),
+        "severity_threshold": policy.severity_threshold,
+        "paths": {"ignore": list(policy.ignore)},
+        "max_comments": policy.max_comments,
+        "min_confidence": policy.min_confidence,
+        "output_language": policy.output_language,
+        "task_board": policy.task_board,
+        "grounding_max_distance": policy.grounding_max_distance,
+        "summary_cluster_depth": policy.summary_cluster_depth,
+        "summary_topk_threshold": policy.summary_topk_threshold,
+        "summary_cluster_depth_overrides": dict(policy.summary_cluster_depth_overrides),
+        "context_limits": asdict(policy.context_limits),
+    }
+
+
+def _empty_meta() -> ResolutionMeta:
+    return ResolutionMeta({}, {}, ())
+
+
+def migrate_repo_config(
+    repo: str,
+    ref: str,
+    fetch_repo_yaml: Callable[[str], str | None],
+    *,
+    config_root: Path | None = None,
+) -> MigrationResult:
+    """Copy a safe committed policy to its repository-scoped home layer."""
+    repo = normalize_repo(repo)
+    root = config_root or reviewer_config_root()
+    source_text = fetch_repo_yaml(ref)
+    candidate = _read_mapping(source_text, ".review.yml")
+    if not candidate:
+        raise HomeConfigError(".review.yml отсутствует или пуст")
+    credential = _credential_path(candidate)
+    if credential:
+        raise HomeConfigError(
+            f".review.yml: credential key {'.'.join(credential)} нельзя мигрировать"
+        )
+    before_data, _ = resolve_policy_data(
+        repo, ref, fetch_repo_yaml, config_root=root, strict_home=True
+    )
+    destination = home_repo_path(repo, root)
+    if destination.is_symlink():
+        raise HomeConfigError(f"{destination}: symlink запрещён")
+    if destination.exists():
+        existing = _read_mapping(destination.read_text(encoding="utf-8"), str(destination))
+        if _credential_path(existing):
+            raise HomeConfigError(f"{destination}: credential key запрещён")
+        if existing != candidate:
+            conflicts = tuple(sorted(
+                key
+                for key in set(existing) | set(candidate)
+                if existing.get(key, _MISSING) != candidate.get(key, _MISSING)
+            ))
+            return MigrationResult(
+                destination, False, False, conflicts, before_data, _empty_meta()
+            )
+        data, meta = resolve_policy_data(
+            repo, ref, fetch_repo_yaml, config_root=root, strict_home=True
+        )
+        return MigrationResult(destination, False, True, (), data, meta)
+
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    temp_path: Path | None = None
+    try:
+        with tempfile.NamedTemporaryFile(
+            "w", encoding="utf-8", dir=destination.parent, delete=False
+        ) as handle:
+            handle.write(source_text or "")
+            temp_path = Path(handle.name)
+        temp_path.chmod(0o600)
+        os.replace(temp_path, destination)
+        after_data, meta = resolve_policy_data(
+            repo, ref, fetch_repo_yaml, config_root=root, strict_home=True
+        )
+        if after_data != before_data:
+            destination.unlink()
+            raise HomeConfigError("effective config изменился после миграции")
+        return MigrationResult(destination, True, False, (), after_data, meta)
+    finally:
+        if temp_path is not None and temp_path.exists():
+            temp_path.unlink()

--- a/reviewer/config/layers.py
+++ b/reviewer/config/layers.py
@@ -220,6 +220,27 @@ def policy_to_public_data(policy: ReviewPolicy) -> dict[str, object]:
     }
 
 
+def build_config_report(
+    repo: str,
+    branch: str,
+    settings,
+    data: Mapping[str, object],
+    meta: ResolutionMeta,
+) -> dict[str, object]:
+    """Собрать безопасный диагностический отчёт об эффективной policy."""
+    policy = ReviewPolicy.load_data(settings, data)
+    effective = policy_to_public_data(policy)
+    sources = {key: meta.sources.get(key, "env") for key in effective}
+    return {
+        "repo": normalize_repo(repo),
+        "branch": branch,
+        "effective": effective,
+        "sources": sources,
+        "shadowed": {key: list(value) for key, value in meta.shadowed.items()},
+        "warnings": list(meta.warnings),
+    }
+
+
 def _empty_meta() -> ResolutionMeta:
     return ResolutionMeta({}, {}, ())
 

--- a/reviewer/config/layers.py
+++ b/reviewer/config/layers.py
@@ -377,7 +377,13 @@ def _read_destination_mapping(path: Path, source: str) -> dict[str, object] | No
         raise HomeConfigError(f"{source}: конфиг не прочитан: {type(exc).__name__}") from exc
     finally:
         if descriptor != -1:
-            os.close(descriptor)
+            try:
+                os.close(descriptor)
+            except OSError as exc:
+                if sys.exc_info()[0] is None:
+                    raise HomeConfigError(
+                        f"{source}: конфиг не прочитан: {type(exc).__name__}"
+                    ) from exc
     before_identity = before.st_dev, before.st_ino
     opened_identity = opened.st_dev, opened.st_ino
     fresh_identity = fresh.st_dev, fresh.st_ino
@@ -504,7 +510,12 @@ def migrate_repo_config(
             destination, existing, candidate, repo, ref, fetch_repo_yaml, root, before_data
         )
 
-    destination.parent.mkdir(parents=True, exist_ok=True)
+    try:
+        destination.parent.mkdir(parents=True, exist_ok=True)
+    except OSError as exc:
+        raise HomeConfigError(
+            f"{source}: destination не подготовлен: {type(exc).__name__}"
+        ) from exc
     published_data, published_meta = _simulated_repo_layer(
         before_data, before_meta, candidate, source
     )

--- a/reviewer/config/layers.py
+++ b/reviewer/config/layers.py
@@ -2,18 +2,21 @@
 from __future__ import annotations
 
 from collections.abc import Callable, Mapping
+from contextlib import contextmanager
 from dataclasses import asdict, dataclass
 from functools import lru_cache
 import json
 import math
 import os
 from pathlib import Path
+import secrets
 import stat
 import sys
 import tempfile
 
 import yaml
 
+from reviewer.config.task_board import normalize_task_board_config
 from reviewer.policy.policy import ReviewPolicy
 from reviewer.services.repo_id import normalize_repo
 
@@ -24,6 +27,10 @@ class HomeConfigError(ValueError):
 
 class HomeCredentialError(HomeConfigError):
     """A home configuration contains a credential-shaped key."""
+
+
+class HomePolicyError(HomeConfigError):
+    """A home configuration contains an invalid value for a known policy key."""
 
 
 @dataclass(frozen=True)
@@ -61,14 +68,15 @@ def reviewer_config_root() -> Path:
 
 def home_repo_path(repo: str, config_root: Path | None = None) -> Path:
     root = config_root or reviewer_config_root()
-    return root.joinpath("repos", *normalize_repo(repo).split("/")).with_suffix(".yml")
+    segments = normalize_repo(repo).split("/")
+    return root.joinpath("repos", *segments[:-1], f"{segments[-1]}.yml")
 
 
 def _read_mapping(text: str | None, source: str) -> dict[str, object]:
     try:
         data = yaml.safe_load(text) if text else {}
-    except yaml.YAMLError as exc:
-        raise HomeConfigError(f"{source}: конфиг не прочитан: YAML") from exc
+    except yaml.YAMLError:
+        raise HomeConfigError(f"{source}: конфиг не прочитан: YAML") from None
     if data is None:
         return {}
     if not isinstance(data, dict):
@@ -143,6 +151,109 @@ def _credential_path(
     return None
 
 
+def _validate_context_limits_layer(value: object) -> bool:
+    if value is None:
+        return True
+    if not isinstance(value, Mapping):
+        return False
+    sections: dict[str, Mapping[str, Callable[[object], bool]]] = {
+        "search_codebase": {
+            "floor": _is_int,
+            "ceiling": _is_int,
+            "ratio": _is_number,
+            "abs_floor": _is_number,
+            "candidate_pool": _is_int,
+            "ann_distance_max": _is_number,
+        },
+        "search_tasks": {
+            "floor": _is_int,
+            "ceiling": _is_int,
+        },
+        "graph": {
+            "hops": _is_int,
+            "callers_topk": _is_int,
+        },
+    }
+    for section, shape in sections.items():
+        if section not in value or value[section] is None:
+            continue
+        section_value = value[section]
+        if not isinstance(section_value, Mapping):
+            return False
+        for key, validator in shape.items():
+            if key in section_value and not validator(section_value[key]):
+                return False
+    return True
+
+
+def _validate_known_policy_data(
+    data: Mapping[str, object],
+    source: str,
+) -> None:
+    """Проверить только известные policy-поля, сохранив future keys."""
+    try:
+        if any(not isinstance(key, str) for key in data):
+            raise TypeError
+        categories = data.get("categories", _MISSING)
+        if categories is not _MISSING and categories is not None and (
+            not isinstance(categories, Mapping)
+            or any(
+                not isinstance(key, str) or not isinstance(value, bool)
+                for key, value in categories.items()
+            )
+        ):
+            raise TypeError
+        severity = data.get("severity_threshold", _MISSING)
+        if severity is not _MISSING and severity not in {
+            "low",
+            "medium",
+            "high",
+            "critical",
+        }:
+            raise TypeError
+        paths = data.get("paths", _MISSING)
+        if paths is not _MISSING:
+            if paths is not None and not isinstance(paths, Mapping):
+                raise TypeError
+            if isinstance(paths, Mapping) and "ignore" in paths:
+                ignore = paths["ignore"]
+                if not isinstance(ignore, list) or not all(
+                    isinstance(item, str) for item in ignore
+                ):
+                    raise TypeError
+        for key in (
+            "max_comments",
+            "grounding_max_distance",
+            "summary_cluster_depth",
+            "summary_topk_threshold",
+        ):
+            if key in data and not _is_int(data[key]):
+                raise TypeError
+        if "min_confidence" in data and not _is_number(data["min_confidence"]):
+            raise TypeError
+        if "output_language" in data and not isinstance(data["output_language"], str):
+            raise TypeError
+        if "task_board" in data:
+            normalize_task_board_config(data["task_board"])
+        overrides = data.get("summary_cluster_depth_overrides", _MISSING)
+        if overrides is not _MISSING:
+            if overrides is not None and not isinstance(overrides, Mapping):
+                raise TypeError
+            if isinstance(overrides, Mapping) and any(
+                not isinstance(key, str) or not _is_int(value)
+                for key, value in overrides.items()
+            ):
+                raise TypeError
+        if "context_limits" in data and not _validate_context_limits_layer(
+            data["context_limits"]
+        ):
+            raise TypeError
+    except (AttributeError, KeyError, OverflowError, RecursionError, TypeError, ValueError):
+        raise HomePolicyError(
+            f"{source}: policy содержит недопустимые значения"
+        ) from None
+
+
 def resolve_policy_data(
     repo: str,
     ref: str,
@@ -176,10 +287,15 @@ def resolve_policy_data(
                 raise HomeCredentialError(
                     f"{source}: credential key {'.'.join(credential)} запрещён"
                 )
+            _validate_known_policy_data(data, source)
             merge(data, source)
         except FileNotFoundError:
             return
         except HomeCredentialError as exc:
+            warnings.append(str(exc))
+        except HomePolicyError as exc:
+            if strict_home:
+                raise
             warnings.append(str(exc))
         except (
             OSError,
@@ -192,7 +308,7 @@ def resolve_policy_data(
                 f"{source}: конфиг не прочитан: {type(exc).__name__}"
             )
             if strict_home:
-                raise wrapped from exc
+                raise wrapped from None
             warnings.append(str(wrapped))
 
     merge_home(root / "review.yml", "home:review.yml")
@@ -333,8 +449,8 @@ def build_config_report(
         policy = ReviewPolicy.load_data(settings, data)
         effective = policy_to_public_data(policy)
         _validate_public_policy_data(effective)
-    except (AttributeError, KeyError, OverflowError, RecursionError, TypeError, ValueError) as exc:
-        raise HomeConfigError("effective policy: недопустимые значения") from exc
+    except (AttributeError, KeyError, OverflowError, RecursionError, TypeError, ValueError):
+        raise HomeConfigError("effective policy: недопустимые значения") from None
     sources = {key: meta.sources.get(key, "env") for key in effective}
     return {
         "repo": normalize_repo(repo),
@@ -350,31 +466,241 @@ def _empty_meta() -> ResolutionMeta:
     return ResolutionMeta({}, {}, ())
 
 
-def _read_destination_mapping(path: Path, source: str) -> dict[str, object] | None:
+def _semantic_equal(left: object, right: object) -> bool:
+    """Сравнить YAML-значения рекурсивно, не смешивая bool/int/float."""
+    if type(left) is not type(right):
+        return False
+    if isinstance(left, Mapping):
+        assert isinstance(right, Mapping)
+        if len(left) != len(right):
+            return False
+        unmatched = list(right.items())
+        for left_key, left_value in left.items():
+            for index, (right_key, right_value) in enumerate(unmatched):
+                if _semantic_equal(left_key, right_key):
+                    if not _semantic_equal(left_value, right_value):
+                        return False
+                    unmatched.pop(index)
+                    break
+            else:
+                return False
+        return not unmatched
+    if isinstance(left, (list, tuple)):
+        assert isinstance(right, (list, tuple))
+        return len(left) == len(right) and all(
+            _semantic_equal(left_item, right_item)
+            for left_item, right_item in zip(left, right, strict=True)
+        )
+    return left == right
+
+
+def _effective_policy_snapshot(
+    data: Mapping[str, object],
+    settings,
+) -> object:
+    """Провалидировать effective data и вернуть каноническую форму сравнения."""
+    _validate_known_policy_data(data, "effective policy")
+    if settings is None:
+        return dict(data)
+    try:
+        policy = ReviewPolicy.load_data(settings, data)
+        effective = policy_to_public_data(policy)
+        _validate_public_policy_data(effective)
+        return effective
+    except (AttributeError, KeyError, OverflowError, RecursionError, TypeError, ValueError):
+        raise HomePolicyError(
+            "effective policy: policy содержит недопустимые значения"
+        ) from None
+
+
+@dataclass(frozen=True)
+class _DestinationParent:
+    path: Path
+    descriptor: int | None
+
+
+def _supports_secure_directory_walk() -> bool:
+    return (
+        bool(getattr(os, "O_DIRECTORY", 0))
+        and bool(getattr(os, "O_NOFOLLOW", 0))
+        and os.open in os.supports_dir_fd
+        and os.mkdir in os.supports_dir_fd
+        and os.stat in os.supports_dir_fd
+        and os.link in os.supports_dir_fd
+        and os.unlink in os.supports_dir_fd
+    )
+
+
+def _prepare_destination_parent_fallback(
+    root: Path,
+    segments: list[str],
+    source: str,
+) -> Path:
+    """Cross-platform fallback с lstat-проверкой каждого компонента под root."""
+    try:
+        root.mkdir(parents=True, exist_ok=True)
+    except OSError as exc:
+        raise HomeConfigError(
+            f"{source}: destination не подготовлен: {type(exc).__name__}"
+        ) from None
+    current = root
+    for segment in segments:
+        current = current / segment
+        try:
+            metadata = os.lstat(current)
+        except FileNotFoundError:
+            try:
+                current.mkdir(mode=0o700)
+                metadata = os.lstat(current)
+            except OSError as exc:
+                raise HomeConfigError(
+                    f"{source}: destination не подготовлен: {type(exc).__name__}"
+                ) from None
+        except OSError as exc:
+            raise HomeConfigError(
+                f"{source}: destination не подготовлен: {type(exc).__name__}"
+            ) from None
+        if stat.S_ISLNK(metadata.st_mode):
+            raise HomeConfigError(f"{source}: symlink в destination запрещён")
+        if not stat.S_ISDIR(metadata.st_mode):
+            raise HomeConfigError(f"{source}: parent destination не является directory")
+    return current
+
+
+@contextmanager
+def _prepare_destination_parent(
+    root: Path,
+    repo: str,
+    source: str,
+):
+    """Создать и открыть parent, не следуя symlink-компонентам ниже config root."""
+    segments = ["repos", *repo.split("/")[:-1]]
+    if not _supports_secure_directory_walk():
+        yield _DestinationParent(
+            _prepare_destination_parent_fallback(root, segments, source),
+            None,
+        )
+        return
+
+    try:
+        root.mkdir(parents=True, exist_ok=True)
+        descriptor = os.open(
+            root,
+            os.O_RDONLY | os.O_DIRECTORY | getattr(os, "O_CLOEXEC", 0),
+        )
+    except OSError as exc:
+        raise HomeConfigError(
+            f"{source}: destination не подготовлен: {type(exc).__name__}"
+        ) from None
+    current_path = root
+    try:
+        for segment in segments:
+            try:
+                os.mkdir(segment, 0o700, dir_fd=descriptor)
+            except FileExistsError:
+                pass
+            except OSError as exc:
+                raise HomeConfigError(
+                    f"{source}: destination не подготовлен: {type(exc).__name__}"
+                ) from None
+            try:
+                child = os.open(
+                    segment,
+                    os.O_RDONLY
+                    | os.O_DIRECTORY
+                    | os.O_NOFOLLOW
+                    | getattr(os, "O_CLOEXEC", 0),
+                    dir_fd=descriptor,
+                )
+            except OSError:
+                raise HomeConfigError(
+                    f"{source}: symlink или non-directory parent запрещён"
+                ) from None
+            try:
+                metadata = os.fstat(child)
+                if not stat.S_ISDIR(metadata.st_mode):
+                    raise HomeConfigError(
+                        f"{source}: parent destination не является directory"
+                    )
+            except Exception:
+                try:
+                    os.close(child)
+                except OSError:
+                    pass
+                raise
+            try:
+                os.close(descriptor)
+            except OSError:
+                try:
+                    os.close(child)
+                except OSError:
+                    pass
+                raise HomeConfigError(
+                    f"{source}: destination descriptor не закрыт"
+                ) from None
+            descriptor = child
+            current_path /= segment
+        yield _DestinationParent(current_path, descriptor)
+    finally:
+        try:
+            os.close(descriptor)
+        except OSError as exc:
+            if sys.exc_info()[0] is None:
+                raise HomeConfigError(
+                    f"{source}: destination descriptor не закрыт: {type(exc).__name__}"
+                ) from None
+
+
+def _read_destination_mapping(
+    path: Path,
+    source: str,
+    *,
+    parent_fd: int | None = None,
+) -> dict[str, object] | None:
     """Прочитать существующий regular destination, не следуя symlink на POSIX."""
     try:
-        before = os.lstat(path)
+        before = (
+            os.stat(path.name, dir_fd=parent_fd, follow_symlinks=False)
+            if parent_fd is not None
+            else os.lstat(path)
+        )
         if stat.S_ISLNK(before.st_mode):
             raise HomeConfigError(f"{source}: symlink запрещён")
     except FileNotFoundError:
         return None
     except OSError as exc:
-        raise HomeConfigError(f"{source}: конфиг не прочитан: {type(exc).__name__}") from exc
+        raise HomeConfigError(
+            f"{source}: конфиг не прочитан: {type(exc).__name__}"
+        ) from None
+    if not stat.S_ISREG(before.st_mode):
+        raise HomeConfigError(f"{source}: destination должен быть regular file")
     flags = os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0)
     try:
-        descriptor = os.open(path, flags)
+        descriptor = (
+            os.open(path.name, flags, dir_fd=parent_fd)
+            if parent_fd is not None
+            else os.open(path, flags)
+        )
     except FileNotFoundError:
         return None
     except OSError as exc:
-        raise HomeConfigError(f"{source}: конфиг не прочитан: {type(exc).__name__}") from exc
+        raise HomeConfigError(
+            f"{source}: конфиг не прочитан: {type(exc).__name__}"
+        ) from None
     try:
         opened = os.fstat(descriptor)
         with os.fdopen(descriptor, encoding="utf-8") as handle:
             descriptor = -1
             text = handle.read()
-        fresh = os.lstat(path)
+        fresh = (
+            os.stat(path.name, dir_fd=parent_fd, follow_symlinks=False)
+            if parent_fd is not None
+            else os.lstat(path)
+        )
     except (OSError, UnicodeError) as exc:
-        raise HomeConfigError(f"{source}: конфиг не прочитан: {type(exc).__name__}") from exc
+        raise HomeConfigError(
+            f"{source}: конфиг не прочитан: {type(exc).__name__}"
+        ) from None
     finally:
         if descriptor != -1:
             try:
@@ -383,7 +709,7 @@ def _read_destination_mapping(path: Path, source: str) -> dict[str, object] | No
                 if sys.exc_info()[0] is None:
                     raise HomeConfigError(
                         f"{source}: конфиг не прочитан: {type(exc).__name__}"
-                    ) from exc
+                    ) from None
     before_identity = before.st_dev, before.st_ino
     opened_identity = opened.st_dev, opened.st_ino
     fresh_identity = fresh.st_dev, fresh.st_ino
@@ -407,14 +733,20 @@ def _existing_migration_result(
     fetch_repo_yaml: Callable[[str], str | None],
     root: Path,
     before_data: dict[str, object],
+    settings,
 ) -> MigrationResult:
     if _credential_path(existing):
         raise HomeConfigError(f"home:repos/{repo}.yml: credential key запрещён")
-    if existing != candidate:
+    source = f"home:repos/{repo}.yml"
+    _validate_known_policy_data(existing, source)
+    if not _semantic_equal(existing, candidate):
         conflicts = tuple(sorted(
             key
             for key in set(existing) | set(candidate)
-            if existing.get(key, _MISSING) != candidate.get(key, _MISSING)
+            if not _semantic_equal(
+                existing.get(key, _MISSING),
+                candidate.get(key, _MISSING),
+            )
         ))
         return MigrationResult(
             destination, False, False, conflicts, before_data, _empty_meta()
@@ -422,11 +754,68 @@ def _existing_migration_result(
     data, meta = resolve_policy_data(
         repo, ref, fetch_repo_yaml, config_root=root, strict_home=True
     )
+    _effective_policy_snapshot(data, settings)
     return MigrationResult(destination, False, True, (), data, meta)
 
 
-def _publish_new_config(destination: Path, content: str, source: str) -> bool:
+def _publish_new_config(
+    destination: Path,
+    content: str,
+    source: str,
+    *,
+    parent_fd: int | None = None,
+) -> bool:
     """Опубликовать новый config без перезаписи уже созданного destination."""
+    if parent_fd is not None:
+        temp_name = f".reviewer-migrate-{secrets.token_hex(12)}"
+        descriptor = -1
+        try:
+            descriptor = os.open(
+                temp_name,
+                os.O_WRONLY | os.O_CREAT | os.O_EXCL,
+                0o600,
+                dir_fd=parent_fd,
+            )
+            with os.fdopen(descriptor, "w", encoding="utf-8") as handle:
+                descriptor = -1
+                handle.write(content)
+                handle.flush()
+                os.fsync(handle.fileno())
+            try:
+                os.link(
+                    temp_name,
+                    destination.name,
+                    src_dir_fd=parent_fd,
+                    dst_dir_fd=parent_fd,
+                    follow_symlinks=False,
+                )
+            except FileExistsError:
+                return False
+            except OSError as exc:
+                raise HomeConfigError(
+                    f"{source}: публикация не выполнена: {type(exc).__name__}"
+                ) from None
+            return True
+        except OSError as exc:
+            raise HomeConfigError(
+                f"{source}: публикация не выполнена: {type(exc).__name__}"
+            ) from None
+        finally:
+            if descriptor != -1:
+                try:
+                    os.close(descriptor)
+                except OSError:
+                    pass
+            try:
+                os.unlink(temp_name, dir_fd=parent_fd)
+            except FileNotFoundError:
+                pass
+            except OSError as exc:
+                if sys.exc_info()[0] is None:
+                    raise HomeConfigError(
+                        f"{source}: очистка temporary file: {type(exc).__name__}"
+                    ) from None
+
     temp_path: Path | None = None
     try:
         with tempfile.NamedTemporaryFile(
@@ -444,12 +833,12 @@ def _publish_new_config(destination: Path, content: str, source: str) -> bool:
         except OSError as exc:
             raise HomeConfigError(
                 f"{source}: публикация не выполнена: {type(exc).__name__}"
-            ) from exc
+            ) from None
         return True
     except OSError as exc:
         raise HomeConfigError(
             f"{source}: публикация не выполнена: {type(exc).__name__}"
-        ) from exc
+        ) from None
     finally:
         if temp_path is not None:
             try:
@@ -460,7 +849,7 @@ def _publish_new_config(destination: Path, content: str, source: str) -> bool:
                 if sys.exc_info()[0] is None:
                     raise HomeConfigError(
                         f"{source}: очистка temporary file: {type(exc).__name__}"
-                    ) from exc
+                    ) from None
 
 
 def _simulated_repo_layer(
@@ -486,6 +875,7 @@ def migrate_repo_config(
     fetch_repo_yaml: Callable[[str], str | None],
     *,
     config_root: Path | None = None,
+    settings=None,
 ) -> MigrationResult:
     """Copy a safe committed policy to its repository-scoped home layer."""
     repo = normalize_repo(repo)
@@ -499,31 +889,62 @@ def migrate_repo_config(
         raise HomeConfigError(
             f".review.yml: credential key {'.'.join(credential)} нельзя мигрировать"
         )
+    _validate_known_policy_data(candidate, ".review.yml")
+    def fetch_snapshot(_selected_ref: str) -> str | None:
+        return source_text
+
     before_data, before_meta = resolve_policy_data(
-        repo, ref, fetch_repo_yaml, config_root=root, strict_home=True
+        repo, ref, fetch_snapshot, config_root=root, strict_home=True
     )
+    before_effective = _effective_policy_snapshot(before_data, settings)
     destination = home_repo_path(repo, root)
     source = f"home:repos/{repo}.yml"
-    existing = _read_destination_mapping(destination, source)
-    if existing is not None:
-        return _existing_migration_result(
-            destination, existing, candidate, repo, ref, fetch_repo_yaml, root, before_data
+    with _prepare_destination_parent(root, repo, source) as parent:
+        existing = _read_destination_mapping(
+            destination,
+            source,
+            parent_fd=parent.descriptor,
         )
-
-    try:
-        destination.parent.mkdir(parents=True, exist_ok=True)
-    except OSError as exc:
-        raise HomeConfigError(
-            f"{source}: destination не подготовлен: {type(exc).__name__}"
-        ) from exc
-    published_data, published_meta = _simulated_repo_layer(
-        before_data, before_meta, candidate, source
-    )
-    if not _publish_new_config(destination, source_text or "", source):
-        existing = _read_destination_mapping(destination, source)
-        if existing is None:
-            raise HomeConfigError(f"{source}: destination исчез во время миграции")
-        return _existing_migration_result(
-            destination, existing, candidate, repo, ref, fetch_repo_yaml, root, before_data
+        if existing is not None:
+            return _existing_migration_result(
+                destination,
+                existing,
+                candidate,
+                repo,
+                ref,
+                fetch_snapshot,
+                root,
+                before_data,
+                settings,
+            )
+        published_data, published_meta = _simulated_repo_layer(
+            before_data, before_meta, candidate, source
         )
+        published_effective = _effective_policy_snapshot(published_data, settings)
+        if not _semantic_equal(before_effective, published_effective):
+            raise HomeConfigError("effective policy изменился после миграции")
+        if not _publish_new_config(
+            destination,
+            source_text or "",
+            source,
+            parent_fd=parent.descriptor,
+        ):
+            existing = _read_destination_mapping(
+                destination,
+                source,
+                parent_fd=parent.descriptor,
+            )
+            if existing is None:
+                raise HomeConfigError(f"{source}: destination исчез во время миграции")
+            return _existing_migration_result(
+                destination,
+                existing,
+                candidate,
+                repo,
+                ref,
+                fetch_snapshot,
+                root,
+                before_data,
+                settings,
+            )
     return MigrationResult(destination, True, False, (), published_data, published_meta)

--- a/reviewer/config/layers.py
+++ b/reviewer/config/layers.py
@@ -9,6 +9,7 @@ import math
 import os
 from pathlib import Path
 import stat
+import sys
 import tempfile
 
 import yaml
@@ -352,10 +353,13 @@ def _empty_meta() -> ResolutionMeta:
 def _read_destination_mapping(path: Path, source: str) -> dict[str, object] | None:
     """Прочитать существующий regular destination, не следуя symlink на POSIX."""
     try:
-        if stat.S_ISLNK(os.lstat(path).st_mode):
+        before = os.lstat(path)
+        if stat.S_ISLNK(before.st_mode):
             raise HomeConfigError(f"{source}: symlink запрещён")
     except FileNotFoundError:
         return None
+    except OSError as exc:
+        raise HomeConfigError(f"{source}: конфиг не прочитан: {type(exc).__name__}") from exc
     flags = os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0)
     try:
         descriptor = os.open(path, flags)
@@ -364,14 +368,28 @@ def _read_destination_mapping(path: Path, source: str) -> dict[str, object] | No
     except OSError as exc:
         raise HomeConfigError(f"{source}: конфиг не прочитан: {type(exc).__name__}") from exc
     try:
-        if not stat.S_ISREG(os.fstat(descriptor).st_mode):
-            raise HomeConfigError(f"{source}: regular file обязателен")
+        opened = os.fstat(descriptor)
         with os.fdopen(descriptor, encoding="utf-8") as handle:
             descriptor = -1
-            return _read_mapping(handle.read(), source)
+            text = handle.read()
+        fresh = os.lstat(path)
+    except (OSError, UnicodeError) as exc:
+        raise HomeConfigError(f"{source}: конфиг не прочитан: {type(exc).__name__}") from exc
     finally:
         if descriptor != -1:
             os.close(descriptor)
+    before_identity = before.st_dev, before.st_ino
+    opened_identity = opened.st_dev, opened.st_ino
+    fresh_identity = fresh.st_dev, fresh.st_ino
+    if (
+        not stat.S_ISREG(before.st_mode)
+        or not stat.S_ISREG(opened.st_mode)
+        or stat.S_ISLNK(fresh.st_mode)
+        or before_identity != opened_identity
+        or opened_identity != fresh_identity
+    ):
+        raise HomeConfigError(f"{source}: race при чтении destination")
+    return _read_mapping(text, source)
 
 
 def _existing_migration_result(
@@ -401,24 +419,7 @@ def _existing_migration_result(
     return MigrationResult(destination, False, True, (), data, meta)
 
 
-def _path_identity(path: Path) -> tuple[int, int] | None:
-    try:
-        stat_result = os.lstat(path)
-    except FileNotFoundError:
-        return None
-    return stat_result.st_dev, stat_result.st_ino
-
-
-def _remove_owned_destination(destination: Path, identity: tuple[int, int]) -> None:
-    """Удалить destination только пока оно всё ещё inode нашей публикации."""
-    if _path_identity(destination) == identity:
-        try:
-            destination.unlink()
-        except FileNotFoundError:
-            pass
-
-
-def _publish_new_config(destination: Path, content: str) -> tuple[int, int] | None:
+def _publish_new_config(destination: Path, content: str, source: str) -> bool:
     """Опубликовать новый config без перезаписи уже созданного destination."""
     temp_path: Path | None = None
     try:
@@ -433,14 +434,44 @@ def _publish_new_config(destination: Path, content: str) -> tuple[int, int] | No
         try:
             os.link(temp_path, destination)
         except FileExistsError:
-            return None
-        identity = _path_identity(destination)
-        if identity is None:
-            raise HomeConfigError("destination исчез после публикации")
-        return identity
+            return False
+        except OSError as exc:
+            raise HomeConfigError(
+                f"{source}: публикация не выполнена: {type(exc).__name__}"
+            ) from exc
+        return True
+    except OSError as exc:
+        raise HomeConfigError(
+            f"{source}: публикация не выполнена: {type(exc).__name__}"
+        ) from exc
     finally:
-        if temp_path is not None and temp_path.exists():
-            temp_path.unlink()
+        if temp_path is not None:
+            try:
+                temp_path.unlink()
+            except FileNotFoundError:
+                pass
+            except OSError as exc:
+                if sys.exc_info()[0] is None:
+                    raise HomeConfigError(
+                        f"{source}: очистка temporary file: {type(exc).__name__}"
+                    ) from exc
+
+
+def _simulated_repo_layer(
+    data: Mapping[str, object], meta: ResolutionMeta, candidate: Mapping[str, object], source: str
+) -> tuple[dict[str, object], ResolutionMeta]:
+    """Вычислить результат repository-home layer до его атомарной публикации."""
+    merged = dict(data)
+    sources = dict(meta.sources)
+    shadowed = {key: list(value) for key, value in meta.shadowed.items()}
+    for key, value in candidate.items():
+        if key in sources:
+            shadowed.setdefault(key, []).append(sources[key])
+        merged[key] = value
+        sources[key] = source
+    return merged, ResolutionMeta(
+        sources, {key: tuple(value) for key, value in shadowed.items()}, meta.warnings
+    )
 
 
 def migrate_repo_config(
@@ -462,7 +493,7 @@ def migrate_repo_config(
         raise HomeConfigError(
             f".review.yml: credential key {'.'.join(credential)} нельзя мигрировать"
         )
-    before_data, _ = resolve_policy_data(
+    before_data, before_meta = resolve_policy_data(
         repo, ref, fetch_repo_yaml, config_root=root, strict_home=True
     )
     destination = home_repo_path(repo, root)
@@ -474,21 +505,14 @@ def migrate_repo_config(
         )
 
     destination.parent.mkdir(parents=True, exist_ok=True)
-    identity = _publish_new_config(destination, source_text or "")
-    if identity is None:
+    published_data, published_meta = _simulated_repo_layer(
+        before_data, before_meta, candidate, source
+    )
+    if not _publish_new_config(destination, source_text or "", source):
         existing = _read_destination_mapping(destination, source)
         if existing is None:
             raise HomeConfigError(f"{source}: destination исчез во время миграции")
         return _existing_migration_result(
             destination, existing, candidate, repo, ref, fetch_repo_yaml, root, before_data
         )
-    try:
-        after_data, meta = resolve_policy_data(
-            repo, ref, fetch_repo_yaml, config_root=root, strict_home=True
-        )
-        if after_data != before_data:
-            raise HomeConfigError("effective config изменился после миграции")
-    except Exception:
-        _remove_owned_destination(destination, identity)
-        raise
-    return MigrationResult(destination, True, False, (), after_data, meta)
+    return MigrationResult(destination, True, False, (), published_data, published_meta)

--- a/reviewer/config/layers.py
+++ b/reviewer/config/layers.py
@@ -62,7 +62,10 @@ def home_repo_path(repo: str, config_root: Path | None = None) -> Path:
 
 
 def _read_mapping(text: str | None, source: str) -> dict[str, object]:
-    data = yaml.safe_load(text) if text else {}
+    try:
+        data = yaml.safe_load(text) if text else {}
+    except yaml.YAMLError as exc:
+        raise HomeConfigError(f"{source}: конфиг не прочитан: YAML") from exc
     if data is None:
         return {}
     if not isinstance(data, dict):
@@ -228,8 +231,11 @@ def build_config_report(
     meta: ResolutionMeta,
 ) -> dict[str, object]:
     """Собрать безопасный диагностический отчёт об эффективной policy."""
-    policy = ReviewPolicy.load_data(settings, data)
-    effective = policy_to_public_data(policy)
+    try:
+        policy = ReviewPolicy.load_data(settings, data)
+        effective = policy_to_public_data(policy)
+    except (AttributeError, KeyError, TypeError, ValueError) as exc:
+        raise HomeConfigError("effective policy: недопустимые значения") from exc
     sources = {key: meta.sources.get(key, "env") for key in effective}
     return {
         "repo": normalize_repo(repo),
@@ -243,6 +249,75 @@ def build_config_report(
 
 def _empty_meta() -> ResolutionMeta:
     return ResolutionMeta({}, {}, ())
+
+
+def _read_destination_mapping(path: Path, source: str) -> dict[str, object] | None:
+    """Прочитать существующий regular destination, не следуя symlink на POSIX."""
+    flags = os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0)
+    try:
+        descriptor = os.open(path, flags)
+    except FileNotFoundError:
+        return None
+    except OSError as exc:
+        raise HomeConfigError(f"{source}: конфиг не прочитан: {type(exc).__name__}") from exc
+    try:
+        if not stat.S_ISREG(os.fstat(descriptor).st_mode):
+            raise HomeConfigError(f"{source}: regular file обязателен")
+        with os.fdopen(descriptor, encoding="utf-8") as handle:
+            descriptor = -1
+            return _read_mapping(handle.read(), source)
+    finally:
+        if descriptor != -1:
+            os.close(descriptor)
+
+
+def _existing_migration_result(
+    destination: Path,
+    existing: dict[str, object],
+    candidate: dict[str, object],
+    repo: str,
+    ref: str,
+    fetch_repo_yaml: Callable[[str], str | None],
+    root: Path,
+    before_data: dict[str, object],
+) -> MigrationResult:
+    if _credential_path(existing):
+        raise HomeConfigError(f"home:repos/{repo}.yml: credential key запрещён")
+    if existing != candidate:
+        conflicts = tuple(sorted(
+            key
+            for key in set(existing) | set(candidate)
+            if existing.get(key, _MISSING) != candidate.get(key, _MISSING)
+        ))
+        return MigrationResult(
+            destination, False, False, conflicts, before_data, _empty_meta()
+        )
+    data, meta = resolve_policy_data(
+        repo, ref, fetch_repo_yaml, config_root=root, strict_home=True
+    )
+    return MigrationResult(destination, False, True, (), data, meta)
+
+
+def _publish_new_config(destination: Path, content: str) -> bool:
+    """Опубликовать новый config без перезаписи уже созданного destination."""
+    temp_path: Path | None = None
+    try:
+        with tempfile.NamedTemporaryFile(
+            "w", encoding="utf-8", dir=destination.parent, delete=False
+        ) as handle:
+            handle.write(content)
+            handle.flush()
+            os.fsync(handle.fileno())
+            temp_path = Path(handle.name)
+        temp_path.chmod(0o600)
+        try:
+            os.link(temp_path, destination)
+        except FileExistsError:
+            return False
+        return True
+    finally:
+        if temp_path is not None and temp_path.exists():
+            temp_path.unlink()
 
 
 def migrate_repo_config(
@@ -268,43 +343,24 @@ def migrate_repo_config(
         repo, ref, fetch_repo_yaml, config_root=root, strict_home=True
     )
     destination = home_repo_path(repo, root)
-    if destination.is_symlink():
-        raise HomeConfigError(f"{destination}: symlink запрещён")
-    if destination.exists():
-        existing = _read_mapping(destination.read_text(encoding="utf-8"), str(destination))
-        if _credential_path(existing):
-            raise HomeConfigError(f"{destination}: credential key запрещён")
-        if existing != candidate:
-            conflicts = tuple(sorted(
-                key
-                for key in set(existing) | set(candidate)
-                if existing.get(key, _MISSING) != candidate.get(key, _MISSING)
-            ))
-            return MigrationResult(
-                destination, False, False, conflicts, before_data, _empty_meta()
-            )
-        data, meta = resolve_policy_data(
-            repo, ref, fetch_repo_yaml, config_root=root, strict_home=True
+    source = f"home:repos/{repo}.yml"
+    existing = _read_destination_mapping(destination, source)
+    if existing is not None:
+        return _existing_migration_result(
+            destination, existing, candidate, repo, ref, fetch_repo_yaml, root, before_data
         )
-        return MigrationResult(destination, False, True, (), data, meta)
 
     destination.parent.mkdir(parents=True, exist_ok=True)
-    temp_path: Path | None = None
-    try:
-        with tempfile.NamedTemporaryFile(
-            "w", encoding="utf-8", dir=destination.parent, delete=False
-        ) as handle:
-            handle.write(source_text or "")
-            temp_path = Path(handle.name)
-        temp_path.chmod(0o600)
-        os.replace(temp_path, destination)
-        after_data, meta = resolve_policy_data(
-            repo, ref, fetch_repo_yaml, config_root=root, strict_home=True
+    if not _publish_new_config(destination, source_text or ""):
+        existing = _read_destination_mapping(destination, source)
+        if existing is None:
+            raise HomeConfigError(f"{source}: destination исчез во время миграции")
+        return _existing_migration_result(
+            destination, existing, candidate, repo, ref, fetch_repo_yaml, root, before_data
         )
-        if after_data != before_data:
-            destination.unlink()
-            raise HomeConfigError("effective config изменился после миграции")
-        return MigrationResult(destination, True, False, (), after_data, meta)
-    finally:
-        if temp_path is not None and temp_path.exists():
-            temp_path.unlink()
+    after_data, meta = resolve_policy_data(
+        repo, ref, fetch_repo_yaml, config_root=root, strict_home=True
+    )
+    if after_data != before_data:
+        raise HomeConfigError("effective config изменился после миграции")
+    return MigrationResult(destination, True, False, (), after_data, meta)

--- a/reviewer/config/layers.py
+++ b/reviewer/config/layers.py
@@ -6,6 +6,7 @@ from dataclasses import asdict, dataclass
 from functools import lru_cache
 import os
 from pathlib import Path
+import stat
 import tempfile
 
 import yaml
@@ -160,9 +161,9 @@ def resolve_policy_data(
             sources[key] = source
 
     def merge_home(path: Path, source: str) -> None:
-        if not path.is_file():
-            return
         try:
+            if not stat.S_ISREG(path.stat().st_mode):
+                return
             data = _read_mapping(path.read_text(encoding="utf-8"), source)
             credential = _credential_path(data)
             if credential:
@@ -170,9 +171,17 @@ def resolve_policy_data(
                     f"{source}: credential key {'.'.join(credential)} запрещён"
                 )
             merge(data, source)
+        except FileNotFoundError:
+            return
         except HomeCredentialError as exc:
             warnings.append(str(exc))
-        except (OSError, UnicodeError, yaml.YAMLError, HomeConfigError) as exc:
+        except (
+            OSError,
+            UnicodeError,
+            RecursionError,
+            yaml.YAMLError,
+            HomeConfigError,
+        ) as exc:
             wrapped = HomeConfigError(
                 f"{source}: конфиг не прочитан: {type(exc).__name__}"
             )

--- a/reviewer/entrypoints/cli.py
+++ b/reviewer/entrypoints/cli.py
@@ -14,6 +14,7 @@ import psycopg
 
 from reviewer.config.settings import Settings
 from reviewer.app import build_components
+from reviewer.config.layers import resolve_policy_data
 from reviewer.gitutil import file_at_ref, list_python_files, rev_parse, remote_url
 from reviewer.graph.backend import build_code_graph
 from reviewer.graph.store import GraphStore
@@ -503,8 +504,15 @@ def index(repo: str, ref: str | None, branch_opt: str | None, repo_tag: str | No
     try:
         c.store.init_schema()
         files = list_python_files(repo, ref)
-        review_yml = file_at_ref(repo, ".review.yml", ref)
-        ignore = ReviewPolicy.from_yaml(review_yml).ignore if review_yml else []
+        policy_data, policy_meta = resolve_policy_data(
+            repo_id,
+            ref,
+            lambda selected_ref: file_at_ref(repo, ".review.yml", selected_ref),
+        )
+        policy = ReviewPolicy.load_data(s, policy_data)
+        ignore = policy.ignore
+        for warning in policy_meta.warnings:
+            log.warning("Домашний слой policy пропущен: %s", warning)
         if ignore:
             files = [f for f in files if not is_ignored(f, ignore)]
         update_base(c.store, c.embedder, repo_id, branch, files,

--- a/reviewer/entrypoints/cli.py
+++ b/reviewer/entrypoints/cli.py
@@ -167,6 +167,7 @@ def config_migrate(repo: str, branch: str | None) -> None:
                 repo_id,
                 ref,
                 lambda selected_ref: vcs.get_file_at_ref(".review.yml", selected_ref),
+                settings=settings,
             )
             if result.conflicting_keys:
                 keys = ", ".join(result.conflicting_keys)

--- a/reviewer/entrypoints/cli.py
+++ b/reviewer/entrypoints/cli.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
+from contextlib import contextmanager
 from dataclasses import dataclass
+import json
 import logging
 import platform as _platform
 import re
@@ -11,10 +13,16 @@ from typing import TYPE_CHECKING
 import click
 import httpx
 import psycopg
+import yaml
 
 from reviewer.config.settings import Settings
 from reviewer.app import build_components
-from reviewer.config.layers import resolve_policy_data
+from reviewer.config.layers import (
+    HomeConfigError,
+    build_config_report,
+    migrate_repo_config,
+    resolve_policy_data,
+)
 from reviewer.gitutil import file_at_ref, list_python_files, rev_parse, remote_url
 from reviewer.graph.backend import build_code_graph
 from reviewer.graph.store import GraphStore
@@ -26,6 +34,7 @@ from reviewer.index.store import ChunkStore
 from reviewer.index.summary_store import SummaryStore
 from reviewer.mcp.session_store import SessionStore
 from reviewer.services.gc import purge_orphaned_overlays
+from reviewer.services.review_service import ReviewService
 from reviewer.services.status import build_status_report, render_status, render_status_json
 from reviewer.versioning import InstallMode, check_latest, detect_installation, upgrade_uv_tool
 
@@ -53,6 +62,110 @@ def _resolve_repo(repo_opt: str | None, path: str, settings) -> str:
 
 @click.group()
 def cli() -> None: ...
+
+
+@cli.group("config")
+def config_group() -> None:
+    """Inspect and migrate layered repository policy."""
+
+
+def _close_config_components(components) -> None:
+    """Закрыть созданные для diagnostic CLI хранилища независимо друг от друга."""
+    for name in ("store", "graph", "task_store", "summary_store"):
+        component = getattr(components, name, None)
+        if component is not None:
+            component.close()
+
+
+def _render_config_report(report: Mapping[str, object]) -> None:
+    effective = report["effective"]
+    sources = report["sources"]
+    shadowed = report["shadowed"]
+    assert isinstance(effective, Mapping)
+    assert isinstance(sources, Mapping)
+    assert isinstance(shadowed, Mapping)
+    for key in sorted(effective):
+        click.echo(
+            f"{key}: {json.dumps(effective[key], ensure_ascii=False, sort_keys=True)}"
+        )
+        click.echo(f"  source: {sources[key]}")
+        if key in shadowed:
+            click.echo(f"  shadowed: {', '.join(shadowed[key])}")
+    for warning in report["warnings"]:
+        click.echo(f"warning: {warning}")
+
+
+@contextmanager
+def _config_context(repo_opt: str, branch_opt: str | None):
+    settings = Settings()
+    components = build_components(settings)
+    vcs = None
+    try:
+        repo = _resolve_config_repo(repo_opt)
+        branch = branch_opt or settings.primary_branch()
+        owner, name = repo.split("/", 1)
+        vcs = ReviewService(settings, components)._create_vcs_provider(owner, name)
+        yield settings, components, vcs, repo, branch
+    finally:
+        if vcs is not None:
+            vcs.close()
+        _close_config_components(components)
+
+
+def _resolve_config_repo(repo: str) -> str:
+    from reviewer.services.repo_id import normalize_repo
+
+    return normalize_repo(repo)
+
+
+@config_group.command("show")
+@click.option("--repo", required=True, help="owner/name репозитория")
+@click.option("--branch", default=None, help="ветка policy; по умолчанию первичная")
+@click.option("--json", "as_json", is_flag=True, default=False)
+def config_show(repo: str, branch: str | None, as_json: bool) -> None:
+    """Показать effective policy и происхождение её верхних ключей."""
+    try:
+        with _config_context(repo, branch) as (settings, _components, vcs, repo_id, ref):
+            data, meta = resolve_policy_data(
+                repo_id,
+                ref,
+                lambda selected_ref: vcs.get_file_at_ref(".review.yml", selected_ref),
+                strict_home=True,
+            )
+            report = build_config_report(repo_id, ref, settings, data, meta)
+    except (HomeConfigError, yaml.YAMLError) as exc:
+        raise click.ClickException(str(exc)) from exc
+    if as_json:
+        click.echo(json.dumps(report, ensure_ascii=False, sort_keys=True, indent=2))
+    else:
+        _render_config_report(report)
+
+
+@config_group.command("migrate")
+@click.option("--repo", required=True, help="owner/name репозитория")
+@click.option("--branch", default=None, help="ветка policy; по умолчанию первичная")
+def config_migrate(repo: str, branch: str | None) -> None:
+    """Безопасно скопировать committed policy в домашний слой репозитория."""
+    try:
+        with _config_context(repo, branch) as (settings, _components, vcs, repo_id, ref):
+            result = migrate_repo_config(
+                repo_id,
+                ref,
+                lambda selected_ref: vcs.get_file_at_ref(".review.yml", selected_ref),
+            )
+            if result.conflicting_keys:
+                keys = ", ".join(result.conflicting_keys)
+                raise click.ClickException(f"Конфликтующие ключи: {keys}")
+            report = build_config_report(
+                repo_id, ref, settings, result.data, result.meta
+            )
+    except (HomeConfigError, yaml.YAMLError) as exc:
+        raise click.ClickException(str(exc)) from exc
+    if result.noop:
+        click.echo(f"Конфиг уже перенесён: {result.path}")
+    else:
+        click.echo(f"Конфиг перенесён: {result.path}")
+    _render_config_report(report)
 
 
 def _run_codex_target(

--- a/reviewer/entrypoints/cli.py
+++ b/reviewer/entrypoints/cli.py
@@ -74,7 +74,22 @@ def _close_config_components(components) -> None:
     for name in ("store", "graph", "task_store", "summary_store"):
         component = getattr(components, name, None)
         if component is not None:
-            component.close()
+            _safe_config_close(component, name)
+
+
+def _safe_config_close(resource, name: str) -> None:
+    """Не дать cleanup-ошибке скрыть исход результата diagnostic команды."""
+    try:
+        resource.close()
+    except Exception:  # noqa: BLE001 — best-effort cleanup не меняет результат команды
+        log.warning("Не удалось закрыть resource config CLI: %s", name)
+
+
+def _config_error_message(exc: Exception) -> str:
+    """Вернуть публичный diagnostic без YAML/normalization payload."""
+    if isinstance(exc, HomeConfigError):
+        return str(exc)
+    return "конфиг не прочитан: YAML"
 
 
 def _render_config_report(report: Mapping[str, object]) -> None:
@@ -108,7 +123,7 @@ def _config_context(repo_opt: str, branch_opt: str | None):
         yield settings, components, vcs, repo, branch
     finally:
         if vcs is not None:
-            vcs.close()
+            _safe_config_close(vcs, "vcs")
         _close_config_components(components)
 
 
@@ -134,7 +149,7 @@ def config_show(repo: str, branch: str | None, as_json: bool) -> None:
             )
             report = build_config_report(repo_id, ref, settings, data, meta)
     except (HomeConfigError, yaml.YAMLError) as exc:
-        raise click.ClickException(str(exc)) from exc
+        raise click.ClickException(_config_error_message(exc)) from exc
     if as_json:
         click.echo(json.dumps(report, ensure_ascii=False, sort_keys=True, indent=2))
     else:
@@ -160,7 +175,7 @@ def config_migrate(repo: str, branch: str | None) -> None:
                 repo_id, ref, settings, result.data, result.meta
             )
     except (HomeConfigError, yaml.YAMLError) as exc:
-        raise click.ClickException(str(exc)) from exc
+        raise click.ClickException(_config_error_message(exc)) from exc
     if result.noop:
         click.echo(f"Конфиг уже перенесён: {result.path}")
     else:

--- a/reviewer/launcher/metadata.py
+++ b/reviewer/launcher/metadata.py
@@ -18,6 +18,26 @@ COMMAND_PRESENTATION = {
         scenarios=("После установки", "После изменения .env"),
         keywords=("health", "диагностика", "доступы"),
     ),
+    ("config", "migrate"): CommandPresentation(
+        summary="Перенести policy в домашний слой",
+        details=(
+            "Атомарно копирует committed .review.yml в repository-scoped home config; "
+            "при конфликте ничего не перезаписывает."
+        ),
+        effects=(Effect.READ, Effect.NETWORK, Effect.WRITE),
+        scenarios=("Переход на home config",),
+        keywords=("config", "migration", "policy"),
+    ),
+    ("config", "show"): CommandPresentation(
+        summary="Показать effective repository policy",
+        details=(
+            "Показывает публичные effective values, источники слоёв и затенённые ключи "
+            "без раскрытия credentials."
+        ),
+        effects=(Effect.READ, Effect.NETWORK),
+        scenarios=("Диагностика repository policy",),
+        keywords=("config", "policy", "provenance"),
+    ),
     ("gc",): CommandPresentation(
         summary="Очистить осиротевшие overlay",
         details="Удаляет только overlay без живой review session и просроченные сессии.",

--- a/reviewer/mcp/service.py
+++ b/reviewer/mcp/service.py
@@ -1512,6 +1512,7 @@ class MCPReviewService:
                     1 for r in asm.findings_rows if r["published"] and not r["inline"]
                 ),
                 "usage": metadata.usage,
+                "config_sources": p.config_sources,
                 "total_cost": metadata.total_cost,
                 "error_text": error or None,
             }

--- a/reviewer/mcp/service.py
+++ b/reviewer/mcp/service.py
@@ -744,7 +744,7 @@ class MCPReviewService:
         try:
             vcs = (
                 self._vcs_factory(owner, name)
-                if self._vcs_factory
+                if self._vcs_factory is not None
                 else self._review_service._create_vcs_provider(owner, name)
             )
             data, meta = resolve_policy_data(

--- a/reviewer/mcp/service.py
+++ b/reviewer/mcp/service.py
@@ -773,7 +773,7 @@ class MCPReviewService:
             )
             return policy.summary_cluster_depth, policy.summary_cluster_depth_overrides, source
         except Exception:
-            log.warning("_resolve_summary_depth: fail-soft → env-дефолт", exc_info=True)
+            log.warning("_resolve_summary_depth: fail-soft → env-дефолт")
             return default, {}, "env"
 
     def _resolve_summary_topk_threshold(self, repo: str, branch: str) -> tuple[int, str]:
@@ -784,7 +784,7 @@ class MCPReviewService:
             source = meta.sources.get("summary_topk_threshold", "env")
             return policy.summary_topk_threshold, source
         except Exception:
-            log.warning("_resolve_summary_topk_threshold: fail-soft → env-дефолт", exc_info=True)
+            log.warning("_resolve_summary_topk_threshold: fail-soft → env-дефолт")
             return default, "env"
 
     def _resolve_context_limits(self, repo: str, branch: str) -> "ContextLimits":
@@ -794,7 +794,7 @@ class MCPReviewService:
             policy, _ = self._resolve_policy(repo, branch)
             return policy.context_limits
         except Exception:
-            log.warning("_resolve_context_limits: fail-soft → дефолт-константы", exc_info=True)
+            log.warning("_resolve_context_limits: fail-soft → дефолт-константы")
             return ContextLimits()
 
     def search_codebase(self, repo: str, query: str, top_k: int | None = None,

--- a/reviewer/mcp/service.py
+++ b/reviewer/mcp/service.py
@@ -736,7 +736,7 @@ class MCPReviewService:
         return (repo, branch or self.settings.primary_branch())
 
     def _resolve_policy(self, repo: str, branch: str) -> tuple["ReviewPolicy", "ResolutionMeta"]:
-        """Резолвит policy из home-слоёв и .review.yml целевой ветки."""
+        """Резолвит effective policy из env, home-слоёв и committed `.review.yml`."""
         from reviewer.config.layers import resolve_policy_data
         from reviewer.policy.policy import ReviewPolicy
         owner, name = repo.split("/", 1)
@@ -808,7 +808,8 @@ class MCPReviewService:
         построчными номерами для цитирования path:line без повторного Read.
         include_tests=True возвращает тест-чанки. Охват адаптивен (cliff-отсечка
         реранкера, PRI-202): top_k — необязательный override потолка (ceiling)
-        для этого вызова; None → потолок берётся из .review.yml/дефолта.
+        для этого вызова; None → потолок берётся из effective layered policy
+        либо дефолта.
         """
         rb = self._resolve_repo_branch(repo, branch)
         if isinstance(rb, str):
@@ -923,7 +924,8 @@ class MCPReviewService:
         """Кластеризовать base-граф по модулям → кластеры для /summarize-subsystems.
         cap (дефолт Settings.summary_rebuild_cap; None/0=безлимит) отбрасывает наименее
         приоритетные stale-кластеры (без сводки → старейшие updated_at первыми) и считает
-        их в deferred (PRI-165)."""
+        их в deferred (PRI-165). Если depth не задан, он берётся из effective layered
+        policy с fail-soft env-дефолтом."""
         from reviewer.graph.summaries import Member, build_clusters
         rb = self._resolve_repo_branch(repo, branch)
         if isinstance(rb, str):
@@ -1076,8 +1078,8 @@ class MCPReviewService:
         """Дешёвый приор: предрасчитанные summary подсистем (fail-open у потребителя).
 
         cluster_key → одна сводка. Иначе: при query И числе сводок > порога масштаба
-        (SUMMARY_TOPK_THRESHOLD, per-repo .review.yml) — ANN top-k по близости (PRI-167);
-        иначе (без query или ≤ порога) — все (бэк-компат)."""
+        (effective `summary_topk_threshold` layered policy) — ANN top-k по близости
+        (PRI-167); иначе (без query или ≤ порога) — все (бэк-компат)."""
         rb = self._resolve_repo_branch(repo, branch)
         if isinstance(rb, str):
             return {"summaries": [], "note": rb}

--- a/reviewer/mcp/service.py
+++ b/reviewer/mcp/service.py
@@ -50,7 +50,9 @@ from reviewer.vcs.base import ChangedFile, Finding, VCSProvider
 from reviewer.vcs.diff import commentable_lines
 
 if TYPE_CHECKING:
+    from reviewer.config.layers import ResolutionMeta
     from reviewer.policy.context_limits import ContextLimits
+    from reviewer.policy.policy import ReviewPolicy
 
 log = logging.getLogger(__name__)
 
@@ -733,93 +735,67 @@ class MCPReviewService:
                     f"({self.settings.review_branches_list()}))")
         return (repo, branch or self.settings.primary_branch())
 
-    def _resolve_summary_depth(self, repo: str, branch: str) -> tuple[int, dict[str, int], str]:
-        """Резолв глубины кластеризации сводок: env-дефолт → override из .review.yml ветки.
-
-        Возвращает (depth, depth_overrides, source). depth_overrides — карта
-        префикс→depth из .review.yml (PRI-161); пусто, если ключа нет. Fail-soft:
-        нет токена/ветки/файла/кривой yml → (settings.summary_cluster_depth, {}, "env").
-        source = ".review.yml", если файл задаёт summary_cluster_depth или _overrides."""
-        import yaml
+    def _resolve_policy(self, repo: str, branch: str) -> tuple["ReviewPolicy", "ResolutionMeta"]:
+        """Резолвит policy из home-слоёв и .review.yml целевой ветки."""
+        from reviewer.config.layers import resolve_policy_data
         from reviewer.policy.policy import ReviewPolicy
-        default = self.settings.summary_cluster_depth
         owner, name = repo.split("/", 1)
         vcs = None
         try:
-            vcs = (self._vcs_factory(owner, name) if self._vcs_factory
-                   else self._review_service._create_vcs_provider(owner, name))
-            text = vcs.get_file_at_ref(".review.yml", branch)
-            if not text:
-                return default, {}, "env"
-            data = yaml.safe_load(text) or {}
-            pol = ReviewPolicy.load(self.settings, text)
-            keyed = ("summary_cluster_depth" in data
-                     or "summary_cluster_depth_overrides" in data)
-            return (pol.summary_cluster_depth, pol.summary_cluster_depth_overrides,
-                    ".review.yml" if keyed else "env")
+            vcs = (
+                self._vcs_factory(owner, name)
+                if self._vcs_factory
+                else self._review_service._create_vcs_provider(owner, name)
+            )
+            data, meta = resolve_policy_data(
+                repo,
+                branch,
+                lambda ref: vcs.get_file_at_ref(".review.yml", ref),
+            )
+            for warning in meta.warnings:
+                log.warning("Домашний слой policy пропущен: %s", warning)
+            return ReviewPolicy.load_data(self.settings, data), meta
+        finally:
+            if vcs is not None and self._vcs_factory is None:
+                try:
+                    vcs.close()
+                except Exception:
+                    log.warning("_resolve_policy: не удалось закрыть VCS", exc_info=True)
+
+    def _resolve_summary_depth(self, repo: str, branch: str) -> tuple[int, dict[str, int], str]:
+        """Резолв глубины кластеризации сводок с сохранением fail-soft env-дефолта."""
+        default = self.settings.summary_cluster_depth
+        try:
+            policy, meta = self._resolve_policy(repo, branch)
+            source = meta.sources.get(
+                "summary_cluster_depth",
+                meta.sources.get("summary_cluster_depth_overrides", "env"),
+            )
+            return policy.summary_cluster_depth, policy.summary_cluster_depth_overrides, source
         except Exception:
             log.warning("_resolve_summary_depth: fail-soft → env-дефолт", exc_info=True)
             return default, {}, "env"
-        finally:
-            if vcs is not None and self._vcs_factory is None:
-                try:
-                    vcs.close()
-                except Exception:
-                    log.warning("_resolve_summary_depth: не удалось закрыть VCS", exc_info=True)
 
     def _resolve_summary_topk_threshold(self, repo: str, branch: str) -> tuple[int, str]:
-        """Резолв порога масштаба приора сводок: env-дефолт → override из .review.yml ветки.
-
-        repo уже нормализован (вызывается после _resolve_repo_branch). Fail-soft:
-        нет токена/ветки/файла/кривой yml → (settings.summary_topk_threshold, "env").
-        source = ".review.yml", только если файл явно задаёт ключ summary_topk_threshold."""
-        import yaml
-        from reviewer.policy.policy import ReviewPolicy
+        """Резолв порога масштаба приора сводок с сохранением env-дефолта."""
         default = self.settings.summary_topk_threshold
-        owner, name = repo.split("/", 1)
-        vcs = None
         try:
-            vcs = (self._vcs_factory(owner, name) if self._vcs_factory
-                   else self._review_service._create_vcs_provider(owner, name))
-            text = vcs.get_file_at_ref(".review.yml", branch)
-            if not text:
-                return default, "env"
-            data = yaml.safe_load(text) or {}
-            val = ReviewPolicy.load(self.settings, text).summary_topk_threshold
-            return val, (".review.yml" if "summary_topk_threshold" in data else "env")
+            policy, meta = self._resolve_policy(repo, branch)
+            source = meta.sources.get("summary_topk_threshold", "env")
+            return policy.summary_topk_threshold, source
         except Exception:
             log.warning("_resolve_summary_topk_threshold: fail-soft → env-дефолт", exc_info=True)
             return default, "env"
-        finally:
-            if vcs is not None and self._vcs_factory is None:
-                try:
-                    vcs.close()
-                except Exception:
-                    log.warning("_resolve_summary_topk_threshold: не удалось закрыть VCS",
-                                exc_info=True)
 
     def _resolve_context_limits(self, repo: str, branch: str) -> "ContextLimits":
-        """Лимиты контекста из .review.yml ветки (PRI-202). Fail-soft → дефолт-константы."""
+        """Лимиты контекста из всех policy-слоёв. Fail-soft → дефолт-константы."""
         from reviewer.policy.context_limits import ContextLimits
-        from reviewer.policy.policy import ReviewPolicy
-        owner, name = repo.split("/", 1)
-        vcs = None
         try:
-            vcs = (self._vcs_factory(owner, name) if self._vcs_factory
-                   else self._review_service._create_vcs_provider(owner, name))
-            text = vcs.get_file_at_ref(".review.yml", branch)
-            if not text:
-                return ContextLimits()
-            return ReviewPolicy.load(self.settings, text).context_limits
+            policy, _ = self._resolve_policy(repo, branch)
+            return policy.context_limits
         except Exception:
             log.warning("_resolve_context_limits: fail-soft → дефолт-константы", exc_info=True)
             return ContextLimits()
-        finally:
-            if vcs is not None and self._vcs_factory is None:
-                try:
-                    vcs.close()
-                except Exception:
-                    log.warning("_resolve_context_limits: не удалось закрыть VCS", exc_info=True)
 
     def search_codebase(self, repo: str, query: str, top_k: int | None = None,
                         branch: str | None = None,

--- a/reviewer/mcp/session_serde.py
+++ b/reviewer/mcp/session_serde.py
@@ -36,6 +36,7 @@ def to_payload(prepared: PreparedReview) -> dict:
         "changed_status": prepared.changed_status,
         "task_board": prepared.task_board,
         "task_keys": prepared.task_keys,
+        "config_sources": prepared.config_sources,
     }
 
 
@@ -79,4 +80,5 @@ def from_payload(d: dict, vcs: VCSProvider) -> PreparedReview:
         changed_status=d["changed_status"],
         task_board=d.get("task_board"),
         task_keys=d.get("task_keys"),
+        config_sources=d.get("config_sources", {}),
     )

--- a/reviewer/policy/policy.py
+++ b/reviewer/policy/policy.py
@@ -1,5 +1,8 @@
 from __future__ import annotations
+
+from collections.abc import Mapping
 from dataclasses import dataclass, field
+
 import yaml
 
 from reviewer.config.settings import SeverityLevel
@@ -81,19 +84,19 @@ class ReviewPolicy:
         )
 
     @classmethod
-    def load(cls, settings, yaml_text: str | None) -> "ReviewPolicy":
-        """Дефолты из env, поверх — переопределения из .review.yml (только заданные ключи)."""
+    def load_data(
+        cls,
+        settings,
+        data: Mapping[str, object] | None,
+    ) -> "ReviewPolicy":
+        """Apply explicit policy keys over Settings-backed defaults."""
         policy = cls.from_settings(settings)
-        if not yaml_text:
-            return policy
-        data = yaml.safe_load(yaml_text) or {}
+        data = dict(data or {})
         if "categories" in data:
             policy.categories = data["categories"] or {}
-            policy.enabled_only = []   # явная форма .yml отменяет env-вайтлист
-        if "severity_threshold" in data:
-            sev = data["severity_threshold"]
-            if sev in _SEV:
-                policy.severity_threshold = sev
+            policy.enabled_only = []
+        if "severity_threshold" in data and data["severity_threshold"] in _SEV:
+            policy.severity_threshold = data["severity_threshold"]
         if "max_comments" in data:
             policy.max_comments = data["max_comments"]
         if "min_confidence" in data:
@@ -118,6 +121,15 @@ class ReviewPolicy:
         if "context_limits" in data:
             policy.context_limits = ContextLimits.from_review_yaml(data)
         return policy
+
+    @classmethod
+    def load(cls, settings, yaml_text: str | None) -> "ReviewPolicy":
+        """Дефолты из env, поверх — переопределения из .review.yml (только заданные ключи)."""
+        data = yaml.safe_load(yaml_text) if yaml_text else {}
+        data = data or {}
+        if not isinstance(data, dict):
+            raise ValueError("review policy YAML must contain a mapping")
+        return cls.load_data(settings, data)
 
     def category_enabled(self, category: str) -> bool:
         if self.enabled_only:

--- a/reviewer/services/repo_id.py
+++ b/reviewer/services/repo_id.py
@@ -10,15 +10,19 @@ _HTTP_HOST_RE = re.compile(r"^https?://([^/]+)/")
 
 
 def normalize_repo(repo: str) -> str:
-    """Привести 'Owner/Repo' к канону 'owner/name' (нижний регистр).
+    """Привести repo к канону 'owner/name' или 'group/.../name' (нижний регистр).
 
-    :raises ValueError: пустая строка или не ровно один '/'.
+    :raises ValueError: недостаточно сегментов или небезопасный путь.
     """
     s = (repo or "").strip().lower()
+    if "\\" in s or "\x00" in s:
+        raise ValueError(f"Некорректный repo: {repo!r}")
     parts = s.split("/")
-    if len(parts) != 2 or not parts[0] or not parts[1]:
-        raise ValueError(f"Некорректный repo (ожидается owner/name): {repo!r}")
-    return f"{parts[0]}/{parts[1]}"
+    if len(parts) < 2 or any(not part or part in {".", ".."} for part in parts):
+        raise ValueError(
+            f"Некорректный repo (ожидается owner/name или group/.../name): {repo!r}"
+        )
+    return "/".join(parts)
 
 
 def derive_repo_from_remote(remote_url: str) -> str | None:

--- a/reviewer/services/review_service.py
+++ b/reviewer/services/review_service.py
@@ -12,7 +12,7 @@ CLI остаётся тонкой обёрткой: парсит аргумен�
 from __future__ import annotations
 
 import logging
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 
 from reviewer.app import Components
 from reviewer.config.settings import Settings
@@ -97,6 +97,7 @@ class PreparedReview:
     changed_status: dict[str, str]       # path -> статус файла (modified/added/removed)
     task_board: dict | None = None       # конфиг доски из policy (прокидывается в payload)
     task_keys: dict | None = None        # {"primary": str|None, "others": [...]}; None только когда task_board выкл.
+    config_sources: dict = field(default_factory=dict)
 
 
 class ReviewService:
@@ -198,13 +199,20 @@ class ReviewService:
             if branch not in self.settings.review_branches_list():
                 raise BranchNotTrackedError(branch)
 
+            from reviewer.config.layers import resolve_policy_data
             from reviewer.index.refs import base_ref as _base_ref
 
-            # paths.ignore из .review.yml целевой (base) ветки — общий для
-            # base-досинка и overlay; берётся по base_sha, а не по ref-имени,
-            # чтобы видеть конфиг именно целевого коммита PR.
-            review_yml = vcs.get_file_at_ref(".review.yml", prq.base_sha)
-            ignore = ReviewPolicy.from_yaml(review_yml).ignore if review_yml else []
+            # Политика резолвится по точному base-коммиту PR и переиспользуется
+            # для досинка base-индекса, overlay и дальнейшего гейта.
+            policy_data, policy_meta = resolve_policy_data(
+                repo,
+                prq.base_sha,
+                lambda ref: vcs.get_file_at_ref(".review.yml", ref),
+            )
+            policy = ReviewPolicy.load_data(self.settings, policy_data)
+            ignore = policy.ignore
+            for warning in policy_meta.warnings:
+                log.warning("Домашний слой policy пропущен: %s", warning)
 
             files = vcs.get_changed_files(pr_number)
 
@@ -320,11 +328,6 @@ class ReviewService:
             # changed_node_ids — объединение node_id всех юнитов (для graph-expansion)
             changed_node_ids = [nid for u in units for nid in u.node_ids]
 
-            policy = ReviewPolicy.load(
-                self.settings,
-                vcs.get_file_at_ref(".review.yml", prq.base_ref),
-            )
-
             task_board = policy.task_board
             task_keys = (
                 extract_task_keys(
@@ -355,6 +358,7 @@ class ReviewService:
                 changed_status=changed_status,
                 task_board=task_board,
                 task_keys=task_keys,
+                config_sources=policy_meta.as_dict(),
             )
         except Exception:
             # При сбое подготовки чистим возможный недостроенный overlay pr:N —

--- a/reviewer/web/history.py
+++ b/reviewer/web/history.py
@@ -114,7 +114,7 @@ class ReviewHistory:
                 files_reviewed, files_skipped, files_failed,
                 findings_analyzed, findings_kept, verify_rejected,
                 comments_inline, comments_summary,
-                usage, total_cost, error_text
+                usage, config_sources, total_cost, error_text
             ) VALUES (
                 %(repo)s, %(pr_number)s, %(base_sha)s, %(head_sha)s,
                 %(model)s, %(model_verify)s, %(dry_run)s,
@@ -122,7 +122,7 @@ class ReviewHistory:
                 %(files_reviewed)s, %(files_skipped)s, %(files_failed)s,
                 %(findings_analyzed)s, %(findings_kept)s, %(verify_rejected)s,
                 %(comments_inline)s, %(comments_summary)s,
-                %(usage)s, %(total_cost)s, %(error_text)s
+                %(usage)s, %(config_sources)s, %(total_cost)s, %(error_text)s
             ) RETURNING id
             """
             finding_sql = """
@@ -144,10 +144,12 @@ class ReviewHistory:
                 %(text)s, %(tool_calls)s, %(tokens)s, %(cost)s
             )
             """
-            # usage должен быть jsonb-совместимой строкой
+            # JSONB-поля передаём строками; старые вызовы без provenance получают {}.
             run_row = dict(run)
-            if "usage" in run_row and not isinstance(run_row["usage"], str):
-                run_row["usage"] = json.dumps(run_row["usage"])
+            run_row.setdefault("config_sources", {})
+            for field in ("usage", "config_sources"):
+                if not isinstance(run_row.get(field), str):
+                    run_row[field] = json.dumps(run_row.get(field), ensure_ascii=False)
 
             with self._connect() as conn:
                 row = conn.execute(run_sql, run_row).fetchone()
@@ -224,7 +226,7 @@ class ReviewHistory:
                files_reviewed, files_skipped, files_failed,
                findings_analyzed, findings_kept, verify_rejected,
                comments_inline, comments_summary,
-               usage, total_cost, error_text
+               usage, config_sources, total_cost, error_text
         FROM review_runs
         {where}
         ORDER BY created_at DESC
@@ -246,7 +248,7 @@ class ReviewHistory:
                files_reviewed, files_skipped, files_failed,
                findings_analyzed, findings_kept, verify_rejected,
                comments_inline, comments_summary,
-               usage, total_cost, error_text
+               usage, config_sources, total_cost, error_text
         FROM review_runs WHERE id = %(id)s
         """
         finding_sql = """

--- a/reviewer/web/history.py
+++ b/reviewer/web/history.py
@@ -146,7 +146,8 @@ class ReviewHistory:
             """
             # JSONB-поля передаём строками; старые вызовы без provenance получают {}.
             run_row = dict(run)
-            run_row.setdefault("config_sources", {})
+            if run_row.get("config_sources") is None:
+                run_row["config_sources"] = {}
             for field in ("usage", "config_sources"):
                 if not isinstance(run_row.get(field), str):
                     run_row[field] = json.dumps(run_row.get(field), ensure_ascii=False)
@@ -226,7 +227,8 @@ class ReviewHistory:
                files_reviewed, files_skipped, files_failed,
                findings_analyzed, findings_kept, verify_rejected,
                comments_inline, comments_summary,
-               usage, config_sources, total_cost, error_text
+               usage, COALESCE(config_sources, '{{}}'::jsonb) AS config_sources,
+               total_cost, error_text
         FROM review_runs
         {where}
         ORDER BY created_at DESC
@@ -248,7 +250,8 @@ class ReviewHistory:
                files_reviewed, files_skipped, files_failed,
                findings_analyzed, findings_kept, verify_rejected,
                comments_inline, comments_summary,
-               usage, config_sources, total_cost, error_text
+               usage, COALESCE(config_sources, '{}'::jsonb) AS config_sources,
+               total_cost, error_text
         FROM review_runs WHERE id = %(id)s
         """
         finding_sql = """
@@ -440,7 +443,9 @@ def _row_to_dict(cols: list[str], row: tuple) -> dict:
     """
     result: dict = {}
     for key, val in zip(cols, row):
-        if isinstance(val, Decimal):
+        if key == "config_sources" and val is None:
+            result[key] = {}
+        elif isinstance(val, Decimal):
             result[key] = float(val)
         elif hasattr(val, "isoformat"):
             result[key] = val.isoformat()

--- a/reviewer/web/schema.sql
+++ b/reviewer/web/schema.sql
@@ -25,9 +25,13 @@ CREATE TABLE IF NOT EXISTS review_runs (
     comments_inline  INT         NOT NULL DEFAULT 0,
     comments_summary INT         NOT NULL DEFAULT 0,
     usage           JSONB,
+    config_sources  JSONB,
     total_cost      NUMERIC(12, 6),
     error_text      TEXT
 );
+
+-- Идемпотентная миграция для БД, где таблица уже существовала без provenance.
+ALTER TABLE review_runs ADD COLUMN IF NOT EXISTS config_sources JSONB;
 
 CREATE INDEX IF NOT EXISTS review_runs_created_at ON review_runs (created_at DESC);
 CREATE INDEX IF NOT EXISTS review_runs_repo ON review_runs (repo);

--- a/reviewer/web/schema.sql
+++ b/reviewer/web/schema.sql
@@ -25,13 +25,16 @@ CREATE TABLE IF NOT EXISTS review_runs (
     comments_inline  INT         NOT NULL DEFAULT 0,
     comments_summary INT         NOT NULL DEFAULT 0,
     usage           JSONB,
-    config_sources  JSONB,
+    config_sources  JSONB       NOT NULL DEFAULT '{}'::jsonb,
     total_cost      NUMERIC(12, 6),
     error_text      TEXT
 );
 
 -- Идемпотентная миграция для БД, где таблица уже существовала без provenance.
 ALTER TABLE review_runs ADD COLUMN IF NOT EXISTS config_sources JSONB;
+UPDATE review_runs SET config_sources = '{}'::jsonb WHERE config_sources IS NULL;
+ALTER TABLE review_runs ALTER COLUMN config_sources SET DEFAULT '{}'::jsonb;
+ALTER TABLE review_runs ALTER COLUMN config_sources SET NOT NULL;
 
 CREATE INDEX IF NOT EXISTS review_runs_created_at ON review_runs (created_at DESC);
 CREATE INDEX IF NOT EXISTS review_runs_repo ON review_runs (repo);

--- a/tests/config/test_layers.py
+++ b/tests/config/test_layers.py
@@ -2,6 +2,7 @@ from pathlib import Path
 
 import pytest
 
+import reviewer.config.layers as layers
 from reviewer.config.layers import (
     HomeConfigError,
     ResolutionMeta,
@@ -260,3 +261,48 @@ def test_build_config_report_marks_policy_defaults_as_env() -> None:
     assert report["sources"]["max_comments"] == "env"
     assert report["sources"]["paths"] == "home:repos/o/r.yml"
     assert report["warnings"] == ["safe warning"]
+
+
+def test_migrate_does_not_clobber_destination_created_during_publish(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    destination = tmp_path / "repos/o/r.yml"
+
+    def race(temp_path, target_path) -> None:
+        Path(target_path).write_text("max_comments: 3\n", encoding="utf-8")
+        raise FileExistsError
+
+    monkeypatch.setattr(layers.os, "link", race)
+
+    result = migrate_repo_config(
+        "o/r", "main", lambda ref: "max_comments: 7\n", config_root=tmp_path
+    )
+
+    assert result.conflicting_keys == ("max_comments",)
+    assert destination.read_text(encoding="utf-8") == "max_comments: 3\n"
+
+
+def test_migrate_rollback_does_not_delete_racing_destination(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    destination = tmp_path / "repos/o/r.yml"
+    meta = ResolutionMeta({}, {}, ())
+    calls = 0
+
+    def resolve_after_race(*args, **kwargs):
+        nonlocal calls
+        calls += 1
+        if calls == 2:
+            destination.unlink()
+            destination.write_text("max_comments: 3\n", encoding="utf-8")
+            return {"max_comments": 3}, meta
+        return {"max_comments": 7}, meta
+
+    monkeypatch.setattr(layers, "resolve_policy_data", resolve_after_race)
+
+    with pytest.raises(HomeConfigError, match="effective config"):
+        migrate_repo_config(
+            "o/r", "main", lambda ref: "max_comments: 7\n", config_root=tmp_path
+        )
+
+    assert destination.read_text(encoding="utf-8") == "max_comments: 3\n"

--- a/tests/config/test_layers.py
+++ b/tests/config/test_layers.py
@@ -395,6 +395,53 @@ def test_migrate_sanitizes_link_error_and_preserves_primary_cleanup_error(
     assert secret not in str(exc.value)
 
 
+def test_migrate_sanitizes_destination_parent_mkdir_error(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    secret = "do-not-echo"
+    original_mkdir = Path.mkdir
+
+    def fail_destination_parent(path: Path, *args, **kwargs) -> None:
+        if path == tmp_path / "repos/o":
+            raise OSError(secret)
+        original_mkdir(path, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "mkdir", fail_destination_parent)
+
+    with pytest.raises(HomeConfigError) as exc:
+        migrate_repo_config(
+            "o/r", "main", lambda ref: "max_comments: 7\n", config_root=tmp_path
+        )
+
+    assert secret not in str(exc.value)
+
+
+def test_migrate_preserves_fdopen_error_when_descriptor_close_also_fails(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    destination = tmp_path / "repos/o/r.yml"
+    _write(destination, "max_comments: 3\n")
+    primary = "fdopen-secret"
+    cleanup = "close-secret"
+
+    def fail_fdopen(*args, **kwargs):
+        raise OSError(primary)
+
+    def fail_close(*args, **kwargs):
+        raise OSError(cleanup)
+
+    monkeypatch.setattr(layers.os, "fdopen", fail_fdopen)
+    monkeypatch.setattr(layers.os, "close", fail_close)
+
+    with pytest.raises(HomeConfigError) as exc:
+        migrate_repo_config(
+            "o/r", "main", lambda ref: "max_comments: 7\n", config_root=tmp_path
+        )
+
+    assert primary not in str(exc.value)
+    assert cleanup not in str(exc.value)
+
+
 def test_build_config_report_rejects_non_json_public_value() -> None:
     class SecretValue:
         def __repr__(self) -> str:

--- a/tests/config/test_layers.py
+++ b/tests/config/test_layers.py
@@ -4,6 +4,8 @@ import pytest
 
 from reviewer.config.layers import (
     HomeConfigError,
+    ResolutionMeta,
+    build_config_report,
     home_repo_path,
     migrate_repo_config,
     policy_to_public_data,
@@ -241,3 +243,20 @@ def test_policy_to_public_data_excludes_settings_secrets_and_unknown_yaml() -> N
     }
     assert data["max_comments"] == 4
     assert secret not in repr(data)
+
+
+def test_build_config_report_marks_policy_defaults_as_env() -> None:
+    report = build_config_report(
+        "O/R",
+        "main",
+        Settings(_env_file=None, review_max_comments=12),
+        {"paths": {"ignore": ["vendor"]}},
+        ResolutionMeta({"paths": "home:repos/o/r.yml"}, {}, ("safe warning",)),
+    )
+
+    assert report["repo"] == "o/r"
+    assert report["branch"] == "main"
+    assert report["effective"]["max_comments"] == 12
+    assert report["sources"]["max_comments"] == "env"
+    assert report["sources"]["paths"] == "home:repos/o/r.yml"
+    assert report["warnings"] == ["safe warning"]

--- a/tests/config/test_layers.py
+++ b/tests/config/test_layers.py
@@ -1,4 +1,7 @@
 from pathlib import Path
+import os
+import stat
+import traceback
 
 import pytest
 
@@ -53,6 +56,27 @@ def test_subgroup_repo_uses_nested_home_path(tmp_path: Path) -> None:
     assert home_repo_path("group/sub/repo", tmp_path) == (
         tmp_path / "repos/group/sub/repo.yml"
     )
+
+
+def test_dotted_repo_name_appends_yaml_suffix_without_colliding(
+    tmp_path: Path,
+) -> None:
+    dotted = tmp_path / "repos/o/api.v2.yml"
+    plain = tmp_path / "repos/o/api.yml"
+    _write(dotted, "max_comments: 7\n")
+    _write(plain, "max_comments: 3\n")
+
+    data, meta = resolve_policy_data(
+        "o/api.v2",
+        "main",
+        lambda ref: "max_comments: 5\n",
+        config_root=tmp_path,
+    )
+
+    assert home_repo_path("o/api.v2", tmp_path) == dotted
+    assert data["max_comments"] == 7
+    assert meta.sources["max_comments"] == "home:repos/o/api.v2.yml"
+    assert meta.shadowed["max_comments"] == (".review.yml",)
 
 
 def test_runtime_skips_bad_home_but_strict_mode_raises(tmp_path: Path) -> None:
@@ -154,6 +178,115 @@ def test_max_tokens_is_not_misclassified_as_secret(tmp_path: Path) -> None:
     assert meta.warnings == ()
 
 
+def test_categories_null_is_a_valid_home_override(tmp_path: Path) -> None:
+    _write(tmp_path / "repos/o/r.yml", "categories:\n")
+
+    data, meta = resolve_policy_data(
+        "o/r",
+        "main",
+        lambda ref: "categories: {security: false}\n",
+        config_root=tmp_path,
+        strict_home=True,
+    )
+
+    assert data["categories"] is None
+    assert meta.sources["categories"] == "home:repos/o/r.yml"
+    assert meta.shadowed["categories"] == (".review.yml",)
+    assert meta.warnings == ()
+
+
+def test_migrate_accepts_categories_null_as_effective_no_change(
+    tmp_path: Path,
+) -> None:
+    _write(tmp_path / "review.yml", "categories: {style: false}\n")
+
+    result = migrate_repo_config(
+        "o/r",
+        "main",
+        lambda ref: "categories:\n",
+        config_root=tmp_path,
+        settings=Settings(_env_file=None, review_categories="security"),
+    )
+
+    assert result.created is True
+    assert result.data["categories"] is None
+    assert (tmp_path / "repos/o/r.yml").read_text(encoding="utf-8") == "categories:\n"
+
+
+def test_runtime_quarantines_invalid_home_layer_even_when_value_is_shadowed(
+    tmp_path: Path,
+) -> None:
+    secret = "do-not-echo"
+    _write(
+        tmp_path / "review.yml",
+        f"max_comments: {secret}\nfuture_policy: enabled\n",
+    )
+
+    data, meta = resolve_policy_data(
+        "o/r",
+        "main",
+        lambda ref: "max_comments: 9\n",
+        config_root=tmp_path,
+    )
+
+    assert data == {"max_comments": 9}
+    assert meta.sources == {"max_comments": ".review.yml"}
+    assert meta.shadowed == {}
+    assert meta.warnings == (
+        "home:review.yml: policy содержит недопустимые значения",
+    )
+    assert secret not in repr(meta)
+
+
+def test_strict_home_rejects_invalid_known_value_without_echoing_literal(
+    tmp_path: Path,
+) -> None:
+    secret = "do-not-echo"
+    _write(
+        tmp_path / "repos/o/r.yml",
+        f"summary_cluster_depth: {secret}\nfuture_policy: enabled\n",
+    )
+
+    with pytest.raises(HomeConfigError) as captured:
+        resolve_policy_data(
+            "o/r",
+            "main",
+            lambda ref: "max_comments: 9\n",
+            config_root=tmp_path,
+            strict_home=True,
+        )
+
+    assert str(captured.value) == (
+        "home:repos/o/r.yml: policy содержит недопустимые значения"
+    )
+    assert secret not in repr(captured.value)
+
+
+def test_strict_home_exception_chain_does_not_echo_malformed_literal(
+    tmp_path: Path,
+) -> None:
+    secret = "do-not-echo"
+    _write(tmp_path / "review.yml", f"max_comments: [{secret}\n")
+
+    with pytest.raises(HomeConfigError) as captured:
+        resolve_policy_data(
+            "o/r",
+            "main",
+            lambda ref: None,
+            config_root=tmp_path,
+            strict_home=True,
+        )
+
+    rendered = "".join(
+        traceback.format_exception(
+            type(captured.value),
+            captured.value,
+            captured.value.__traceback__,
+        )
+    )
+    assert secret not in rendered
+
+
 def test_runtime_skips_home_config_with_recursive_yaml_alias(tmp_path: Path) -> None:
     _write(tmp_path / "review.yml", "loop: &loop\n  next: *loop\n")
 
@@ -206,6 +339,37 @@ def test_migrate_refuses_different_destination(tmp_path: Path) -> None:
     assert destination.read_text(encoding="utf-8") == "max_comments: 3\n"
 
 
+@pytest.mark.parametrize(
+    ("source", "existing"),
+    [
+        ("future: true\n", "future: 1\n"),
+        ("future: 1\n", "future: 1.0\n"),
+        (
+            "future:\n  nested: [true, {value: 2}]\n",
+            "future:\n  nested: [1, {value: 2.0}]\n",
+        ),
+    ],
+)
+def test_migrate_semantic_equality_is_type_sensitive_recursively(
+    tmp_path: Path,
+    source: str,
+    existing: str,
+) -> None:
+    destination = tmp_path / "repos/o/r.yml"
+    _write(destination, existing)
+
+    result = migrate_repo_config(
+        "o/r",
+        "main",
+        lambda ref: source,
+        config_root=tmp_path,
+    )
+
+    assert result.noop is False
+    assert result.conflicting_keys == ("future",)
+    assert destination.read_text(encoding="utf-8") == existing
+
+
 def test_migrate_rejects_secret_candidate_before_write(tmp_path: Path) -> None:
     with pytest.raises(HomeConfigError) as exc:
         migrate_repo_config(
@@ -215,6 +379,88 @@ def test_migrate_rejects_secret_candidate_before_write(tmp_path: Path) -> None:
             config_root=tmp_path,
         )
     assert "do-not-write" not in str(exc.value)
+    assert not (tmp_path / "repos/o/r.yml").exists()
+
+
+@pytest.mark.parametrize("existing", [False, True])
+def test_migrate_uses_one_committed_snapshot_for_create_and_noop(
+    tmp_path: Path,
+    existing: bool,
+) -> None:
+    source = "max_comments: 7\n"
+    destination = tmp_path / "repos/o/r.yml"
+    if existing:
+        _write(destination, source)
+    calls = 0
+
+    def fetch_once(ref: str) -> str:
+        nonlocal calls
+        calls += 1
+        if calls > 1:
+            raise AssertionError("committed policy was fetched more than once")
+        return source
+
+    result = migrate_repo_config(
+        "o/r",
+        "moving-branch",
+        fetch_once,
+        config_root=tmp_path,
+    )
+
+    assert calls == 1
+    assert result.noop is existing
+    assert result.created is not existing
+
+
+def test_migrate_validates_candidate_before_destination_mutation(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    secret = "do-not-echo"
+
+    def publication_must_not_run(*args, **kwargs):
+        raise AssertionError("invalid candidate reached publication")
+
+    monkeypatch.setattr(layers, "_publish_new_config", publication_must_not_run)
+
+    with pytest.raises(HomeConfigError) as captured:
+        migrate_repo_config(
+            "o/r",
+            "main",
+            lambda ref: f"max_comments: {secret}\n",
+            config_root=tmp_path,
+        )
+
+    assert secret not in repr(captured.value)
+    assert not (tmp_path / "repos").exists()
+
+
+def test_migrate_validates_simulated_effective_policy_before_publication(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    original_simulation = layers._simulated_repo_layer
+
+    def invalid_simulation(data, meta, candidate, source):
+        simulated, simulated_meta = original_simulation(data, meta, candidate, source)
+        simulated["context_limits"] = {"graph": {"hops": "do-not-echo"}}
+        return simulated, simulated_meta
+
+    def publication_must_not_run(*args, **kwargs):
+        raise AssertionError("invalid effective policy reached publication")
+
+    monkeypatch.setattr(layers, "_simulated_repo_layer", invalid_simulation)
+    monkeypatch.setattr(layers, "_publish_new_config", publication_must_not_run)
+
+    with pytest.raises(HomeConfigError) as captured:
+        migrate_repo_config(
+            "o/r",
+            "main",
+            lambda ref: "max_comments: 7\n",
+            config_root=tmp_path,
+        )
+
+    assert "do-not-echo" not in repr(captured.value)
     assert not (tmp_path / "repos/o/r.yml").exists()
 
 
@@ -321,6 +567,97 @@ def test_migrate_refuses_symlink_destination(tmp_path: Path) -> None:
     assert target.read_text(encoding="utf-8") == "max_comments: 3\n"
 
 
+def test_migrate_rejects_symlinked_parent_below_config_root(tmp_path: Path) -> None:
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    repos = tmp_path / "repos"
+    repos.mkdir()
+    (repos / "o").symlink_to(outside, target_is_directory=True)
+
+    with pytest.raises(HomeConfigError, match="symlink"):
+        migrate_repo_config(
+            "o/r",
+            "main",
+            lambda ref: "max_comments: 7\n",
+            config_root=tmp_path,
+        )
+
+    assert not (outside / "r.yml").exists()
+
+
+def test_migrate_allows_symlinked_ancestor_outside_config_root(tmp_path: Path) -> None:
+    real_parent = tmp_path / "real"
+    real_parent.mkdir()
+    alias = tmp_path / "alias"
+    alias.symlink_to(real_parent, target_is_directory=True)
+    config_root = alias / "reviewer-config"
+
+    result = migrate_repo_config(
+        "o/r",
+        "main",
+        lambda ref: "max_comments: 7\n",
+        config_root=config_root,
+    )
+
+    assert result.created is True
+    assert (real_parent / "reviewer-config/repos/o/r.yml").read_text(
+        encoding="utf-8"
+    ) == "max_comments: 7\n"
+
+
+def test_migrate_rejects_fifo_before_open(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    destination = tmp_path / "repos/o/r.yml"
+    destination.parent.mkdir(parents=True)
+    os.mkfifo(destination)
+
+    def nonregular_must_not_be_opened(*args, **kwargs):
+        raise AssertionError("FIFO was opened")
+
+    monkeypatch.setattr(layers.os, "open", nonregular_must_not_be_opened)
+
+    with pytest.raises(HomeConfigError, match="regular"):
+        migrate_repo_config(
+            "o/r",
+            "main",
+            lambda ref: "max_comments: 7\n",
+            config_root=tmp_path,
+        )
+
+
+def test_migrate_rejects_socket_before_open(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    destination = tmp_path / "repos/o/r.yml"
+    _write(destination, "max_comments: 3\n")
+    original_lstat = layers.os.lstat
+
+    def socket_lstat(path, *args, **kwargs):
+        result = original_lstat(path, *args, **kwargs)
+        if Path(path) == destination:
+            fields = list(result)
+            fields[0] = stat.S_IFSOCK | 0o600
+            return os.stat_result(fields)
+        return result
+
+    def nonregular_must_not_be_opened(*args, **kwargs):
+        raise AssertionError("socket was opened")
+
+    monkeypatch.setattr(layers.os, "lstat", socket_lstat)
+    monkeypatch.setattr(layers.os, "open", nonregular_must_not_be_opened)
+
+    with pytest.raises(HomeConfigError, match="regular"):
+        migrate_repo_config(
+            "o/r",
+            "main",
+            lambda ref: "max_comments: 7\n",
+            config_root=tmp_path,
+        )
+
+
 def test_migrate_rejects_replacement_during_existing_destination_read(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -399,14 +736,14 @@ def test_migrate_sanitizes_destination_parent_mkdir_error(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     secret = "do-not-echo"
-    original_mkdir = Path.mkdir
+    original_mkdir = layers.os.mkdir
 
-    def fail_destination_parent(path: Path, *args, **kwargs) -> None:
-        if path == tmp_path / "repos/o":
+    def fail_destination_parent(path, *args, **kwargs) -> None:
+        if Path(path) == tmp_path / "repos/o" or path == "o":
             raise OSError(secret)
         original_mkdir(path, *args, **kwargs)
 
-    monkeypatch.setattr(Path, "mkdir", fail_destination_parent)
+    monkeypatch.setattr(layers.os, "mkdir", fail_destination_parent)
 
     with pytest.raises(HomeConfigError) as exc:
         migrate_repo_config(
@@ -423,14 +760,20 @@ def test_migrate_preserves_fdopen_error_when_descriptor_close_also_fails(
     _write(destination, "max_comments: 3\n")
     primary = "fdopen-secret"
     cleanup = "close-secret"
+    fdopen_failed = False
 
     def fail_fdopen(*args, **kwargs):
+        nonlocal fdopen_failed
+        fdopen_failed = True
         raise OSError(primary)
 
     def fail_close(*args, **kwargs):
-        raise OSError(cleanup)
+        if fdopen_failed:
+            raise OSError(cleanup)
+        return original_close(*args, **kwargs)
 
     monkeypatch.setattr(layers.os, "fdopen", fail_fdopen)
+    original_close = layers.os.close
     monkeypatch.setattr(layers.os, "close", fail_close)
 
     with pytest.raises(HomeConfigError) as exc:

--- a/tests/config/test_layers.py
+++ b/tests/config/test_layers.py
@@ -1,0 +1,159 @@
+from pathlib import Path
+
+import pytest
+
+from reviewer.config.layers import (
+    HomeConfigError,
+    home_repo_path,
+    migrate_repo_config,
+    resolve_policy_data,
+)
+
+
+def _write(path: Path, text: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+
+
+def test_layers_replace_top_level_values_and_report_sources(tmp_path: Path) -> None:
+    _write(
+        tmp_path / "review.yml",
+        "paths: {ignore: [global]}\nmax_comments: 5\ncontext_limits: {graph: {hops: 2}}\n",
+    )
+    _write(
+        tmp_path / "repos/o/r.yml",
+        "paths: {ignore: [home-repo]}\ntask_board:\n",
+    )
+    committed = (
+        "paths: {ignore: [committed]}\n"
+        "max_comments: 7\n"
+        "context_limits: {search_codebase: {ceiling: 25}}\n"
+    )
+
+    data, meta = resolve_policy_data(
+        "O/R", "main", lambda ref: committed, config_root=tmp_path
+    )
+
+    assert data["paths"] == {"ignore": ["home-repo"]}
+    assert data["context_limits"] == {"search_codebase": {"ceiling": 25}}
+    assert data["task_board"] is None
+    assert meta.sources["paths"] == "home:repos/o/r.yml"
+    assert meta.sources["max_comments"] == ".review.yml"
+    assert meta.shadowed["paths"] == ("home:review.yml", ".review.yml")
+    assert meta.shadowed["max_comments"] == ("home:review.yml",)
+
+
+def test_subgroup_repo_uses_nested_home_path(tmp_path: Path) -> None:
+    assert home_repo_path("group/sub/repo", tmp_path) == (
+        tmp_path / "repos/group/sub/repo.yml"
+    )
+
+
+def test_runtime_skips_bad_home_but_strict_mode_raises(tmp_path: Path) -> None:
+    _write(tmp_path / "review.yml", "[not-a-mapping]\n")
+
+    data, meta = resolve_policy_data(
+        "o/r", "main", lambda ref: "max_comments: 9\n", config_root=tmp_path
+    )
+    assert data == {"max_comments": 9}
+    assert len(meta.warnings) == 1
+    assert "home:review.yml" in meta.warnings[0]
+
+    with pytest.raises(HomeConfigError):
+        resolve_policy_data(
+            "o/r",
+            "main",
+            lambda ref: "max_comments: 9\n",
+            config_root=tmp_path,
+            strict_home=True,
+        )
+
+
+def test_credential_file_is_skipped_without_echoing_value(tmp_path: Path) -> None:
+    secret = "do-not-echo"
+    _write(
+        tmp_path / "repos/o/r.yml",
+        f"max_comments: 4\nnested:\n  github_token: {secret}\n",
+    )
+
+    data, meta = resolve_policy_data(
+        "o/r", "main", lambda ref: "max_comments: 8\n", config_root=tmp_path
+    )
+
+    assert data["max_comments"] == 8
+    rendered = "\n".join(meta.warnings)
+    assert "github_token" in rendered
+    assert secret not in rendered
+
+
+def test_max_tokens_is_not_misclassified_as_secret(tmp_path: Path) -> None:
+    _write(tmp_path / "review.yml", "future: {max_tokens: 100}\n")
+    data, meta = resolve_policy_data(
+        "o/r", "main", lambda ref: None, config_root=tmp_path
+    )
+    assert data["future"] == {"max_tokens": 100}
+    assert meta.warnings == ()
+
+
+def test_runtime_skips_home_config_with_recursive_yaml_alias(tmp_path: Path) -> None:
+    _write(tmp_path / "review.yml", "loop: &loop\n  next: *loop\n")
+
+    data, meta = resolve_policy_data(
+        "o/r", "main", lambda ref: "max_comments: 9\n", config_root=tmp_path
+    )
+
+    assert data == {"max_comments": 9}
+    assert len(meta.warnings) == 1
+
+    with pytest.raises(HomeConfigError):
+        resolve_policy_data(
+            "o/r",
+            "main",
+            lambda ref: "max_comments: 9\n",
+            config_root=tmp_path,
+            strict_home=True,
+        )
+
+
+def test_migrate_creates_file_and_second_call_is_noop(tmp_path: Path) -> None:
+    source = "# keep comment\npaths:\n  ignore: [vendor]\n"
+    first = migrate_repo_config(
+        "o/r", "main", lambda ref: source, config_root=tmp_path
+    )
+    second = migrate_repo_config(
+        "o/r", "main", lambda ref: source, config_root=tmp_path
+    )
+
+    destination = tmp_path / "repos/o/r.yml"
+    assert first.created is True
+    assert second.noop is True
+    assert destination.read_text(encoding="utf-8") == source
+
+
+def test_migrate_refuses_different_destination(tmp_path: Path) -> None:
+    destination = tmp_path / "repos/o/r.yml"
+    _write(destination, "max_comments: 3\n")
+
+    result = migrate_repo_config(
+        "o/r",
+        "main",
+        lambda ref: "max_comments: 7\npaths: {ignore: [vendor]}\n",
+        config_root=tmp_path,
+    )
+
+    assert result.created is False
+    assert result.noop is False
+    assert result.conflicting_keys == ("max_comments", "paths")
+    assert destination.read_text(encoding="utf-8") == "max_comments: 3\n"
+
+
+def test_migrate_rejects_secret_candidate_before_write(tmp_path: Path) -> None:
+    with pytest.raises(HomeConfigError) as exc:
+        migrate_repo_config(
+            "o/r",
+            "main",
+            lambda ref: "github_token: do-not-write\n",
+            config_root=tmp_path,
+        )
+    assert "do-not-write" not in str(exc.value)
+    assert not (tmp_path / "repos/o/r.yml").exists()

--- a/tests/config/test_layers.py
+++ b/tests/config/test_layers.py
@@ -282,74 +282,28 @@ def test_migrate_does_not_clobber_destination_created_during_publish(
     assert destination.read_text(encoding="utf-8") == "max_comments: 3\n"
 
 
-def test_migrate_rollback_does_not_delete_racing_destination(
+def test_migrate_precomputes_result_before_final_publish(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    destination = tmp_path / "repos/o/r.yml"
     meta = ResolutionMeta({}, {}, ())
     calls = 0
 
-    def resolve_after_race(*args, **kwargs):
+    def resolution_must_not_run_after_publish(*args, **kwargs):
         nonlocal calls
         calls += 1
-        if calls == 2:
-            destination.unlink()
-            destination.write_text("max_comments: 3\n", encoding="utf-8")
-            return {"max_comments": 3}, meta
+        if calls > 1:
+            raise AssertionError("resolver ran after publish")
         return {"max_comments": 7}, meta
 
-    monkeypatch.setattr(layers, "resolve_policy_data", resolve_after_race)
+    monkeypatch.setattr(layers, "resolve_policy_data", resolution_must_not_run_after_publish)
 
-    with pytest.raises(HomeConfigError, match="effective config"):
-        migrate_repo_config(
-            "o/r", "main", lambda ref: "max_comments: 7\n", config_root=tmp_path
-        )
+    result = migrate_repo_config(
+        "o/r", "main", lambda ref: "max_comments: 7\n", config_root=tmp_path
+    )
 
-    assert destination.read_text(encoding="utf-8") == "max_comments: 3\n"
-
-
-def test_migrate_mismatch_removes_only_its_own_new_destination(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    meta = ResolutionMeta({}, {}, ())
-    calls = 0
-
-    def mismatching_resolution(*args, **kwargs):
-        nonlocal calls
-        calls += 1
-        return ({"max_comments": 7} if calls == 1 else {"max_comments": 3}), meta
-
-    monkeypatch.setattr(layers, "resolve_policy_data", mismatching_resolution)
-
-    with pytest.raises(HomeConfigError, match="effective config"):
-        migrate_repo_config(
-            "o/r", "main", lambda ref: "max_comments: 7\n", config_root=tmp_path
-        )
-
-    assert not (tmp_path / "repos/o/r.yml").exists()
-
-
-def test_migrate_resolver_failure_removes_only_its_own_new_destination(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    meta = ResolutionMeta({}, {}, ())
-    calls = 0
-
-    def failing_resolution(*args, **kwargs):
-        nonlocal calls
-        calls += 1
-        if calls == 2:
-            raise HomeConfigError("after resolution failed")
-        return {"max_comments": 7}, meta
-
-    monkeypatch.setattr(layers, "resolve_policy_data", failing_resolution)
-
-    with pytest.raises(HomeConfigError, match="after resolution failed"):
-        migrate_repo_config(
-            "o/r", "main", lambda ref: "max_comments: 7\n", config_root=tmp_path
-        )
-
-    assert not (tmp_path / "repos/o/r.yml").exists()
+    assert result.created is True
+    assert calls == 1
+    assert (tmp_path / "repos/o/r.yml").read_text(encoding="utf-8") == "max_comments: 7\n"
 
 
 def test_migrate_refuses_symlink_destination(tmp_path: Path) -> None:
@@ -365,6 +319,80 @@ def test_migrate_refuses_symlink_destination(tmp_path: Path) -> None:
         )
 
     assert target.read_text(encoding="utf-8") == "max_comments: 3\n"
+
+
+def test_migrate_rejects_replacement_during_existing_destination_read(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    destination = tmp_path / "repos/o/r.yml"
+    _write(destination, "max_comments: 3\n")
+    original_open = layers.os.open
+
+    def open_then_replace(path, flags):
+        descriptor = original_open(path, flags)
+        destination.unlink()
+        destination.write_text("max_comments: 9\n", encoding="utf-8")
+        return descriptor
+
+    monkeypatch.setattr(layers.os, "open", open_then_replace)
+
+    with pytest.raises(HomeConfigError, match="race"):
+        migrate_repo_config(
+            "o/r", "main", lambda ref: "max_comments: 7\n", config_root=tmp_path
+        )
+
+    assert destination.read_text(encoding="utf-8") == "max_comments: 9\n"
+
+
+def test_migrate_rejects_symlink_swap_without_o_nofollow(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    destination = tmp_path / "repos/o/r.yml"
+    target = tmp_path / "target.yml"
+    _write(destination, "max_comments: 3\n")
+    target.write_text("max_comments: 9\n", encoding="utf-8")
+    original_open = layers.os.open
+    monkeypatch.delattr(layers.os, "O_NOFOLLOW", raising=False)
+
+    def open_after_symlink_swap(path, flags):
+        destination.unlink()
+        destination.symlink_to(target)
+        return original_open(path, flags)
+
+    monkeypatch.setattr(layers.os, "open", open_after_symlink_swap)
+
+    with pytest.raises(HomeConfigError, match="race"):
+        migrate_repo_config(
+            "o/r", "main", lambda ref: "max_comments: 7\n", config_root=tmp_path
+        )
+
+    assert target.read_text(encoding="utf-8") == "max_comments: 9\n"
+
+
+def test_migrate_sanitizes_link_error_and_preserves_primary_cleanup_error(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    secret = "do-not-echo"
+
+    def fail_link(*args) -> None:
+        raise OSError(secret)
+
+    monkeypatch.setattr(layers.os, "link", fail_link)
+    original_unlink = Path.unlink
+
+    def fail_temp_cleanup(path: Path, *args, **kwargs) -> None:
+        if path.parent == tmp_path / "repos/o":
+            raise OSError("cleanup-" + secret)
+        original_unlink(path, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "unlink", fail_temp_cleanup)
+
+    with pytest.raises(HomeConfigError) as exc:
+        migrate_repo_config(
+            "o/r", "main", lambda ref: "max_comments: 7\n", config_root=tmp_path
+        )
+
+    assert secret not in str(exc.value)
 
 
 def test_build_config_report_rejects_non_json_public_value() -> None:

--- a/tests/config/test_layers.py
+++ b/tests/config/test_layers.py
@@ -306,3 +306,79 @@ def test_migrate_rollback_does_not_delete_racing_destination(
         )
 
     assert destination.read_text(encoding="utf-8") == "max_comments: 3\n"
+
+
+def test_migrate_mismatch_removes_only_its_own_new_destination(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    meta = ResolutionMeta({}, {}, ())
+    calls = 0
+
+    def mismatching_resolution(*args, **kwargs):
+        nonlocal calls
+        calls += 1
+        return ({"max_comments": 7} if calls == 1 else {"max_comments": 3}), meta
+
+    monkeypatch.setattr(layers, "resolve_policy_data", mismatching_resolution)
+
+    with pytest.raises(HomeConfigError, match="effective config"):
+        migrate_repo_config(
+            "o/r", "main", lambda ref: "max_comments: 7\n", config_root=tmp_path
+        )
+
+    assert not (tmp_path / "repos/o/r.yml").exists()
+
+
+def test_migrate_resolver_failure_removes_only_its_own_new_destination(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    meta = ResolutionMeta({}, {}, ())
+    calls = 0
+
+    def failing_resolution(*args, **kwargs):
+        nonlocal calls
+        calls += 1
+        if calls == 2:
+            raise HomeConfigError("after resolution failed")
+        return {"max_comments": 7}, meta
+
+    monkeypatch.setattr(layers, "resolve_policy_data", failing_resolution)
+
+    with pytest.raises(HomeConfigError, match="after resolution failed"):
+        migrate_repo_config(
+            "o/r", "main", lambda ref: "max_comments: 7\n", config_root=tmp_path
+        )
+
+    assert not (tmp_path / "repos/o/r.yml").exists()
+
+
+def test_migrate_refuses_symlink_destination(tmp_path: Path) -> None:
+    destination = tmp_path / "repos/o/r.yml"
+    destination.parent.mkdir(parents=True)
+    target = tmp_path / "outside.yml"
+    target.write_text("max_comments: 3\n", encoding="utf-8")
+    destination.symlink_to(target)
+
+    with pytest.raises(HomeConfigError, match="symlink"):
+        migrate_repo_config(
+            "o/r", "main", lambda ref: "max_comments: 7\n", config_root=tmp_path
+        )
+
+    assert target.read_text(encoding="utf-8") == "max_comments: 3\n"
+
+
+def test_build_config_report_rejects_non_json_public_value() -> None:
+    class SecretValue:
+        def __repr__(self) -> str:
+            return "do-not-echo"
+
+    with pytest.raises(HomeConfigError) as exc:
+        build_config_report(
+            "o/r",
+            "main",
+            Settings(_env_file=None),
+            {"categories": {"security": SecretValue()}},
+            ResolutionMeta({}, {}, ()),
+        )
+
+    assert "do-not-echo" not in str(exc.value)

--- a/tests/config/test_layers.py
+++ b/tests/config/test_layers.py
@@ -6,8 +6,11 @@ from reviewer.config.layers import (
     HomeConfigError,
     home_repo_path,
     migrate_repo_config,
+    policy_to_public_data,
     resolve_policy_data,
 )
+from reviewer.config.settings import Settings
+from reviewer.policy.policy import ReviewPolicy
 
 
 def _write(path: Path, text: str) -> None:
@@ -58,6 +61,59 @@ def test_runtime_skips_bad_home_but_strict_mode_raises(tmp_path: Path) -> None:
     assert data == {"max_comments": 9}
     assert len(meta.warnings) == 1
     assert "home:review.yml" in meta.warnings[0]
+
+    with pytest.raises(HomeConfigError):
+        resolve_policy_data(
+            "o/r",
+            "main",
+            lambda ref: "max_comments: 9\n",
+            config_root=tmp_path,
+            strict_home=True,
+        )
+
+
+def test_runtime_warns_when_home_file_probe_fails(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    home_config = tmp_path / "review.yml"
+    _write(home_config, "max_comments: 4\n")
+    original_stat = Path.stat
+
+    def inaccessible_probe(path: Path, *args, **kwargs):
+        if path == home_config:
+            raise PermissionError("denied")
+        return original_stat(path, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "stat", inaccessible_probe)
+
+    data, meta = resolve_policy_data(
+        "o/r", "main", lambda ref: "max_comments: 9\n", config_root=tmp_path
+    )
+    assert data == {"max_comments": 9}
+    assert len(meta.warnings) == 1
+    assert "home:review.yml" in meta.warnings[0]
+
+    with pytest.raises(HomeConfigError):
+        resolve_policy_data(
+            "o/r",
+            "main",
+            lambda ref: "max_comments: 9\n",
+            config_root=tmp_path,
+            strict_home=True,
+        )
+
+
+def test_runtime_skips_recursion_during_home_yaml_parse(tmp_path: Path) -> None:
+    deep_yaml = "".join(
+        "  " * depth + "nested:\n" for depth in range(500)
+    ) + "  " * 500 + "value: true\n"
+    _write(tmp_path / "review.yml", deep_yaml)
+
+    data, meta = resolve_policy_data(
+        "o/r", "main", lambda ref: "max_comments: 9\n", config_root=tmp_path
+    )
+    assert data == {"max_comments": 9}
+    assert len(meta.warnings) == 1
 
     with pytest.raises(HomeConfigError):
         resolve_policy_data(
@@ -157,3 +213,31 @@ def test_migrate_rejects_secret_candidate_before_write(tmp_path: Path) -> None:
         )
     assert "do-not-write" not in str(exc.value)
     assert not (tmp_path / "repos/o/r.yml").exists()
+
+
+def test_policy_to_public_data_excludes_settings_secrets_and_unknown_yaml() -> None:
+    secret = "do-not-serialize"
+    policy = ReviewPolicy.load_data(
+        Settings(_env_file=None, github_token=secret, neo4j_password=secret),
+        {"max_comments": 4, "unknown_yaml_value": secret},
+    )
+
+    data = policy_to_public_data(policy)
+
+    assert set(data) == {
+        "categories",
+        "enabled_only",
+        "severity_threshold",
+        "paths",
+        "max_comments",
+        "min_confidence",
+        "output_language",
+        "task_board",
+        "grounding_max_distance",
+        "summary_cluster_depth",
+        "summary_topk_threshold",
+        "summary_cluster_depth_overrides",
+        "context_limits",
+    }
+    assert data["max_comments"] == 4
+    assert secret not in repr(data)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from pathlib import Path
 import socket
 import sys
 from types import FunctionType
@@ -161,8 +162,21 @@ def pytest_collection_modifyitems(items: list[pytest.Item]) -> None:
 
 
 @pytest.fixture(autouse=True)
+def isolated_xdg_config_home(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> Path:
+    """Изолировать policy/.env каждого теста от home конфигурации оператора."""
+    config_home = tmp_path / "xdg-config"
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(config_home))
+    return config_home
+
+
+@pytest.fixture(autouse=True)
 def infrastructure_test_settings(
-    request: pytest.FixtureRequest, monkeypatch: pytest.MonkeyPatch
+    request: pytest.FixtureRequest,
+    monkeypatch: pytest.MonkeyPatch,
+    isolated_xdg_config_home: Path,
 ) -> InfrastructureTestSettings | None:
     if request.node.get_closest_marker("integration") is None:
         enable_socket()

--- a/tests/entrypoints/test_cli.py
+++ b/tests/entrypoints/test_cli.py
@@ -134,6 +134,7 @@ def fake_settings() -> MagicMock:
     s.review_history = False
     s.graph_backend = "auto"
     s.default_repo = "owner/default"
+    s.task_board_default.return_value = None
     return s
 
 

--- a/tests/entrypoints/test_cli.py
+++ b/tests/entrypoints/test_cli.py
@@ -161,8 +161,11 @@ def test_index_command_runs_indexing_steps(
     runner,
     fake_components,
     fake_settings,
+    monkeypatch,
+    tmp_path,
 ):
     """Команда index вызывает init_schema, update_base, build_code_graph и cleanup."""
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
     mock_settings_cls.return_value = fake_settings
     mock_build.return_value = fake_components
     mock_list_files.return_value = ["a.py", "b.py"]
@@ -237,8 +240,11 @@ def test_index_derives_repo_from_git_remote(
     runner,
     fake_components,
     fake_settings,
+    monkeypatch,
+    tmp_path,
 ):
     """Если не задан --repo, repo_id берётся из git remote."""
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
     fake_settings.default_repo = None
     mock_settings_cls.return_value = fake_settings
     mock_build.return_value = fake_components

--- a/tests/entrypoints/test_config_commands.py
+++ b/tests/entrypoints/test_config_commands.py
@@ -2,6 +2,7 @@ import json
 from types import SimpleNamespace
 from unittest.mock import MagicMock
 
+import pytest
 from click.testing import CliRunner
 
 import reviewer.entrypoints.cli as cli_mod
@@ -174,6 +175,25 @@ def test_config_show_sanitizes_invalid_policy_value(monkeypatch, tmp_path) -> No
     result = CliRunner().invoke(
         cli_mod.cli, ["config", "show", "--repo", "o/r", "--branch", "main"]
     )
+
+    assert result.exit_code != 0
+    assert "effective policy" in result.output
+    assert secret not in result.output
+    assert secret not in repr(result.exception)
+
+
+@pytest.mark.parametrize("as_json", [False, True])
+def test_config_show_rejects_invalid_public_type_without_echoing_value(
+    monkeypatch, tmp_path, as_json
+) -> None:
+    secret = "do-not-echo"
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
+    _install_fake_vcs(monkeypatch, f"max_comments: {secret}\n")
+    arguments = ["config", "show", "--repo", "o/r", "--branch", "main"]
+    if as_json:
+        arguments.append("--json")
+
+    result = CliRunner().invoke(cli_mod.cli, arguments)
 
     assert result.exit_code != 0
     assert "effective policy" in result.output

--- a/tests/entrypoints/test_config_commands.py
+++ b/tests/entrypoints/test_config_commands.py
@@ -1,0 +1,118 @@
+import json
+from unittest.mock import MagicMock
+
+from click.testing import CliRunner
+
+import reviewer.entrypoints.cli as cli_mod
+
+
+def _install_fake_vcs(monkeypatch, committed):
+    vcs = MagicMock()
+    vcs.get_file_at_ref.return_value = committed
+    vcs.close = MagicMock()
+    components = MagicMock()
+    monkeypatch.setattr(cli_mod, "build_components", lambda settings: components)
+    monkeypatch.setattr(
+        cli_mod.ReviewService,
+        "_create_vcs_provider",
+        lambda self, owner, name: vcs,
+    )
+    return vcs
+
+
+def test_config_show_json_reports_effective_sources_and_shadowing(
+    monkeypatch, tmp_path
+) -> None:
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
+    global_path = tmp_path / "rag-reviewer/review.yml"
+    repo_path = tmp_path / "rag-reviewer/repos/o/r.yml"
+    global_path.parent.mkdir(parents=True)
+    repo_path.parent.mkdir(parents=True)
+    global_path.write_text("max_comments: 5\npaths: {ignore: [global]}\n", encoding="utf-8")
+    repo_path.write_text("paths: {ignore: [home]}\n", encoding="utf-8")
+    _install_fake_vcs(monkeypatch, "max_comments: 7\npaths: {ignore: [repo]}\n")
+
+    result = CliRunner().invoke(
+        cli_mod.cli,
+        ["config", "show", "--repo", "o/r", "--branch", "main", "--json"],
+    )
+
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    assert payload["effective"]["max_comments"] == 7
+    assert payload["effective"]["paths"]["ignore"] == ["home"]
+    assert payload["sources"]["paths"] == "home:repos/o/r.yml"
+    assert payload["shadowed"]["paths"] == ["home:review.yml", ".review.yml"]
+
+
+def test_config_show_rejects_malformed_home_yaml_in_strict_mode(
+    monkeypatch, tmp_path
+) -> None:
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
+    home = tmp_path / "rag-reviewer/review.yml"
+    home.parent.mkdir(parents=True)
+    home.write_text("[not-a-mapping]\n", encoding="utf-8")
+    _install_fake_vcs(monkeypatch, "max_comments: 7\n")
+
+    result = CliRunner().invoke(
+        cli_mod.cli, ["config", "show", "--repo", "o/r", "--branch", "main"]
+    )
+
+    assert result.exit_code != 0
+    assert "home:review.yml" in result.output
+
+
+def test_config_show_skips_credential_home_yaml_without_echoing_secret(
+    monkeypatch, tmp_path
+) -> None:
+    secret = "do-not-echo"
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
+    home = tmp_path / "rag-reviewer/review.yml"
+    home.parent.mkdir(parents=True)
+    home.write_text(f"github_token: {secret}\n", encoding="utf-8")
+    _install_fake_vcs(monkeypatch, "max_comments: 7\n")
+
+    result = CliRunner().invoke(
+        cli_mod.cli, ["config", "show", "--repo", "o/r", "--branch", "main"]
+    )
+
+    assert result.exit_code == 0, result.output
+    assert "credential key github_token" in result.output
+    assert secret not in result.output
+    assert secret not in repr(result.exception)
+
+
+def test_config_migrate_creates_home_file_and_reports_shadowing(
+    monkeypatch, tmp_path
+) -> None:
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
+    source = "# repo policy\npaths: {ignore: [vendor]}\n"
+    _install_fake_vcs(monkeypatch, source)
+
+    result = CliRunner().invoke(
+        cli_mod.cli,
+        ["config", "migrate", "--repo", "o/r", "--branch", "main"],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert (tmp_path / "rag-reviewer/repos/o/r.yml").read_text(
+        encoding="utf-8"
+    ) == source
+    assert "shadowed" in result.output
+
+
+def test_config_migrate_refuses_conflicting_home_file(monkeypatch, tmp_path) -> None:
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
+    destination = tmp_path / "rag-reviewer/repos/o/r.yml"
+    destination.parent.mkdir(parents=True)
+    destination.write_text("max_comments: 3\n", encoding="utf-8")
+    _install_fake_vcs(monkeypatch, "max_comments: 7\n")
+
+    result = CliRunner().invoke(
+        cli_mod.cli,
+        ["config", "migrate", "--repo", "o/r", "--branch", "main"],
+    )
+
+    assert result.exit_code != 0
+    assert "max_comments" in result.output
+    assert destination.read_text(encoding="utf-8") == "max_comments: 3\n"

--- a/tests/entrypoints/test_config_commands.py
+++ b/tests/entrypoints/test_config_commands.py
@@ -93,6 +93,26 @@ def test_config_show_skips_credential_home_yaml_without_echoing_secret(
     assert secret not in repr(result.exception)
 
 
+def test_config_show_rejects_invalid_known_home_value_without_echoing_literal(
+    monkeypatch, tmp_path
+) -> None:
+    secret = "do-not-echo"
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
+    home = tmp_path / "rag-reviewer/review.yml"
+    home.parent.mkdir(parents=True)
+    home.write_text(f"max_comments: {secret}\n", encoding="utf-8")
+    _install_fake_vcs(monkeypatch, "max_comments: 7\n")
+
+    result = CliRunner().invoke(
+        cli_mod.cli, ["config", "show", "--repo", "o/r", "--branch", "main"]
+    )
+
+    assert result.exit_code != 0
+    assert "home:review.yml" in result.output
+    assert secret not in result.output
+    assert secret not in repr(result.exception)
+
+
 def test_config_migrate_creates_home_file_and_reports_shadowing(
     monkeypatch, tmp_path
 ) -> None:

--- a/tests/entrypoints/test_config_commands.py
+++ b/tests/entrypoints/test_config_commands.py
@@ -1,23 +1,33 @@
 import json
+from types import SimpleNamespace
 from unittest.mock import MagicMock
 
 from click.testing import CliRunner
 
 import reviewer.entrypoints.cli as cli_mod
+from reviewer.config.settings import Settings
 
 
-def _install_fake_vcs(monkeypatch, committed):
+def _install_fake_vcs(monkeypatch, committed, *, branch: str = "main"):
     vcs = MagicMock()
     vcs.get_file_at_ref.return_value = committed
     vcs.close = MagicMock()
-    components = MagicMock()
+    components = SimpleNamespace(
+        store=MagicMock(),
+        graph=MagicMock(),
+        task_store=MagicMock(),
+        summary_store=MagicMock(),
+    )
+    monkeypatch.setattr(
+        cli_mod, "Settings", lambda: Settings(_env_file=None, review_branches=branch)
+    )
     monkeypatch.setattr(cli_mod, "build_components", lambda settings: components)
     monkeypatch.setattr(
         cli_mod.ReviewService,
         "_create_vcs_provider",
         lambda self, owner, name: vcs,
     )
-    return vcs
+    return vcs, components
 
 
 def test_config_show_json_reports_effective_sources_and_shadowing(
@@ -116,3 +126,118 @@ def test_config_migrate_refuses_conflicting_home_file(monkeypatch, tmp_path) -> 
     assert result.exit_code != 0
     assert "max_comments" in result.output
     assert destination.read_text(encoding="utf-8") == "max_comments: 3\n"
+
+
+def test_config_show_uses_default_branch_and_normalized_nested_repo(
+    monkeypatch, tmp_path
+) -> None:
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
+    vcs, _ = _install_fake_vcs(monkeypatch, "max_comments: 7\n", branch="trunk")
+
+    result = CliRunner().invoke(
+        cli_mod.cli, ["config", "show", "--repo", "Group/Sub/Repo", "--json"]
+    )
+
+    assert result.exit_code == 0, result.output
+    assert json.loads(result.output)["repo"] == "group/sub/repo"
+    vcs.get_file_at_ref.assert_called_once_with(".review.yml", "trunk")
+
+
+def test_config_show_sanitizes_committed_yaml_and_closes_every_resource(
+    monkeypatch, tmp_path
+) -> None:
+    secret = "do-not-echo"
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
+    vcs, components = _install_fake_vcs(monkeypatch, f"paths: [{secret}\n")
+    vcs.close.side_effect = RuntimeError(secret)
+    components.store.close.side_effect = RuntimeError(secret)
+    components.graph.close.side_effect = RuntimeError(secret)
+
+    result = CliRunner().invoke(
+        cli_mod.cli, ["config", "show", "--repo", "o/r", "--branch", "main"]
+    )
+
+    assert result.exit_code != 0
+    assert ".review.yml" in result.output
+    assert secret not in result.output
+    assert secret not in repr(result.exception)
+    vcs.close.assert_called_once()
+    for component in vars(components).values():
+        component.close.assert_called_once()
+
+
+def test_config_show_sanitizes_invalid_policy_value(monkeypatch, tmp_path) -> None:
+    secret = "do-not-echo"
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
+    _install_fake_vcs(monkeypatch, f"paths: [{secret}]\n")
+
+    result = CliRunner().invoke(
+        cli_mod.cli, ["config", "show", "--repo", "o/r", "--branch", "main"]
+    )
+
+    assert result.exit_code != 0
+    assert "effective policy" in result.output
+    assert secret not in result.output
+    assert secret not in repr(result.exception)
+
+
+def test_config_migrate_handles_missing_or_malformed_committed_policy(monkeypatch, tmp_path) -> None:
+    secret = "do-not-echo"
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
+    _install_fake_vcs(monkeypatch, None)
+
+    missing = CliRunner().invoke(
+        cli_mod.cli, ["config", "migrate", "--repo", "o/r", "--branch", "main"]
+    )
+
+    assert missing.exit_code != 0
+    assert ".review.yml" in missing.output
+
+    _install_fake_vcs(monkeypatch, f"max_comments: [{secret}\n")
+    malformed = CliRunner().invoke(
+        cli_mod.cli, ["config", "migrate", "--repo", "o/r", "--branch", "main"]
+    )
+
+    assert malformed.exit_code != 0
+    assert ".review.yml" in malformed.output
+    assert secret not in malformed.output
+    assert secret not in repr(malformed.exception)
+
+
+def test_config_migrate_reports_semantic_noop_with_default_branch(monkeypatch, tmp_path) -> None:
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
+    destination = tmp_path / "rag-reviewer/repos/o/r.yml"
+    destination.parent.mkdir(parents=True)
+    destination.write_text("max_comments: 7\n", encoding="utf-8")
+    vcs, _ = _install_fake_vcs(monkeypatch, "# comment\nmax_comments: 7\n", branch="trunk")
+
+    result = CliRunner().invoke(cli_mod.cli, ["config", "migrate", "--repo", "o/r"])
+
+    assert result.exit_code == 0, result.output
+    assert "уже перенесён" in result.output
+    vcs.get_file_at_ref.assert_called_with(".review.yml", "trunk")
+
+
+def test_config_migrate_conflict_closes_every_resource_without_masking_error(
+    monkeypatch, tmp_path
+) -> None:
+    secret = "do-not-echo"
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
+    destination = tmp_path / "rag-reviewer/repos/o/r.yml"
+    destination.parent.mkdir(parents=True)
+    destination.write_text("max_comments: 3\n", encoding="utf-8")
+    vcs, components = _install_fake_vcs(monkeypatch, "max_comments: 7\n")
+    vcs.close.side_effect = RuntimeError(secret)
+    components.task_store.close.side_effect = RuntimeError(secret)
+
+    result = CliRunner().invoke(
+        cli_mod.cli, ["config", "migrate", "--repo", "o/r", "--branch", "main"]
+    )
+
+    assert result.exit_code != 0
+    assert "max_comments" in result.output
+    assert secret not in result.output
+    assert secret not in repr(result.exception)
+    vcs.close.assert_called_once()
+    for component in vars(components).values():
+        component.close.assert_called_once()

--- a/tests/entrypoints/test_index_ignore.py
+++ b/tests/entrypoints/test_index_ignore.py
@@ -36,3 +36,38 @@ def test_index_filters_ignored_files(monkeypatch):
     assert result.exit_code == 0, result.output
     assert captured["files"] == ["reviewer/a.py"]      # vendor/x.py отфильтрован
     assert "vendor" in captured["ignore"]
+
+
+def test_index_uses_home_policy_without_committed_file(monkeypatch, tmp_path):
+    """index применяет paths.ignore из home-слоя без committed policy."""
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
+    home = tmp_path / "rag-reviewer/repos/o/r.yml"
+    home.parent.mkdir(parents=True)
+    home.write_text("paths:\n  ignore:\n    - vendor\n", encoding="utf-8")
+    captured = {}
+
+    def fake_update_base(store, embedder, repo, branch, files, **kwargs):
+        captured["files"] = list(files)
+        captured["ignore"] = list(kwargs.get("ignore", []))
+
+    fake_components = MagicMock()
+    monkeypatch.setattr(cli_mod, "build_components", lambda s: fake_components)
+    monkeypatch.setattr(cli_mod, "_resolve_repo", lambda *a: "o/r")
+    monkeypatch.setattr(cli_mod, "list_python_files",
+                        lambda repo, ref: ["vendor/x.py", "reviewer/a.py"])
+    monkeypatch.setattr(cli_mod, "rev_parse", lambda repo, ref: "deadbeef")
+    monkeypatch.setattr(cli_mod, "build_code_graph",
+                        lambda *a, **k: (set(), [], "tree-sitter"))
+
+    def fake_file_at_ref(repo, path, ref):
+        if path == ".review.yml":
+            return None
+        return "def f():\n    pass\n"
+
+    monkeypatch.setattr(cli_mod, "file_at_ref", fake_file_at_ref)
+    monkeypatch.setattr(cli_mod, "update_base", fake_update_base)
+
+    result = CliRunner().invoke(cli_mod.cli, ["index", "/tmp/repo", "--ref", "main"])
+    assert result.exit_code == 0, result.output
+    assert captured["files"] == ["reviewer/a.py"]
+    assert captured["ignore"] == ["vendor"]

--- a/tests/entrypoints/test_index_ignore.py
+++ b/tests/entrypoints/test_index_ignore.py
@@ -4,8 +4,15 @@ from __future__ import annotations
 from unittest.mock import MagicMock
 
 from click.testing import CliRunner
+import pytest
 
 import reviewer.entrypoints.cli as cli_mod
+
+
+@pytest.fixture(autouse=True)
+def _isolated_config_home(monkeypatch, tmp_path):
+    """Каждый index-тест начинает с пустого конфигурационного дома."""
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
 
 
 def test_index_filters_ignored_files(monkeypatch):
@@ -40,11 +47,11 @@ def test_index_filters_ignored_files(monkeypatch):
 
 def test_index_uses_home_policy_without_committed_file(monkeypatch, tmp_path):
     """index применяет paths.ignore из home-слоя без committed policy."""
-    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
     home = tmp_path / "rag-reviewer/repos/o/r.yml"
     home.parent.mkdir(parents=True)
     home.write_text("paths:\n  ignore:\n    - vendor\n", encoding="utf-8")
     captured = {}
+    committed_refs = []
 
     def fake_update_base(store, embedder, repo, branch, files, **kwargs):
         captured["files"] = list(files)
@@ -61,13 +68,15 @@ def test_index_uses_home_policy_without_committed_file(monkeypatch, tmp_path):
 
     def fake_file_at_ref(repo, path, ref):
         if path == ".review.yml":
+            committed_refs.append((repo, path, ref))
             return None
         return "def f():\n    pass\n"
 
     monkeypatch.setattr(cli_mod, "file_at_ref", fake_file_at_ref)
     monkeypatch.setattr(cli_mod, "update_base", fake_update_base)
 
-    result = CliRunner().invoke(cli_mod.cli, ["index", "/tmp/repo", "--ref", "main"])
+    result = CliRunner().invoke(cli_mod.cli, ["index", "/tmp/repo", "--ref", "release/2026"])
     assert result.exit_code == 0, result.output
     assert captured["files"] == ["reviewer/a.py"]
     assert captured["ignore"] == ["vendor"]
+    assert committed_refs == [("/tmp/repo", ".review.yml", "release/2026")]

--- a/tests/entrypoints/test_index_ignore.py
+++ b/tests/entrypoints/test_index_ignore.py
@@ -4,15 +4,8 @@ from __future__ import annotations
 from unittest.mock import MagicMock
 
 from click.testing import CliRunner
-import pytest
 
 import reviewer.entrypoints.cli as cli_mod
-
-
-@pytest.fixture(autouse=True)
-def _isolated_config_home(monkeypatch, tmp_path):
-    """Каждый index-тест начинает с пустого конфигурационного дома."""
-    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
 
 
 def test_index_filters_ignored_files(monkeypatch):
@@ -45,9 +38,12 @@ def test_index_filters_ignored_files(monkeypatch):
     assert "vendor" in captured["ignore"]
 
 
-def test_index_uses_home_policy_without_committed_file(monkeypatch, tmp_path):
+def test_index_uses_home_policy_without_committed_file(
+    monkeypatch,
+    isolated_xdg_config_home,
+):
     """index применяет paths.ignore из home-слоя без committed policy."""
-    home = tmp_path / "rag-reviewer/repos/o/r.yml"
+    home = isolated_xdg_config_home / "rag-reviewer/repos/o/r.yml"
     home.parent.mkdir(parents=True)
     home.write_text("paths:\n  ignore:\n    - vendor\n", encoding="utf-8")
     captured = {}

--- a/tests/launcher/test_catalog.py
+++ b/tests/launcher/test_catalog.py
@@ -10,6 +10,8 @@ from reviewer.launcher.models import Effect, ParameterPresentation
 
 VISIBLE_COMMANDS = {
     "check",
+    "config migrate",
+    "config show",
     "gc",
     "index",
     "init",

--- a/tests/mcp/test_context_limits_wiring.py
+++ b/tests/mcp/test_context_limits_wiring.py
@@ -6,6 +6,8 @@ ceiling_override в Retriever.search_base (новая сигнатура, Task 5
 """
 from unittest.mock import MagicMock
 
+import pytest
+
 from reviewer.config.settings import Settings
 from reviewer.mcp.service import MCPReviewService
 from reviewer.policy.context_limits import CodebaseLimits, ContextLimits
@@ -17,6 +19,12 @@ def _settings() -> Settings:
     s.github_token = "test"
     s.default_repo = ""
     return s
+
+
+@pytest.fixture(autouse=True)
+def _isolated_home_config(monkeypatch, tmp_path) -> None:
+    """Изолирует MCP-резолв policy от конфигурации разработчика."""
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
 
 
 def test_resolve_context_limits_failsoft_returns_defaults() -> None:
@@ -45,6 +53,22 @@ def test_resolve_context_limits_no_review_yml_returns_defaults() -> None:
 
     assert isinstance(cl, ContextLimits)
     assert cl.search_codebase.ceiling == 15
+
+
+def test_resolve_context_limits_uses_home_repo_layer(tmp_path) -> None:
+    """Репозиторный home-слой задаёт лимит graph.hops без .review.yml в VCS."""
+    path = tmp_path / "rag-reviewer/repos/o/r.yml"
+    path.parent.mkdir(parents=True)
+    path.write_text("context_limits: {graph: {hops: 2}}\n", encoding="utf-8")
+    s = _settings()
+    components = MagicMock()
+    vcs = MagicMock()
+    vcs.get_file_at_ref.return_value = None
+    svc = MCPReviewService(s, components, vcs_factory=lambda o, n: vcs)
+
+    limits = svc._resolve_context_limits("o/r", "dev")
+
+    assert limits.graph.hops == 2
 
 
 class _FakeRetriever:

--- a/tests/mcp/test_context_limits_wiring.py
+++ b/tests/mcp/test_context_limits_wiring.py
@@ -1,9 +1,10 @@
-"""Тесты обвязки context_limits в session-less MCP-тулах (PRI-202, Task 7).
+"""Тесты effective layered policy для context limits в session-less MCP-тулах.
 
-_resolve_context_limits — fail-soft резолв ContextLimits из .review.yml ветки
-(зеркало _resolve_summary_depth). search_codebase пробрасывает limits/hops/
-ceiling_override в Retriever.search_base (новая сигнатура, Task 5).
+_resolve_context_limits fail-soft объединяет env, home-слои и committed
+`.review.yml` (зеркало `_resolve_summary_depth`). `search_codebase` передаёт
+limits/hops/ceiling_override в `Retriever.search_base`.
 """
+import logging
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -28,7 +29,7 @@ def _isolated_home_config(monkeypatch, tmp_path) -> None:
 
 
 def test_resolve_context_limits_failsoft_returns_defaults() -> None:
-    """Сбой чтения .review.yml (VCS недоступен) → дефолт-константы ContextLimits."""
+    """Сбой чтения committed policy через VCS → дефолтные ContextLimits."""
     s = _settings()
     components = MagicMock()
     vcs = MagicMock()
@@ -42,7 +43,7 @@ def test_resolve_context_limits_failsoft_returns_defaults() -> None:
 
 
 def test_resolve_context_limits_no_review_yml_returns_defaults() -> None:
-    """Файла .review.yml нет (пустой текст) → тоже дефолт, без исключения."""
+    """Без committed policy effective policy даёт дефолты без исключения."""
     s = _settings()
     components = MagicMock()
     vcs = MagicMock()
@@ -56,7 +57,7 @@ def test_resolve_context_limits_no_review_yml_returns_defaults() -> None:
 
 
 def test_resolve_context_limits_uses_home_repo_layer(tmp_path) -> None:
-    """Репозиторный home-слой задаёт лимит graph.hops без .review.yml в VCS."""
+    """Репозиторный home-слой задаёт graph.hops без committed policy в VCS."""
     path = tmp_path / "rag-reviewer/repos/o/r.yml"
     path.parent.mkdir(parents=True)
     path.write_text("context_limits: {graph: {hops: 2}}\n", encoding="utf-8")
@@ -102,6 +103,19 @@ def test_resolve_policy_closes_internally_created_vcs() -> None:
     vcs.close.assert_called_once_with()
 
 
+def test_resolve_context_limits_failsoft_closes_internal_vcs_after_fetch_error() -> None:
+    """Сбой чтения committed layer сохраняет fallback и закрывает owned VCS."""
+    vcs = MagicMock()
+    vcs.get_file_at_ref.side_effect = RuntimeError("network down")
+    svc = MCPReviewService(_settings(), MagicMock(), vcs_factory=None)
+
+    with patch.object(svc._review_service, "_create_vcs_provider", return_value=vcs):
+        limits = svc._resolve_context_limits("o/r", "dev")
+
+    assert limits == ContextLimits()
+    vcs.close.assert_called_once_with()
+
+
 def test_resolve_context_limits_ignores_internal_vcs_close_failure() -> None:
     """Ошибка close внутреннего provider не отменяет уже полученный policy."""
     vcs = MagicMock()
@@ -114,6 +128,25 @@ def test_resolve_context_limits_ignores_internal_vcs_close_failure() -> None:
 
     assert limits.graph.hops == 2
     vcs.close.assert_called_once_with()
+
+
+def test_resolve_policy_logs_sanitized_home_credential_warning(caplog, tmp_path) -> None:
+    """MCP warning explains skipped credential-shaped home layer without its value."""
+    path = tmp_path / "rag-reviewer/repos/o/r.yml"
+    path.parent.mkdir(parents=True)
+    path.write_text("github_token: leaked-value\n", encoding="utf-8")
+    vcs = MagicMock()
+    vcs.get_file_at_ref.return_value = None
+    svc = MCPReviewService(_settings(), MagicMock(), vcs_factory=lambda owner, name: vcs)
+
+    with caplog.at_level(logging.WARNING, logger="reviewer.mcp.service"):
+        policy, meta = svc._resolve_policy("o/r", "dev")
+
+    assert policy.context_limits == ContextLimits()
+    assert meta.warnings
+    assert "Домашний слой policy пропущен" in caplog.text
+    assert "github_token" in caplog.text
+    assert "leaked-value" not in caplog.text
 
 
 def test_resolve_context_limits_uses_falsey_injected_vcs_factory() -> None:

--- a/tests/mcp/test_context_limits_wiring.py
+++ b/tests/mcp/test_context_limits_wiring.py
@@ -7,8 +7,6 @@ limits/hops/ceiling_override в `Retriever.search_base`.
 import logging
 from unittest.mock import MagicMock, patch
 
-import pytest
-
 from reviewer.config.settings import Settings
 from reviewer.mcp.service import MCPReviewService
 from reviewer.policy.context_limits import CodebaseLimits, ContextLimits
@@ -20,12 +18,6 @@ def _settings() -> Settings:
     s.github_token = "test"
     s.default_repo = ""
     return s
-
-
-@pytest.fixture(autouse=True)
-def _isolated_home_config(monkeypatch, tmp_path) -> None:
-    """Изолирует MCP-резолв policy от конфигурации разработчика."""
-    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
 
 
 def test_resolve_context_limits_failsoft_returns_defaults() -> None:
@@ -56,9 +48,11 @@ def test_resolve_context_limits_no_review_yml_returns_defaults() -> None:
     assert cl.search_codebase.ceiling == 15
 
 
-def test_resolve_context_limits_uses_home_repo_layer(tmp_path) -> None:
+def test_resolve_context_limits_uses_home_repo_layer(
+    isolated_xdg_config_home,
+) -> None:
     """Репозиторный home-слой задаёт graph.hops без committed policy в VCS."""
-    path = tmp_path / "rag-reviewer/repos/o/r.yml"
+    path = isolated_xdg_config_home / "rag-reviewer/repos/o/r.yml"
     path.parent.mkdir(parents=True)
     path.write_text("context_limits: {graph: {hops: 2}}\n", encoding="utf-8")
     s = _settings()
@@ -72,12 +66,14 @@ def test_resolve_context_limits_uses_home_repo_layer(tmp_path) -> None:
     assert limits.graph.hops == 2
 
 
-def test_resolve_policy_reports_repo_home_source_and_keeps_injected_vcs_open(tmp_path) -> None:
+def test_resolve_policy_reports_repo_home_source_and_keeps_injected_vcs_open(
+    isolated_xdg_config_home,
+) -> None:
     """Репозиторный слой побеждает VCS и сохраняет ownership injected VCS."""
-    global_path = tmp_path / "rag-reviewer/review.yml"
+    global_path = isolated_xdg_config_home / "rag-reviewer/review.yml"
     global_path.parent.mkdir(parents=True)
     global_path.write_text("summary_topk_threshold: 3\n", encoding="utf-8")
-    repo_path = tmp_path / "rag-reviewer/repos/o/r.yml"
+    repo_path = isolated_xdg_config_home / "rag-reviewer/repos/o/r.yml"
     repo_path.parent.mkdir(parents=True)
     repo_path.write_text("summary_topk_threshold: 7\n", encoding="utf-8")
     vcs = MagicMock()
@@ -130,9 +126,12 @@ def test_resolve_context_limits_ignores_internal_vcs_close_failure() -> None:
     vcs.close.assert_called_once_with()
 
 
-def test_resolve_policy_logs_sanitized_home_credential_warning(caplog, tmp_path) -> None:
+def test_resolve_policy_logs_sanitized_home_credential_warning(
+    caplog,
+    isolated_xdg_config_home,
+) -> None:
     """MCP warning explains skipped credential-shaped home layer without its value."""
-    path = tmp_path / "rag-reviewer/repos/o/r.yml"
+    path = isolated_xdg_config_home / "rag-reviewer/repos/o/r.yml"
     path.parent.mkdir(parents=True)
     path.write_text("github_token: leaked-value\n", encoding="utf-8")
     vcs = MagicMock()
@@ -147,6 +146,47 @@ def test_resolve_policy_logs_sanitized_home_credential_warning(caplog, tmp_path)
     assert "Домашний слой policy пропущен" in caplog.text
     assert "github_token" in caplog.text
     assert "leaked-value" not in caplog.text
+
+
+def test_resolve_policy_skips_invalid_home_value_without_logging_literal(
+    caplog,
+    isolated_xdg_config_home,
+) -> None:
+    secret = "do-not-echo"
+    path = isolated_xdg_config_home / "rag-reviewer/repos/o/r.yml"
+    path.parent.mkdir(parents=True)
+    path.write_text(
+        f"context_limits: {{graph: {{hops: {secret}}}}}\n"
+        "future_policy: enabled\n",
+        encoding="utf-8",
+    )
+    vcs = MagicMock()
+    vcs.get_file_at_ref.return_value = "context_limits: {graph: {hops: 2}}\n"
+    svc = MCPReviewService(_settings(), MagicMock(), vcs_factory=lambda owner, name: vcs)
+
+    with caplog.at_level(logging.WARNING, logger="reviewer.mcp.service"):
+        policy, meta = svc._resolve_policy("o/r", "dev")
+
+    assert policy.context_limits.graph.hops == 2
+    assert meta.sources["context_limits"] == ".review.yml"
+    assert "home:repos/o/r.yml" in caplog.text
+    assert secret not in caplog.text
+
+
+def test_context_limits_failsoft_does_not_log_invalid_committed_literal(caplog) -> None:
+    secret = "do-not-echo"
+    vcs = MagicMock()
+    vcs.get_file_at_ref.return_value = (
+        f"context_limits: {{graph: {{hops: {secret}}}}}\n"
+    )
+    svc = MCPReviewService(_settings(), MagicMock(), vcs_factory=lambda owner, name: vcs)
+
+    with caplog.at_level(logging.WARNING, logger="reviewer.mcp.service"):
+        limits = svc._resolve_context_limits("o/r", "dev")
+
+    assert limits == ContextLimits()
+    assert "fail-soft" in caplog.text
+    assert secret not in caplog.text
 
 
 def test_resolve_context_limits_uses_falsey_injected_vcs_factory() -> None:

--- a/tests/mcp/test_context_limits_wiring.py
+++ b/tests/mcp/test_context_limits_wiring.py
@@ -4,7 +4,7 @@ _resolve_context_limits — fail-soft резолв ContextLimits из .review.ym
 (зеркало _resolve_summary_depth). search_codebase пробрасывает limits/hops/
 ceiling_override в Retriever.search_base (новая сигнатура, Task 5).
 """
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -69,6 +69,78 @@ def test_resolve_context_limits_uses_home_repo_layer(tmp_path) -> None:
     limits = svc._resolve_context_limits("o/r", "dev")
 
     assert limits.graph.hops == 2
+
+
+def test_resolve_policy_reports_repo_home_source_and_keeps_injected_vcs_open(tmp_path) -> None:
+    """Репозиторный слой побеждает VCS и сохраняет ownership injected VCS."""
+    global_path = tmp_path / "rag-reviewer/review.yml"
+    global_path.parent.mkdir(parents=True)
+    global_path.write_text("summary_topk_threshold: 3\n", encoding="utf-8")
+    repo_path = tmp_path / "rag-reviewer/repos/o/r.yml"
+    repo_path.parent.mkdir(parents=True)
+    repo_path.write_text("summary_topk_threshold: 7\n", encoding="utf-8")
+    vcs = MagicMock()
+    vcs.get_file_at_ref.return_value = "summary_topk_threshold: 5\n"
+    svc = MCPReviewService(_settings(), MagicMock(), vcs_factory=lambda owner, name: vcs)
+
+    policy, meta = svc._resolve_policy("o/r", "dev")
+
+    assert policy.summary_topk_threshold == 7
+    assert meta.sources["summary_topk_threshold"] == "home:repos/o/r.yml"
+    vcs.close.assert_not_called()
+
+
+def test_resolve_policy_closes_internally_created_vcs() -> None:
+    """Созданный сервисом VCS закрывается после резолва policy."""
+    vcs = MagicMock()
+    vcs.get_file_at_ref.return_value = None
+    svc = MCPReviewService(_settings(), MagicMock(), vcs_factory=None)
+
+    with patch.object(svc._review_service, "_create_vcs_provider", return_value=vcs):
+        svc._resolve_policy("o/r", "dev")
+
+    vcs.close.assert_called_once_with()
+
+
+def test_resolve_context_limits_ignores_internal_vcs_close_failure() -> None:
+    """Ошибка close внутреннего provider не отменяет уже полученный policy."""
+    vcs = MagicMock()
+    vcs.get_file_at_ref.return_value = "context_limits: {graph: {hops: 2}}\n"
+    vcs.close.side_effect = RuntimeError("close failed")
+    svc = MCPReviewService(_settings(), MagicMock(), vcs_factory=None)
+
+    with patch.object(svc._review_service, "_create_vcs_provider", return_value=vcs):
+        limits = svc._resolve_context_limits("o/r", "dev")
+
+    assert limits.graph.hops == 2
+    vcs.close.assert_called_once_with()
+
+
+def test_resolve_context_limits_uses_falsey_injected_vcs_factory() -> None:
+    """Переданная VCS-фабрика остаётся caller-owned независимо от truthiness."""
+    class _FalseyFactory:
+        def __init__(self, vcs) -> None:
+            self.vcs = vcs
+
+        def __bool__(self) -> bool:
+            return False
+
+        def __call__(self, owner, name):
+            return self.vcs
+
+    injected_vcs = MagicMock()
+    injected_vcs.get_file_at_ref.return_value = None
+    internal_vcs = MagicMock()
+    internal_vcs.get_file_at_ref.return_value = None
+    svc = MCPReviewService(
+        _settings(), MagicMock(), vcs_factory=_FalseyFactory(injected_vcs)
+    )
+
+    with patch.object(svc._review_service, "_create_vcs_provider", return_value=internal_vcs) as create:
+        svc._resolve_context_limits("o/r", "dev")
+
+    create.assert_not_called()
+    injected_vcs.close.assert_not_called()
 
 
 class _FakeRetriever:

--- a/tests/mcp/test_publish.py
+++ b/tests/mcp/test_publish.py
@@ -196,16 +196,17 @@ def _submit_then_publish(svc, repo, pr, findings, *, summary="s", dry_run=False,
 def test_publish_posts_inline_and_records_history(_ov, _ch) -> None:
     svc, vcs, history = _make_mcp_service_with_publish()
     svc.prepare_review("o/r", 7)
-    svc._sessions[("o/r", 7)].prepared.config_sources = {
+    provenance = {
         "sources": {"paths": "home:repos/o/r.yml"},
         "shadowed": {"paths": [".review.yml"]},
         "warnings": [],
     }
+    svc._sessions[("o/r", 7)].prepared.config_sources = provenance
     report = _submit_then_publish(svc, "o/r", 7, [RAW], summary="Overall fine")
     assert report["posted"] is True
     assert vcs.published[0]["comments"][0]["path"] == "a.py"
     assert history.runs[0]["pr_number"] == 7
-    assert history.runs[0]["config_sources"]["sources"]["paths"] == "home:repos/o/r.yml"
+    assert history.runs[0]["config_sources"] == provenance
     assert ("o/r", 7) not in svc._sessions          # сессия закрыта
 
 

--- a/tests/mcp/test_publish.py
+++ b/tests/mcp/test_publish.py
@@ -196,10 +196,16 @@ def _submit_then_publish(svc, repo, pr, findings, *, summary="s", dry_run=False,
 def test_publish_posts_inline_and_records_history(_ov, _ch) -> None:
     svc, vcs, history = _make_mcp_service_with_publish()
     svc.prepare_review("o/r", 7)
+    svc._sessions[("o/r", 7)].prepared.config_sources = {
+        "sources": {"paths": "home:repos/o/r.yml"},
+        "shadowed": {"paths": [".review.yml"]},
+        "warnings": [],
+    }
     report = _submit_then_publish(svc, "o/r", 7, [RAW], summary="Overall fine")
     assert report["posted"] is True
     assert vcs.published[0]["comments"][0]["path"] == "a.py"
     assert history.runs[0]["pr_number"] == 7
+    assert history.runs[0]["config_sources"]["sources"]["paths"] == "home:repos/o/r.yml"
     assert ("o/r", 7) not in svc._sessions          # сессия закрыта
 
 

--- a/tests/mcp/test_session_serde.py
+++ b/tests/mcp/test_session_serde.py
@@ -38,6 +38,11 @@ def _prepared(vcs) -> PreparedReview:
         changed_status={"a.py": "modified", "b.py": "added"},
         task_board={"type": "yougile"},
         task_keys={"primary": "PRI-7", "others": []},
+        config_sources={
+            "sources": {"paths": "home:repos/o/r.yml"},
+            "shadowed": {"paths": [".review.yml"]},
+            "warnings": [],
+        },
     )
 
 
@@ -63,6 +68,7 @@ def test_payload_roundtrip_preserves_fields() -> None:
     assert restored.changed_status == original.changed_status
     assert restored.task_board == original.task_board
     assert restored.task_keys == original.task_keys
+    assert restored.config_sources == original.config_sources
     assert restored.vcs is new_vcs                       # vcs не сериализуется, подставлен заново
 
 
@@ -95,3 +101,13 @@ def test_from_payload_bad_prq_raises_type_error() -> None:
     payload["prq"] = {"unexpected_field": 1}  # PullRequest(**...) → TypeError
     with pytest.raises(TypeError):
         from_payload(payload, _DummyVCS())
+
+
+def test_from_payload_without_config_sources_is_backward_compatible() -> None:
+    """Payload старой сессии восстанавливается с пустой конфигурацией источников."""
+    payload = json.loads(json.dumps(to_payload(_prepared(_DummyVCS()))))
+    payload.pop("config_sources")
+
+    restored = from_payload(payload, _DummyVCS())
+
+    assert restored.config_sources == {}

--- a/tests/mcp/test_subsystem_summaries.py
+++ b/tests/mcp/test_subsystem_summaries.py
@@ -3,8 +3,6 @@ from __future__ import annotations
 
 from unittest.mock import MagicMock
 
-import pytest
-
 from reviewer.config.settings import Settings
 from reviewer.mcp.service import MCPReviewService
 
@@ -14,12 +12,6 @@ def _settings() -> Settings:
     s.voyage_api_key = "test"
     s.default_repo = ""
     return s
-
-
-@pytest.fixture(autouse=True)
-def _isolated_home_config(monkeypatch, tmp_path) -> None:
-    """Изолирует MCP-резолв policy от конфигурации разработчика."""
-    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
 
 
 def _svc(components) -> MCPReviewService:
@@ -386,9 +378,9 @@ def test_resolve_summary_topk_threshold_no_key_falls_back_to_env():
     assert source == "env"
 
 
-def test_summary_threshold_reports_home_repo_source(tmp_path):
+def test_summary_threshold_reports_home_repo_source(isolated_xdg_config_home):
     """Источник порога указывает репозиторный home-слой, а не env."""
-    path = tmp_path / "rag-reviewer/repos/o/r.yml"
+    path = isolated_xdg_config_home / "rag-reviewer/repos/o/r.yml"
     path.parent.mkdir(parents=True)
     path.write_text("summary_topk_threshold: 7\n", encoding="utf-8")
     svc, vcs = _service_for_summary_resolution()

--- a/tests/mcp/test_subsystem_summaries.py
+++ b/tests/mcp/test_subsystem_summaries.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 
 from unittest.mock import MagicMock
 
+import pytest
+
 from reviewer.config.settings import Settings
 from reviewer.mcp.service import MCPReviewService
 
@@ -12,6 +14,12 @@ def _settings() -> Settings:
     s.voyage_api_key = "test"
     s.default_repo = ""
     return s
+
+
+@pytest.fixture(autouse=True)
+def _isolated_home_config(monkeypatch, tmp_path) -> None:
+    """Изолирует MCP-резолв policy от конфигурации разработчика."""
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
 
 
 def _svc(components) -> MCPReviewService:
@@ -258,6 +266,14 @@ def _svc_with_vcs(vcs_or_exc):
     return svc
 
 
+def _service_for_summary_resolution() -> tuple[MCPReviewService, MagicMock]:
+    """Сервис с VCS-фабрикой для изолированного резолва policy сводок."""
+    vcs = MagicMock()
+    svc = MCPReviewService(_settings(), components=MagicMock(),
+                           vcs_factory=lambda owner, name: vcs)
+    return svc, vcs
+
+
 def test_resolve_summary_depth_override_from_review_yml():
     svc = _svc_with_vcs(_FakeVCS("summary_cluster_depth: 3"))
     depth, overrides, source = svc._resolve_summary_depth("o/n", "dev")
@@ -368,6 +384,20 @@ def test_resolve_summary_topk_threshold_no_key_falls_back_to_env():
     val, source = svc._resolve_summary_topk_threshold("o/n", "dev")
     assert val == svc.settings.summary_topk_threshold
     assert source == "env"
+
+
+def test_summary_threshold_reports_home_repo_source(tmp_path):
+    """Источник порога указывает репозиторный home-слой, а не env."""
+    path = tmp_path / "rag-reviewer/repos/o/r.yml"
+    path.parent.mkdir(parents=True)
+    path.write_text("summary_topk_threshold: 7\n", encoding="utf-8")
+    svc, vcs = _service_for_summary_resolution()
+    vcs.get_file_at_ref.return_value = None
+
+    value, source = svc._resolve_summary_topk_threshold("o/r", "main")
+
+    assert value == 7
+    assert source == "home:repos/o/r.yml"
 
 
 def test_settings_default_summary_topk_threshold_is_20():

--- a/tests/mcp/test_summary_depth_overrides.py
+++ b/tests/mcp/test_summary_depth_overrides.py
@@ -1,8 +1,16 @@
 """Тест per-path depth overrides в list/index/prune сводок (PRI-161, Task 6)."""
 from unittest.mock import MagicMock
 
+import pytest
+
 from reviewer.config.settings import Settings
 from reviewer.mcp.service import MCPReviewService
+
+
+@pytest.fixture(autouse=True)
+def _isolated_home_config(monkeypatch, tmp_path) -> None:
+    """Изолирует резолв policy от конфигурации разработчика."""
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
 
 
 def _svc(review_yml: str):

--- a/tests/mcp/test_summary_depth_overrides.py
+++ b/tests/mcp/test_summary_depth_overrides.py
@@ -1,16 +1,8 @@
 """Тест per-path depth overrides в list/index/prune сводок (PRI-161, Task 6)."""
 from unittest.mock import MagicMock
 
-import pytest
-
 from reviewer.config.settings import Settings
 from reviewer.mcp.service import MCPReviewService
-
-
-@pytest.fixture(autouse=True)
-def _isolated_home_config(monkeypatch, tmp_path) -> None:
-    """Изолирует резолв policy от конфигурации разработчика."""
-    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
 
 
 def _svc(review_yml: str):

--- a/tests/policy/test_policy.py
+++ b/tests/policy/test_policy.py
@@ -1,3 +1,5 @@
+import yaml
+
 from reviewer.policy.policy import ReviewPolicy
 from reviewer.config.settings import Settings
 from reviewer.vcs.base import Finding
@@ -52,6 +54,24 @@ def test_load_env_defaults_then_yaml_override():
 
     p3 = ReviewPolicy.load(s, "output_language: en")
     assert p3.output_language == "en"   # YAML переопределяет env-дефолт
+
+
+def test_load_data_matches_load_for_nested_policy() -> None:
+    settings = Settings(_env_file=None, review_severity_threshold="medium")
+    data = {
+        "severity_threshold": "high",
+        "paths": {"ignore": ["vendor/**"]},
+        "context_limits": {"graph": {"hops": 2}},
+        "task_board": None,
+    }
+
+    from_data = ReviewPolicy.load_data(settings, data)
+    from_text = ReviewPolicy.load(settings, yaml.safe_dump(data))
+
+    assert from_data == from_text
+    assert from_data.ignore == ["vendor/**"]
+    assert from_data.context_limits.graph.hops == 2
+    assert from_data.task_board is None
 
 
 def test_output_language_default_and_yaml_override():

--- a/tests/services/test_prepare_ignore.py
+++ b/tests/services/test_prepare_ignore.py
@@ -5,8 +5,6 @@ import subprocess
 import sys
 from unittest.mock import MagicMock, call
 
-import pytest
-
 import reviewer.services.review_service as rs
 from reviewer.config.settings import Settings
 from reviewer.vcs.base import ChangedFile, PullRequest
@@ -39,12 +37,6 @@ def _minimal_vcs_for_prepare() -> MagicMock:
         ChangedFile(path="reviewer/a.py", status="modified", patch="@@"),
     ]
     return vcs
-
-
-@pytest.fixture(autouse=True)
-def _isolated_config_home(monkeypatch, tmp_path):
-    """Каждый prepare-тест начинает с пустого конфигурационного дома."""
-    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
 
 
 def test_prepare_test_case_isolated_from_conflicting_xdg_config(tmp_path):

--- a/tests/services/test_prepare_ignore.py
+++ b/tests/services/test_prepare_ignore.py
@@ -1,5 +1,5 @@
-"""Тест: prepare прокидывает paths.ignore из .review.yml base-ветки в build_overlay."""
-from unittest.mock import MagicMock
+"""Тесты policy paths.ignore при подготовке ревью."""
+from unittest.mock import MagicMock, call
 
 import reviewer.services.review_service as rs
 from reviewer.config.settings import Settings
@@ -21,15 +21,8 @@ def _settings() -> Settings:
     return s
 
 
-def test_prepare_passes_ignore_to_build_overlay(monkeypatch):
-    """prepare() резолвит paths.ignore из .review.yml целевой ветки и прокидывает
-    в build_overlay — агент не видит игнорируемые пути в overlay."""
-    captured = {}
-    monkeypatch.setattr(rs, "build_overlay",
-                        lambda *a, **k: captured.update(ignore=k.get("ignore")))
-    monkeypatch.setattr(rs, "chunk_python", lambda path, src: [])
-    monkeypatch.setattr(rs, "_structural_summary", lambda *a, **k: "")
-
+def _minimal_vcs_for_prepare() -> MagicMock:
+    """VCS-двойник с минимальным PR и одним изменённым Python-файлом."""
     vcs = MagicMock()
     pr = PullRequest(
         number=7, base_sha="b", head_sha="h", base_ref="main",
@@ -39,6 +32,18 @@ def test_prepare_passes_ignore_to_build_overlay(monkeypatch):
     vcs.get_changed_files.return_value = [
         ChangedFile(path="reviewer/a.py", status="modified", patch="@@"),
     ]
+    return vcs
+
+
+def test_prepare_passes_ignore_to_build_overlay(monkeypatch):
+    """prepare() передаёт committed paths.ignore в overlay."""
+    captured = {}
+    monkeypatch.setattr(rs, "build_overlay",
+                        lambda *a, **k: captured.update(ignore=k.get("ignore")))
+    monkeypatch.setattr(rs, "chunk_python", lambda path, src: [])
+    monkeypatch.setattr(rs, "_structural_summary", lambda *a, **k: "")
+
+    vcs = _minimal_vcs_for_prepare()
     vcs.get_file_at_ref.side_effect = (
         lambda path, sha: "paths:\n  ignore:\n    - vendor\n"
         if path == ".review.yml" else "def f():\n    pass\n")
@@ -49,3 +54,36 @@ def test_prepare_passes_ignore_to_build_overlay(monkeypatch):
     svc = rs.ReviewService(_settings(), components)
     svc.prepare("o", "r", 7, vcs_provider=vcs)
     assert captured.get("ignore") == ["vendor"]
+
+
+def test_prepare_uses_home_policy_without_committed_file(monkeypatch, tmp_path):
+    """Home-policy применяется, когда в base-коммите нет .review.yml."""
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
+    home = tmp_path / "rag-reviewer/repos/o/r.yml"
+    home.parent.mkdir(parents=True)
+    home.write_text(
+        "paths: {ignore: [vendor]}\nmax_comments: 4\ntask_board: null\n",
+        encoding="utf-8",
+    )
+    captured = {}
+    monkeypatch.setattr(rs, "build_overlay", lambda *a, **k: captured.update(ignore=k["ignore"]))
+    monkeypatch.setattr(rs, "chunk_python", lambda path, src: [])
+    monkeypatch.setattr(rs, "_structural_summary", lambda *a, **k: "")
+    vcs = _minimal_vcs_for_prepare()
+    vcs.get_file_at_ref.side_effect = (
+        lambda path, ref: None if path == ".review.yml" else "def f():\n    pass\n"
+    )
+    components = MagicMock()
+    components.store.get_index_meta.return_value = None
+
+    prepared = rs.ReviewService(_settings(), components).prepare(
+        "o", "r", 7, vcs_provider=vcs
+    )
+
+    assert captured["ignore"] == ["vendor"]
+    assert prepared.policy.max_comments == 4
+    assert prepared.config_sources["sources"]["paths"] == "home:repos/o/r.yml"
+    committed_calls = [
+        call for call in vcs.get_file_at_ref.call_args_list if call.args[0] == ".review.yml"
+    ]
+    assert committed_calls == [call(".review.yml", "b")]

--- a/tests/services/test_prepare_ignore.py
+++ b/tests/services/test_prepare_ignore.py
@@ -1,5 +1,11 @@
 """Тесты policy paths.ignore при подготовке ревью."""
+import os
+from pathlib import Path
+import subprocess
+import sys
 from unittest.mock import MagicMock, call
+
+import pytest
 
 import reviewer.services.review_service as rs
 from reviewer.config.settings import Settings
@@ -33,6 +39,38 @@ def _minimal_vcs_for_prepare() -> MagicMock:
         ChangedFile(path="reviewer/a.py", status="modified", patch="@@"),
     ]
     return vcs
+
+
+@pytest.fixture(autouse=True)
+def _isolated_config_home(monkeypatch, tmp_path):
+    """Каждый prepare-тест начинает с пустого конфигурационного дома."""
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
+
+
+def test_prepare_test_case_isolated_from_conflicting_xdg_config(tmp_path):
+    """Проверяем, что committed-policy тест не зависит от домашнего слоя разработчика."""
+    home = tmp_path / "developer-config/rag-reviewer/repos/o/r.yml"
+    home.parent.mkdir(parents=True)
+    home.write_text("paths: {ignore: [home-vendor]}\n", encoding="utf-8")
+    env = {**os.environ, "XDG_CONFIG_HOME": str(tmp_path / "developer-config")}
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "pytest",
+            "-q",
+            "-p",
+            "no:cacheprovider",
+            "tests/services/test_prepare_ignore.py::test_prepare_passes_ignore_to_build_overlay",
+        ],
+        cwd=Path(__file__).parents[2],
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stdout + result.stderr
 
 
 def test_prepare_passes_ignore_to_build_overlay(monkeypatch):

--- a/tests/services/test_repo_id.py
+++ b/tests/services/test_repo_id.py
@@ -4,14 +4,16 @@ from reviewer.services.repo_id import normalize_repo, derive_repo_from_remote, d
 
 @pytest.mark.parametrize("raw,expected", [
     ("Owner/Repo", "owner/repo"),
-    ("  OWNER/Name  ", "owner/name"),
-    ("owner/name", "owner/name"),
+    ("Group/Sub/Repo", "group/sub/repo"),
 ])
 def test_normalize_repo(raw, expected):
     assert normalize_repo(raw) == expected
 
 
-@pytest.mark.parametrize("bad", ["", "noslash", "a/b/c"])
+@pytest.mark.parametrize(
+    "bad",
+    ["", "noslash", "/a/b", "a/b/", "a/../b", "a/./b", "a\\b/c", "a/\x00/b"],
+)
 def test_normalize_repo_rejects_bad(bad):
     with pytest.raises(ValueError):
         normalize_repo(bad)

--- a/tests/services/test_review_service.py
+++ b/tests/services/test_review_service.py
@@ -25,12 +25,6 @@ from reviewer.vcs.base import (
 # Фикстуры
 # ---------------------------------------------------------------------------
 
-@pytest.fixture(autouse=True)
-def _isolated_config_home(monkeypatch, tmp_path):
-    """Каждый prepare-тест начинает с пустого конфигурационного дома."""
-    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
-
-
 @pytest.fixture
 def settings() -> Settings:
     """Минимальные настройки для unit-тестов."""

--- a/tests/services/test_review_service.py
+++ b/tests/services/test_review_service.py
@@ -5,6 +5,10 @@
 """
 from __future__ import annotations
 
+import os
+from pathlib import Path
+import subprocess
+import sys
 from unittest.mock import MagicMock, call, patch
 
 import pytest
@@ -20,6 +24,12 @@ from reviewer.vcs.base import (
 # ---------------------------------------------------------------------------
 # Фикстуры
 # ---------------------------------------------------------------------------
+
+@pytest.fixture(autouse=True)
+def _isolated_config_home(monkeypatch, tmp_path):
+    """Каждый prepare-тест начинает с пустого конфигурационного дома."""
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
+
 
 @pytest.fixture
 def settings() -> Settings:
@@ -97,6 +107,32 @@ def _vcs_with_files(files: list[ChangedFile], draft: bool = False) -> MagicMock:
     vcs.get_changed_files.return_value = files
     vcs.get_file_at_ref.return_value = "def foo(): pass"
     return vcs
+
+
+def test_prepare_module_isolated_from_conflicting_xdg_config(tmp_path):
+    """Prepare-тесты не должны наследовать repository-home policy разработчика."""
+    home = tmp_path / "developer-config/rag-reviewer/repos/o/r.yml"
+    home.parent.mkdir(parents=True)
+    home.write_text("task_board: {type: yougile}\n", encoding="utf-8")
+    env = {**os.environ, "XDG_CONFIG_HOME": str(tmp_path / "developer-config")}
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "pytest",
+            "-q",
+            "-p",
+            "no:cacheprovider",
+            "tests/services/test_review_service.py::test_prepare_task_keys_none_without_task_board",
+        ],
+        cwd=Path(__file__).parents[2],
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stdout + result.stderr
 
 
 # ---------------------------------------------------------------------------

--- a/tests/web/test_history.py
+++ b/tests/web/test_history.py
@@ -143,6 +143,7 @@ def test_record_run_defaults_missing_outcome_keys():
         def __enter__(self): return self
         def __exit__(self, *a): return False
         def execute(self, sql, row=None):
+            captured["run_sql"] = sql
             captured["run_row"] = row
             class _R:
                 def fetchone(self_inner): return (1,)
@@ -156,7 +157,101 @@ def test_record_run_defaults_missing_outcome_keys():
     # _sample_findings() без outcome → в строках дефолт None по обоим ключам.
     assert all(r["outcome"] is None and r["reject_reason"] is None
                for r in captured["rows"])
+    assert "usage, config_sources, total_cost" in captured["run_sql"]
+    assert "%(usage)s, %(config_sources)s, %(total_cost)s" in captured["run_sql"]
     assert json.loads(captured["run_row"]["config_sources"]) == _sample_run()["config_sources"]
+
+
+@pytest.mark.parametrize("missing", [True, False], ids=["missing", "none"])
+def test_record_run_defaults_missing_or_none_config_sources(missing: bool) -> None:
+    """Старые и частично заполненные вызовы пишут provenance как пустой объект."""
+    history = ReviewHistory("postgresql://bad:bad@localhost:1/nonexistent")
+    captured = {}
+
+    class _Conn:
+        def __enter__(self): return self
+        def __exit__(self, *a): return False
+        def execute(self, sql, row=None):
+            captured["run_row"] = row
+
+            class _Result:
+                def fetchone(self_inner): return (1,)
+
+            return _Result()
+        def commit(self): pass
+
+    run = _sample_run()
+    if missing:
+        run.pop("config_sources")
+    else:
+        run["config_sources"] = None
+
+    with patch.object(history, "_connect", return_value=_Conn()):
+        assert history.record_run(run, []) == 1
+
+    assert json.loads(captured["run_row"]["config_sources"]) == {}
+
+
+class _Column:
+    def __init__(self, name: str) -> None:
+        self.name = name
+
+
+class _ReadCursor:
+    def __init__(self, responses: list[tuple[list[str], list[tuple]]], sql: list[str]) -> None:
+        self._responses = iter(responses)
+        self._sql = sql
+        self._rows: list[tuple] = []
+        self.description: list[_Column] = []
+
+    def __enter__(self): return self
+    def __exit__(self, *args): return False
+
+    def execute(self, sql: str, params: dict) -> None:
+        self._sql.append(sql)
+        columns, self._rows = next(self._responses)
+        self.description = [_Column(name) for name in columns]
+
+    def fetchall(self) -> list[tuple]:
+        return self._rows
+
+    def fetchone(self) -> tuple | None:
+        return self._rows[0] if self._rows else None
+
+
+class _ReadConnection:
+    def __init__(self, cursor: _ReadCursor) -> None:
+        self._cursor = cursor
+
+    def __enter__(self): return self
+    def __exit__(self, *args): return False
+    def cursor(self) -> _ReadCursor: return self._cursor
+
+
+def test_list_runs_maps_legacy_null_config_sources_to_empty_object() -> None:
+    """Старые строки с SQL NULL получают публичный совместимый пустой provenance."""
+    history = ReviewHistory("postgresql://bad:bad@localhost:1/nonexistent")
+    sql: list[str] = []
+    cursor = _ReadCursor([(["id", "config_sources"], [(1, None)])], sql)
+
+    with patch.object(history, "_connect", return_value=_ReadConnection(cursor)):
+        assert history.list_runs() == [{"id": 1, "config_sources": {}}]
+
+    assert "COALESCE(config_sources, '{}'::jsonb) AS config_sources" in sql[0]
+
+
+def test_get_run_maps_legacy_null_config_sources_to_empty_object() -> None:
+    """Деталь прогона также нормализует provenance старой SQL-строки."""
+    history = ReviewHistory("postgresql://bad:bad@localhost:1/nonexistent")
+    sql: list[str] = []
+    cursor = _ReadCursor(
+        [(["id", "config_sources"], [(1, None)]), (["id"], [])], sql,
+    )
+
+    with patch.object(history, "_connect", return_value=_ReadConnection(cursor)):
+        assert history.get_run(1) == {"id": 1, "config_sources": {}, "findings": []}
+
+    assert "COALESCE(config_sources, '{}'::jsonb) AS config_sources" in sql[0]
 
 
 @pytest.mark.integration
@@ -218,6 +313,27 @@ def test_record_run_self_migrates_missing_columns():
     finally:
         # Восстанавливаем схему независимо от исхода, чтобы падение теста не
         # каскадировало на последующие integration-тесты (не полагаемся на self-heal).
+        ReviewHistory(dsn).init_schema()
+
+
+@pytest.mark.integration
+def test_record_run_self_migrates_missing_config_sources_column():
+    """Новый history writer домигрирует provenance-колонку старой review_runs."""
+    import psycopg
+
+    dsn = Settings().pg_dsn
+    ReviewHistory(dsn).init_schema()
+    with psycopg.connect(dsn) as conn:
+        conn.execute("ALTER TABLE review_runs DROP COLUMN IF EXISTS config_sources")
+        conn.commit()
+
+    try:
+        history = ReviewHistory(dsn)
+        run_id = history.record_run(_sample_run(), [])
+
+        assert run_id is not None
+        assert history.get_run(run_id)["config_sources"] == _sample_run()["config_sources"]
+    finally:
         ReviewHistory(dsn).init_schema()
 
 

--- a/tests/web/test_history.py
+++ b/tests/web/test_history.py
@@ -6,6 +6,7 @@ Unit fail-soft мокает `_connect`; integration проверяет запи�
 """
 from __future__ import annotations
 
+import json
 from datetime import datetime, timezone
 from unittest.mock import patch
 
@@ -43,6 +44,11 @@ def _sample_run() -> dict:
         "comments_summary": 1,
         "usage": {"analyze": {"calls": 3, "input_tokens": 1000, "output_tokens": 200,
                                "cache_read_tokens": 0, "cost": 0.01}},
+        "config_sources": {
+            "sources": {"paths": "home:repos/owner/repo.yml"},
+            "shadowed": {"paths": [".review.yml"]},
+            "warnings": [],
+        },
         "total_cost": 0.01,
         "error_text": None,
     }
@@ -137,6 +143,7 @@ def test_record_run_defaults_missing_outcome_keys():
         def __enter__(self): return self
         def __exit__(self, *a): return False
         def execute(self, sql, row=None):
+            captured["run_row"] = row
             class _R:
                 def fetchone(self_inner): return (1,)
             return _R()
@@ -149,6 +156,7 @@ def test_record_run_defaults_missing_outcome_keys():
     # _sample_findings() без outcome → в строках дефолт None по обоим ключам.
     assert all(r["outcome"] is None and r["reject_reason"] is None
                for r in captured["rows"])
+    assert json.loads(captured["run_row"]["config_sources"]) == _sample_run()["config_sources"]
 
 
 @pytest.mark.integration
@@ -168,6 +176,7 @@ def test_record_and_get_run_persists_outcome():
     ]
     run_id = history.record_run(_sample_run(), findings)
     result = history.get_run(run_id)
+    assert result["config_sources"]["sources"]["paths"] == "home:repos/owner/repo.yml"
     by_outcome = {f["outcome"]: f for f in result["findings"]}
     assert by_outcome["published_inline"]["reject_reason"] is None
     assert by_outcome["verify_rejected"]["reject_reason"] == "line does not exist"


### PR DESCRIPTION
Task: [PRI-221](https://ru.yougile.com/team/686c049c8af8/#PRI-221)

## Summary

- add global and per-repository home policy layers with exact provenance and top-level replacement
- wire one effective policy through review, index, MCP sessions, CLI inspection/migration, and history audit
- harden migration against invalid policy, mutable refs, dotted repo collisions, unsafe paths, secret leakage, and concurrent publication
- update configure-review skill plus English/Russian operator documentation

## Verification

- 2720 passed, 1 skipped, 93 deselected
- Ruff: clean
- Codex plugin manifest check: clean
- final whole-branch review: approved

Task: PRI-221