### PR TITLE
refactor(skills): убрать дублирование reviewer из имён (PRI-227)

### DIFF
--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "rag-reviewer",
-  "version": "0.4.2+codex.d174a66ebfd3",
+  "version": "0.4.2+codex.e01aedcc17e0",
   "description": "Agentic PR review: hybrid RAG + code graph via MCP, review skills for Codex",
   "repository": "https://github.com/mimfort/rag_for_git",
   "license": "MIT",

--- a/.kimi-code/INSTALL.md
+++ b/.kimi-code/INSTALL.md
@@ -68,7 +68,8 @@ tar xz -C ~/.kimi-code/skills --strip-components=3 -f /tmp/rag-reviewer.tgz 'rag
 rm /tmp/rag-reviewer.tgz
 ```
 
-Skills installed: `reviewer_review-pr`, `reviewer_solve-task`, `reviewer_sync-codebase`, `reviewer_sync-tasks`, `reviewer_performance-review`, `reviewer_maintainability-review`.
+Skills installed: `review-pr`, `solve-task`, `sync-codebase`, `sync-tasks`,
+`performance-review`, `maintainability-review`.
 
 ## Обновление
 

--- a/.mimocode/INSTALL.md
+++ b/.mimocode/INSTALL.md
@@ -67,7 +67,8 @@ tar xz -C ~/.config/mimocode/skills --strip-components=3 -f /tmp/rag-reviewer.tg
 rm /tmp/rag-reviewer.tgz
 ```
 
-Skills installed: `reviewer_review-pr`, `reviewer_solve-task`, `reviewer_sync-codebase`, `reviewer_sync-tasks`, `reviewer_performance-review`, `reviewer_maintainability-review`.
+Skills installed: `review-pr`, `solve-task`, `sync-codebase`, `sync-tasks`,
+`performance-review`, `maintainability-review`.
 
 ## Verify
 

--- a/.opencode/INSTALL.md
+++ b/.opencode/INSTALL.md
@@ -52,4 +52,5 @@ uvx --from rag-reviewer reviewer install-skills opencode
 ```
 
 (or `reviewer install opencode`, which sets up the MCP server and the skills together).
-Then restart OpenCode and run `opencode debug skill` — the `reviewer_*` skills should be listed.
+Then restart OpenCode and run `opencode debug skill` — short names such as `review-pr` and
+`solve-task` should be listed.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -52,14 +52,15 @@ registered skills.
 
 Available skills include:
 
-- `rag-reviewer:reviewer_review-pr`
-- `rag-reviewer:reviewer_solve-task`
-- `rag-reviewer:reviewer_sync-codebase`
-- `rag-reviewer:reviewer_sync-tasks`
-- `rag-reviewer:reviewer_performance-review`
-- `rag-reviewer:reviewer_maintainability-review`
-- `rag-reviewer:reviewer_ask`
-- `rag-reviewer:reviewer_pr-walkthrough`
-- `rag-reviewer:reviewer_configure-review`
-- `rag-reviewer:reviewer_summarize-subsystems`
-- `rag-reviewer:reviewer_finish-task`
+- `rag-reviewer:review-pr`
+- `rag-reviewer:solve-task`
+- `rag-reviewer:sync-codebase`
+- `rag-reviewer:sync-tasks`
+- `rag-reviewer:performance-review`
+- `rag-reviewer:maintainability-review`
+- `rag-reviewer:ask`
+- `rag-reviewer:pr-walkthrough`
+- `rag-reviewer:configure-review`
+- `rag-reviewer:summarize-subsystems`
+- `rag-reviewer:create-task`
+- `rag-reviewer:finish-task`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,7 +53,7 @@ reviewer-mcp                               # запустить MCP-сервер
 
 # Ревью через Claude Code-плагин:
 # 1. Открыть репозиторий как проект в Claude Code
-# 2. Использовать скилл /rag-reviewer:reviewer_review-pr (из plugin/)
+# 2. Использовать скилл /rag-reviewer:review-pr (из plugin/)
 #    Плагин вызывает prepare_review → analyze (Claude subagents) → publish_review
 
 # На хосте (для разработки фронта): pip install -e ".[web]" && (cd web/frontend && npm install && npm run build) && reviewer serve
@@ -77,7 +77,7 @@ production-сред. Сервисы Compose для разработки и те�
 
 Ядро — библиотека `reviewer/`, собираемая в `reviewer/app.py::build_components(settings)` из `Settings` (pydantic-settings, `.env`). Точка входа — `reviewer/entrypoints/cli.py` (Click) и `reviewer/entrypoints/mcp_server.py` (FastMCP).
 
-Поток ревью: **prepare_review** (MCP) → **analyze** (Claude subagents через скилл `/rag-reviewer:reviewer_review-pr`) → **publish_review** (MCP).
+Поток ревью: **prepare_review** (MCP) → **analyze** (Claude subagents через скилл `/rag-reviewer:review-pr`) → **publish_review** (MCP).
 
 1. **prepare** — `ReviewService.prepare`: `GitHubProvider` тянет PR (base/head sha), изменённые `.py` чанкуются (tree-sitter) и эмбеддятся (Voyage) в `ref="pr:N"`. Возвращает `PreparedReview` с юнитами, policy, patches.
 2. **analyze** — Claude Code-скилл (fan-out на subagents): каждый файл ревьюится параллельно с инструментами `search_code`, `get_related_symbols`, `read_file`, `get_definition`, `find_callers`, `get_changed_file_diff` через MCP.
@@ -144,10 +144,10 @@ MCP-сессия (PreparedReview + ToolContext) живёт в процессе `
 - **Наблюдаемость (`reviewer/web/`)**: каждый `publish_review` пишет в Postgres итоги прогона (`review_runs`/`review_findings`, гейт `REVIEW_HISTORY`) — fail-soft. Веб-админка (FastAPI `reviewer serve`) читает **ту же** БД.
 - **Полная воронка находок в `review_findings` (outcome/reject_reason).** `review_findings` персистит **каждого кандидата**, а не только опубликованных: колонка `outcome` — терминальный исход одного из 6 состояний (`published_inline`/`published_summary`/`verify_rejected`/`gate_dropped`/`deduped`/`already_posted`), `reject_reason` — причина отсева (текст верификатора при `verify_rejected` через `VerdictIn.reason`; сработавшее правило политики через `ReviewPolicy.gate_reason` при `gate_dropped`; иначе `NULL`). Учёт — чистый юнит `reviewer/agent/outcomes.py::account_outcomes`, инвариант `len(rows) == len(candidates)` (сумма по 6 исходам = числу кандидатов). **`deduped`-разность считается по IDENTITY (`id()`), не по fingerprint**: точный дубль имеет тот же fingerprint, что выживший (`dedup_findings` возвращает те же объекты), поэтому fingerprint-diff недосчитал бы схлопнутые. `outcome` — новое поле-истина; старые `is_real`/`published`/`inline` заполняются как прежде (обратная совместимость). Миграция аддитивна/идемпотентна (`ADD COLUMN IF NOT EXISTS` + best-effort бэкфилл). При `status='error'` строки хранят намеченный `outcome`, но `published=False`.
 - **MCP-сессия живёт в процессе сервера** между `prepare_review` и `publish_review` одного PR: `_Session(prepared, ctx)` в `MCPReviewService._sessions`. При повторном `prepare_review` для того же (repo, pr) сессия перезаписывается, старый VCS-провайдер закрывается (fail-soft).
-- **Плагин** находится в `plugin/` в корне репозитория — это корень Claude Code-плагина для скилла `/rag-reviewer:reviewer_review-pr`.
+- **Плагин** находится в `plugin/` в корне репозитория — это корень Claude Code-плагина для скилла `/rag-reviewer:review-pr`.
 - **Общие reference-блоки промптов** вынесены в `plugin/skills/_common/` (единый источник: `findings-schema.md`, `anti-hallucination.md`, `tool-usage.md`, `branch-selection.md`). Скиллы и reference-промпты подключают их маркером `<!-- include: _common/<file>.md -->` (путь от `plugin/skills/`), который LLM-оркестратор разворачивает verbatim при сборке промпта субагента; скилл-специфичные части остаются в самих скиллах. Соответствие findings-schema ↔ `Finding` (`reviewer/vcs/base.py`) и корректность сборки промптов охраняют guard-тесты в `tests/skills/`.
 - **Мульти-платформа VCS (GitHub + GitLab).** Тип провайдера — свойство репо, не PR. `reviewer index` определяет платформу из `git remote` (`derive_vcs_from_remote`) и пишет в таблицу `repo_vcs(repo→provider,base_url)`. При ревью (API-only движок) `_create_vcs_provider` читает `repo_vcs` ДО любого API-вызова и выбирает `GitHubProvider`/`GitLabProvider`; токен — из ENV по платформе (`GITHUB_TOKEN`/`GITLAB_TOKEN`, `GITLAB_URL` для self-hosted). Фолбэк при пустом `repo_vcs` — `VCS_PROVIDER` (дефолт github), что сохраняет обратную совместимость. Секретов в `.review.yml` нет (нет блока `vcs:`).
-- **Закрытие задачи после PR (`finish_task`).** Скилл `/reviewer_finish-task` после создания PR
+- **Закрытие задачи после PR (`finish_task`).** Скилл `/rag-reviewer:finish-task` после создания PR
   идемпотентно дописывает PR-ссылку и запрашивает generic done target через server-side MCP-тул
   `finish_task(..., board_type, target, provider_options)`. Провайдер возвращает отдельные
   `pr_link_added`, `done_set`, `already_closed` и warnings; общий слой затем делает write-through

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -49,9 +49,10 @@ tar xz -C ~/.gemini/skills --strip-components=3 -f /tmp/rag-reviewer.tgz 'rag_fo
 rm /tmp/rag-reviewer.tgz
 ```
 
-Skills installed: `reviewer_review-pr`, `reviewer_solve-task`, `reviewer_sync-codebase`, `reviewer_sync-tasks`, `reviewer_performance-review`, `reviewer_maintainability-review`.
+Skills installed: `review-pr`, `solve-task`, `sync-codebase`, `sync-tasks`,
+`performance-review`, `maintainability-review`.
 
-Then use them: `use skill rag-reviewer:reviewer_review-pr`
+Then use them: `use skill rag-reviewer:review-pr`
 
 ## Verify
 

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ stores run locally; embedding and reranking requests go to Voyage.
 
    Indexing initializes the `chunks` schema that `reviewer check` queries, so a fresh installation
    must index before checking. The check currently requires `GITHUB_TOKEN`, even for a GitLab-only
-   setup; validate `GITLAB_TOKEN` with a dry-run `reviewer_review-pr` against a GitLab MR until
+   setup; validate `GITLAB_TOKEN` with a dry-run `/rag-reviewer:review-pr` against a GitLab MR until
    that limitation is removed. The status payload should show an indexed SHA and `drift == 0`.
    Full indexing sends code chunks to Voyage and can be slow on its free tier. Without a base
    index, PR review has only the diff and its temporary changed-file index (overlay), and therefore
@@ -66,10 +66,10 @@ stores run locally; embedding and reranking requests go to Voyage.
 
    ```text
    # Claude Code
-   /rag-reviewer:reviewer_review-pr owner/repo#123 --dry-run
+   /rag-reviewer:review-pr owner/repo#123 --dry-run
 
    # Codex
-   $rag-reviewer:reviewer_review-pr owner/repo#123
+   $rag-reviewer:review-pr owner/repo#123
    ```
 
    Invocation syntax differs by client. A dry run returns grounded findings without publishing;
@@ -139,37 +139,37 @@ boundaries and confirmation gates; the MCP server performs storage, graph, VCS, 
 
 ### Review a pull request
 
-Use `reviewer_review-pr` for bug finding. It prepares a PR session, retrieves code and graph
+Use `review-pr` for bug finding. It prepares a PR session, retrieves code and graph
 context, analyzes changed files, verifies candidate findings, and publishes only grounded results.
 Use `--dry-run` first when validating a deployment. Inline comments can target only commentable
 diff lines; off-diff findings go to the summary.
 
 ### Solve a task
 
-Use `reviewer_solve-task` to turn a board task or free-text request into a persisted brief before
+Use `solve-task` to turn a board task or free-text request into a persisted brief before
 development. It checks index freshness, warms task context, gathers related work and code, then
 hands the brief to brainstorming. It does not implement the task by itself.
 
 ### Ask a grounded codebase question
 
-Use `reviewer_ask` for onboarding and codebase Q&A. Answers cite real `path:line` locations from
+Use `ask` for onboarding and codebase Q&A. Answers cite real `path:line` locations from
 the base index and code graph. It reads and explains; it neither reviews a PR nor modifies code.
 
 ### Walk a human reviewer through a PR
 
-Use `reviewer_pr-walkthrough` for a reading guide: where to start, what each file changes, and
+Use `pr-walkthrough` for a reading guide: where to start, what each file changes, and
 which callers are affected. It is intentionally separate from bug review.
 
 ### Run a focused review
 
-Use `reviewer_performance-review` for repeated I/O, N+1 work, poor asymptotics, batching, caching,
-and memory risks. Use `reviewer_maintainability-review` for complexity, duplication, readability,
+Use `performance-review` for repeated I/O, N+1 work, poor asymptotics, batching, caching,
+and memory risks. Use `maintainability-review` for complexity, duplication, readability,
 separation of concerns, and repository conventions. Both stay within the requested dimension.
 
 ### Create and finish board tasks
 
-`reviewer_create-task` drafts a canonical task body and writes only after confirmation.
-`reviewer_finish-task` links the PR, moves the task to a discovered done target, adds a task link
+`create-task` drafts a canonical task body and writes only after confirmation.
+`finish-task` links the PR, moves the task to a discovered done target, adds a task link
 to the PR body, and re-syncs the task corpus—also only after confirmation.
 
 ### Reviewer grounding in plan/review phases (optional)
@@ -266,6 +266,12 @@ claude plugin marketplace list --json
 
 After installation, start a new chat/CLI session; in an IDE, also use Reload Window.
 
+### Breaking skill-name migration
+
+This release removes the redundant `reviewer_` segment from every skill name. Legacy skill
+invocations are unsupported: update the plugin/cache, use the short names listed below, then open
+a New Chat or new CLI session. In an IDE, also use Reload Window.
+
 ### Required services and credentials
 
 Run `reviewer init` to write the selected env file and `reviewer check` to validate it. Resolution
@@ -315,7 +321,7 @@ context_limits:
     hops: 1
 ```
 
-Use `reviewer_configure-review` to update context fields without clobbering unrelated keys.
+Use `configure-review` to update context fields without clobbering unrelated keys.
 
 ### Task boards
 
@@ -375,101 +381,101 @@ Use `reviewer COMMAND --help` for the current option set. `status` does not spen
 The examples below use Claude-style `/rag-reviewer:...` invocation. Codex exposes the same
 namespaced skills with `$rag-reviewer:...`.
 
-### `reviewer_review-pr` — full PR review
+### `review-pr` — full PR review
 
 - **When:** find correctness, security, performance, and maintainability issues in a PR.
-- **Invoke:** `/rag-reviewer:reviewer_review-pr owner/repo#123 --dry-run`.
+- **Invoke:** `/rag-reviewer:review-pr owner/repo#123 --dry-run`.
 - **Needs:** reviewer MCP, VCS access, stores, and preferably a fresh base index/graph.
 - **Reads/writes:** reads PR/code/task context; publishes through `publish_review` unless dry-run.
 - **Result:** grounded inline comments plus a summary; deterministic publish handles dedup.
 
-### `reviewer_solve-task` — task to development brief
+### `solve-task` — task to development brief
 
 - **When:** start implementation from a key such as `PRI-220` or a free-text request.
-- **Invoke:** `/rag-reviewer:reviewer_solve-task PRI-220`.
+- **Invoke:** `/rag-reviewer:solve-task PRI-220`.
 - **Needs:** reviewer MCP; board context is optional and the pipeline continues board-less.
 - **Reads/writes:** reads task/code context and writes one brief under `docs/superpowers/briefs/`.
 - **Result:** a compact brief handed to brainstorming; implementation happens in later skills.
 
-### `reviewer_ask` — grounded codebase Q&A
+### `ask` — grounded codebase Q&A
 
 - **When:** ask where code lives or how a subsystem works.
-- **Invoke:** `/rag-reviewer:reviewer_ask how does index freshness work?`.
+- **Invoke:** `/rag-reviewer:ask how does index freshness work?`.
 - **Needs:** a built base index and graph.
 - **Reads/writes:** reads repository context and local files; does not modify or review code.
 - **Result:** a Russian explanation with real `path:line` citations.
 
-### `reviewer_pr-walkthrough` — human reading guide
+### `pr-walkthrough` — human reading guide
 
 - **When:** orient a human reviewer without running a bug review.
-- **Invoke:** `/rag-reviewer:reviewer_pr-walkthrough owner/repo#123`.
+- **Invoke:** `/rag-reviewer:pr-walkthrough owner/repo#123`.
 - **Needs:** reviewer MCP, PR access, base index, and graph.
 - **Reads/writes:** reads impact/diffs/callers; posts only on explicit request.
 - **Result:** centrality-first reading order, per-file summary, and grounded impact notes.
 
-### `reviewer_performance-review` — performance-only review
+### `performance-review` — performance-only review
 
 - **When:** inspect a diff for repeated work, N+1 I/O, asymptotics, batching, caching, or memory.
-- **Invoke:** `/rag-reviewer:reviewer_performance-review`.
+- **Invoke:** `/rag-reviewer:performance-review`.
 - **Needs:** a diff/PR or explicit change scope; reviewer context is fail-open.
 - **Reads/writes:** reads the selected changes and nearby context; does not publish by itself.
 - **Result:** only concrete performance findings, with assumptions stated.
 
-### `reviewer_maintainability-review` — maintainability-only review
+### `maintainability-review` — maintainability-only review
 
 - **When:** inspect complexity, readability, duplication, boundaries, and repository conventions.
-- **Invoke:** `/rag-reviewer:reviewer_maintainability-review`.
+- **Invoke:** `/rag-reviewer:maintainability-review`.
 - **Needs:** a diff/PR or explicit change scope plus repository guidance.
 - **Reads/writes:** reads changes and nearby patterns; does not change behavior.
 - **Result:** focused simplification findings, excluding unrelated correctness/performance advice.
 
-### `reviewer_create-task` — create a canonical board task
+### `create-task` — create a canonical board task
 
 - **When:** file a grounded task on the configured board.
-- **Invoke:** `/rag-reviewer:reviewer_create-task describe the requested change`.
+- **Invoke:** `/rag-reviewer:create-task describe the requested change`.
 - **Needs:** registered board config, discovered create target/options, and project credentials.
 - **Reads/writes:** reads code for evidence; calls `create_task` only after explicit confirmation.
 - **Result:** canonical body, task key/URL, and a refreshed task corpus.
 
-### `reviewer_finish-task` — close a task after its PR
+### `finish-task` — close a task after its PR
 
 - **When:** a PR exists and the board task should be linked and completed.
-- **Invoke:** `/rag-reviewer:reviewer_finish-task PRI-220 https://github.com/owner/repo/pull/123`.
+- **Invoke:** `/rag-reviewer:finish-task PRI-220 https://github.com/owner/repo/pull/123`.
 - **Needs:** task key, PR URL, registered board config, and discovered done target/options.
 - **Reads/writes:** after explicit confirmation, appends the PR idempotently, updates the task,
   prepends a task backlink to the PR body, and re-syncs.
 - **Result:** done state plus `already_closed`/`task_link_added` reporting without duplicate links.
 
-### `reviewer_sync-codebase` — build or update the base index
+### `sync-codebase` — build or update the base index
 
 - **When:** initialize an index, refresh stale code, or rebuild the graph.
-- **Invoke:** `/rag-reviewer:reviewer_sync-codebase --path /srv/repo --ref main`.
+- **Invoke:** `/rag-reviewer:sync-codebase --path /srv/repo --ref main`.
 - **Needs:** git clone, `uvx`, reviewer services, Voyage, and optional SCIP.
 - **Reads/writes:** reads the selected git ref and writes branch-scoped vectors/graph nodes.
 - **Result:** incremental index report; failures name the missing prerequisite.
 
-### `reviewer_sync-tasks` — warm task vectors and graph
+### `sync-tasks` — warm task vectors and graph
 
 - **When:** synchronize a configured board before task search or solve-task.
-- **Invoke:** `/rag-reviewer:reviewer_sync-tasks`.
+- **Invoke:** `/rag-reviewer:sync-tasks`.
 - **Needs:** use `reviewer init`, configure the selected provider as documented in
   `docs/board-providers.md`, then validate it with `reviewer check`.
 - **Reads/writes:** calls idempotent server-side `sync_board`; it reads the board and does not write
   back.
 - **Result:** compact counts and per-board warnings; missing config remains board-less/fail-open.
 
-### `reviewer_summarize-subsystems` — GraphRAG subsystem summaries
+### `summarize-subsystems` — GraphRAG subsystem summaries
 
 - **When:** build or refresh the architectural prior used by Q&A and PR walkthroughs.
-- **Invoke:** `/rag-reviewer:reviewer_summarize-subsystems`.
+- **Invoke:** `/rag-reviewer:summarize-subsystems`.
 - **Needs:** a fresh base index, code graph, reviewer MCP, and confirmation of cluster depth.
 - **Reads/writes:** reads cluster symbols and writes grounded summaries to the summary store.
 - **Result:** fresh/pruned summaries with deferred and orphan reporting.
 
-### `reviewer_configure-review` — update `.review.yml`
+### `configure-review` — update `.review.yml`
 
 - **When:** tune ignored paths, retrieval limits, summary clustering, or board metadata.
-- **Invoke:** `/rag-reviewer:reviewer_configure-review`.
+- **Invoke:** `/rag-reviewer:configure-review`.
 - **Needs:** a git repository; MCP and databases are not required for baseline analysis.
 - **Reads/writes:** reads tracked Python structure/history and changes only approved YAML fields.
 - **Result:** preserved foreign keys/comments plus exact rebuild guidance.
@@ -508,7 +514,7 @@ uncommitted files directly from disk.
 | `reviewer check` reports Postgres/Neo4j unavailable | Default stores are not running or DSNs differ | Run `docker compose up -d`, then repeat `reviewer check` |
 | Voyage returns 429 | Free-tier RPM/TPM quota is exhausted | Wait for the quota window; rerun incremental indexing rather than deleting the index |
 | PR is skipped | Its target branch is outside `REVIEW_BRANCHES`, or draft policy skips it | Inspect `prepare_review` reason and update policy only if the target is intentional |
-| Task lookup is empty | Board is disabled/unconfigured or the corpus is cold | Validate [board setup](docs/board-providers.md), then run `reviewer_sync-tasks` |
+| Task lookup is empty | Board is disabled/unconfigured or the corpus is cold | Validate [board setup](docs/board-providers.md), then run `/rag-reviewer:sync-tasks` |
 | Q&A misses new local code | Base index contains only a committed ref | Read the local file or commit/index the intended branch |
 | AI client cannot see new skills | Client session predates installation | Start a New Chat/new CLI session; use Reload Window in an IDE |
 
@@ -549,7 +555,7 @@ errors are reported without preventing the process from starting where fail-soft
 - OAuth loopback flows are not supported in headless/SSH integrations; use documented PAT/API-key
   credentials.
 - `reviewer check` currently validates `GITHUB_TOKEN` and the GitHub API even in a GitLab-only
-  deployment; validate `GITLAB_TOKEN` with a dry-run `reviewer_review-pr` against a GitLab MR.
+  deployment; validate `GITLAB_TOKEN` with a dry-run `/rag-reviewer:review-pr` against a GitLab MR.
 - Board work is optional. Missing provider configuration keeps task-aware skills board-less rather
   than blocking code retrieval.
 

--- a/README.ru.md
+++ b/README.ru.md
@@ -57,7 +57,7 @@ inline-комментарии, привязанные к изменённым с
    Индексация создаёт схему `chunks`, которую запрашивает `reviewer check`, поэтому в свежей
    установке сначала нужен index. Сейчас check требует `GITHUB_TOKEN` даже для GitLab-only
    конфигурации; до снятия этого ограничения проверяйте `GITLAB_TOKEN` через dry-run
-   `reviewer_review-pr` для GitLab MR. Status payload должен показать indexed SHA и `drift == 0`.
+   `/rag-reviewer:review-pr` для GitLab MR. Status payload должен показать indexed SHA и `drift == 0`.
    Полная индексация отправляет чанки кода в Voyage и может быть медленной на free tier. Без base
    index ревью видит только дифф и временный индекс изменённых файлов (overlay), поэтому получает
    более узкий контекст репозитория.
@@ -66,10 +66,10 @@ inline-комментарии, привязанные к изменённым с
 
    ```text
    # Claude Code
-   /rag-reviewer:reviewer_review-pr owner/repo#123 --dry-run
+   /rag-reviewer:review-pr owner/repo#123 --dry-run
 
    # Codex
-   $rag-reviewer:reviewer_review-pr owner/repo#123
+   $rag-reviewer:review-pr owner/repo#123
    ```
 
    Синтаксис вызова зависит от клиента. Dry run возвращает обоснованные findings без публикации;
@@ -142,37 +142,37 @@ VCS и доской.
 
 ### Ревью pull request
 
-Используйте `reviewer_review-pr` для поиска багов. Skill готовит PR-сессию, подтягивает код и
+Используйте `review-pr` для поиска багов. Skill готовит PR-сессию, подтягивает код и
 графовый контекст, анализирует изменённые файлы, проверяет findings и публикует только обоснованный
 результат. Для проверки deployment начните с `--dry-run`. Inline-комментарии возможны только на
 commentable строках диффа; off-diff findings уходят в сводку.
 
 ### Решение задачи
 
-`reviewer_solve-task` превращает задачу доски или текстовый запрос в сохраняемый brief до начала
+`solve-task` превращает задачу доски или текстовый запрос в сохраняемый brief до начала
 разработки. Skill проверяет свежесть индекса, прогревает task context, собирает related work и код,
 затем передаёт brief в brainstorming. Саму задачу этот skill не реализует.
 
 ### Обоснованный вопрос по кодовой базе
 
-`reviewer_ask` подходит для онбординга и Q&A. Ответы ссылаются на реальные `path:line` из base
+`ask` подходит для онбординга и Q&A. Ответы ссылаются на реальные `path:line` из base
 index и code graph. Skill читает и объясняет, но не ревьюит PR и не изменяет код.
 
 ### Гид по PR для ревьюера
 
-`reviewer_pr-walkthrough` строит порядок чтения: с чего начать, что меняет каждый файл и на каких
+`pr-walkthrough` строит порядок чтения: с чего начать, что меняет каждый файл и на каких
 callers влияет правка. Это отдельный сценарий, а не bug review.
 
 ### Сфокусированное ревью
 
-`reviewer_performance-review` ищет повторный I/O, N+1, плохую асимптотику, проблемы batching,
-caching и памяти. `reviewer_maintainability-review` ищет сложность, дублирование, проблемы
+`performance-review` ищет повторный I/O, N+1, плохую асимптотику, проблемы batching,
+caching и памяти. `maintainability-review` ищет сложность, дублирование, проблемы
 читаемости, границ и соглашений репозитория. Оба остаются в явно выбранном измерении.
 
 ### Создание и завершение задач доски
 
-`reviewer_create-task` собирает каноническое тело и пишет только после подтверждения.
-`reviewer_finish-task` добавляет PR, переводит задачу в обнаруженный done target, добавляет ссылку
+`create-task` собирает каноническое тело и пишет только после подтверждения.
+`finish-task` добавляет PR, переводит задачу в обнаруженный done target, добавляет ссылку
 на задачу в PR body и повторно синхронизирует корпус—тоже только после подтверждения.
 
 ### Грунтовка reviewer в фазах план/ревью (опционально)
@@ -269,6 +269,12 @@ claude plugin marketplace list --json
 
 После установки начните новую chat/CLI session; в IDE также выполните Reload Window.
 
+### Миграция с ломающим изменением имён скиллов
+
+В этом релизе из имени каждого скилла удалён избыточный сегмент `reviewer_`. Старые вызовы
+скиллов не поддерживаются: обновите plugin/cache, используйте короткие имена ниже, затем откройте
+New Chat или новую CLI-сессию. В IDE также выполните Reload Window.
+
 ### Сервисы и credentials
 
 `reviewer init` записывает выбранный env-файл, а `reviewer check` проверяет его. Порядок поиска:
@@ -318,7 +324,7 @@ context_limits:
     hops: 1
 ```
 
-`reviewer_configure-review` меняет context fields, сохраняя посторонние ключи.
+`configure-review` меняет context fields, сохраняя посторонние ключи.
 
 ### Доски задач
 
@@ -378,100 +384,100 @@ threshold, graph backend и retrieval ceilings меняют cost/recall; сна�
 Примеры ниже используют Claude-синтаксис `/rag-reviewer:...`. В Codex те же namespaced skills
 доступны как `$rag-reviewer:...`.
 
-### `reviewer_review-pr` — полное ревью PR
+### `review-pr` — полное ревью PR
 
 - **Когда:** найти correctness, security, performance и maintainability проблемы в PR.
-- **Вызов:** `/rag-reviewer:reviewer_review-pr owner/repo#123 --dry-run`.
+- **Вызов:** `/rag-reviewer:review-pr owner/repo#123 --dry-run`.
 - **Нужно:** reviewer MCP, VCS access, хранилища и желательно свежий base index/graph.
 - **Чтение/запись:** читает PR, код и task context; публикует через `publish_review`, кроме dry-run.
 - **Результат:** grounded inline comments и summary; deterministic publish выполняет dedup.
 
-### `reviewer_solve-task` — от задачи к brief разработки
+### `solve-task` — от задачи к brief разработки
 
 - **Когда:** начать реализацию по ключу `PRI-220` или текстовому запросу.
-- **Вызов:** `/rag-reviewer:reviewer_solve-task PRI-220`.
+- **Вызов:** `/rag-reviewer:solve-task PRI-220`.
 - **Нужно:** reviewer MCP; board context опционален, pipeline продолжает board-less.
 - **Чтение/запись:** читает task/code context и пишет один brief в `docs/superpowers/briefs/`.
 - **Результат:** компактный brief для brainstorming; реализация идёт в следующих skills.
 
-### `reviewer_ask` — обоснованный Q&A по коду
+### `ask` — обоснованный Q&A по коду
 
 - **Когда:** узнать, где лежит код или как устроена подсистема.
-- **Вызов:** `/rag-reviewer:reviewer_ask как работает свежесть индекса?`.
+- **Вызов:** `/rag-reviewer:ask как работает свежесть индекса?`.
 - **Нужно:** построенные base index и graph.
 - **Чтение/запись:** читает repo context и локальные файлы; не меняет и не ревьюит код.
 - **Результат:** русское объяснение с реальными `path:line`.
 
-### `reviewer_pr-walkthrough` — порядок чтения PR
+### `pr-walkthrough` — порядок чтения PR
 
 - **Когда:** провести ревьюера-человека по PR без bug review.
-- **Вызов:** `/rag-reviewer:reviewer_pr-walkthrough owner/repo#123`.
+- **Вызов:** `/rag-reviewer:pr-walkthrough owner/repo#123`.
 - **Нужно:** reviewer MCP, PR access, base index и graph.
 - **Чтение/запись:** читает impact/diffs/callers; постит только по явному запросу.
 - **Результат:** centrality-first порядок, per-file summary и grounded impact.
 
-### `reviewer_performance-review` — только performance
+### `performance-review` — только performance
 
 - **Когда:** проверить repeated work, N+1 I/O, asymptotics, batching, caching и memory.
-- **Вызов:** `/rag-reviewer:reviewer_performance-review`.
+- **Вызов:** `/rag-reviewer:performance-review`.
 - **Нужно:** diff/PR или явно выбранный scope; reviewer context fail-open.
 - **Чтение/запись:** читает изменения и ближайший контекст; сам не публикует.
 - **Результат:** только конкретные performance findings с явными assumptions.
 
-### `reviewer_maintainability-review` — только maintainability
+### `maintainability-review` — только maintainability
 
 - **Когда:** проверить complexity, readability, duplication, boundaries и repo conventions.
-- **Вызов:** `/rag-reviewer:reviewer_maintainability-review`.
+- **Вызов:** `/rag-reviewer:maintainability-review`.
 - **Нужно:** diff/PR или выбранный scope плюс локальные инструкции репозитория.
 - **Чтение/запись:** читает изменения и соседние patterns; не меняет behavior.
 - **Результат:** сфокусированные simplification findings без посторонних советов.
 
-### `reviewer_create-task` — создать каноническую задачу
+### `create-task` — создать каноническую задачу
 
 - **Когда:** завести grounded task на настроенной доске.
-- **Вызов:** `/rag-reviewer:reviewer_create-task опиши требуемое изменение`.
+- **Вызов:** `/rag-reviewer:create-task опиши требуемое изменение`.
 - **Нужно:** registered board config, обнаруженные create target/options и credentials.
 - **Чтение/запись:** читает код; вызывает `create_task` только после явного подтверждения.
 - **Результат:** каноническое тело, key/URL и обновлённый task corpus.
 
-### `reviewer_finish-task` — закрыть задачу после PR
+### `finish-task` — закрыть задачу после PR
 
 - **Когда:** PR готов и board task нужно связать и завершить.
-- **Вызов:** `/rag-reviewer:reviewer_finish-task PRI-220 https://github.com/owner/repo/pull/123`.
+- **Вызов:** `/rag-reviewer:finish-task PRI-220 https://github.com/owner/repo/pull/123`.
 - **Нужно:** task key, PR URL, registered board config и обнаруженный done target/options.
 - **Чтение/запись:** после подтверждения идемпотентно добавляет PR, обновляет задачу, добавляет
   task backlink в PR body и запускает sync.
 - **Результат:** done state и отчёт `already_closed`/`task_link_added` без duplicate links.
 
-### `reviewer_sync-codebase` — построить или обновить base index
+### `sync-codebase` — построить или обновить base index
 
 - **Когда:** создать индекс, обновить stale code или перестроить graph.
-- **Вызов:** `/rag-reviewer:reviewer_sync-codebase --path /srv/repo --ref main`.
+- **Вызов:** `/rag-reviewer:sync-codebase --path /srv/repo --ref main`.
 - **Нужно:** git clone, `uvx`, reviewer services, Voyage и опциональный SCIP.
 - **Чтение/запись:** читает выбранный git ref и пишет branch-scoped vectors/graph nodes.
 - **Результат:** incremental index report; ошибки называют отсутствующий prerequisite.
 
-### `reviewer_sync-tasks` — прогреть vectors и graph задач
+### `sync-tasks` — прогреть vectors и graph задач
 
 - **Когда:** синхронизировать доску перед task search или solve-task.
-- **Вызов:** `/rag-reviewer:reviewer_sync-tasks`.
+- **Вызов:** `/rag-reviewer:sync-tasks`.
 - **Нужно:** запустите `reviewer init`, настройте provider по `docs/board-providers.md`, затем
   проверьте его через `reviewer check`.
 - **Чтение/запись:** вызывает идемпотентный server-side `sync_board`; читает board и не пишет в неё.
 - **Результат:** компактные counts/warnings; отсутствие config остаётся board-less/fail-open.
 
-### `reviewer_summarize-subsystems` — GraphRAG summaries подсистем
+### `summarize-subsystems` — GraphRAG summaries подсистем
 
 - **Когда:** построить architectural prior для Q&A и PR walkthrough.
-- **Вызов:** `/rag-reviewer:reviewer_summarize-subsystems`.
+- **Вызов:** `/rag-reviewer:summarize-subsystems`.
 - **Нужно:** свежий base index, code graph, reviewer MCP и подтверждённый cluster depth.
 - **Чтение/запись:** читает symbols кластеров и пишет grounded summaries в summary store.
 - **Результат:** fresh/pruned summaries с отчётом deferred и orphans.
 
-### `reviewer_configure-review` — обновить `.review.yml`
+### `configure-review` — обновить `.review.yml`
 
 - **Когда:** настроить ignored paths, retrieval limits, summary clustering или board metadata.
-- **Вызов:** `/rag-reviewer:reviewer_configure-review`.
+- **Вызов:** `/rag-reviewer:configure-review`.
 - **Нужно:** git repo; MCP и databases не нужны для baseline analysis.
 - **Чтение/запись:** читает tracked Python structure/history и меняет только одобренные YAML fields.
 - **Результат:** сохранённые посторонние keys/comments и точная rebuild guidance.
@@ -510,7 +516,7 @@ Base indexes отслеживают committed refs, а не working-tree edits. 
 | `reviewer check` не видит Postgres/Neo4j | Stores не запущены или DSN отличается | Запустите `docker compose up -d`, затем повторите `reviewer check` |
 | Voyage отвечает 429 | Исчерпан free-tier RPM/TPM | Дождитесь quota window; повторите incremental index, не удаляя существующий |
 | PR пропущен | Target branch вне `REVIEW_BRANCHES` или draft policy его исключает | Прочитайте reason `prepare_review`; меняйте policy только для намеренной target branch |
-| Task lookup пуст | Board отключён/не настроен или corpus не прогрет | Проверьте [board setup](docs/board-providers.md), затем запустите `reviewer_sync-tasks` |
+| Task lookup пуст | Board отключён/не настроен или corpus не прогрет | Проверьте [board setup](docs/board-providers.md), затем запустите `/rag-reviewer:sync-tasks` |
 | Q&A не видит новый локальный код | Base index содержит только committed ref | Прочитайте локальный файл или commit/index нужную ветку |
 | AI-клиент не видит новые skills | Session открыта до установки | Начните New Chat/new CLI session; в IDE выполните Reload Window |
 
@@ -551,7 +557,7 @@ reviewer serve
 - OAuth loopback не поддерживается в headless/SSH integrations; используйте документированные
   PAT/API-key credentials.
 - Сейчас `reviewer check` проверяет `GITHUB_TOKEN` и GitHub API даже в GitLab-only deployment;
-  проверяйте `GITLAB_TOKEN` через dry-run `reviewer_review-pr` для GitLab MR.
+  проверяйте `GITLAB_TOKEN` через dry-run `/rag-reviewer:review-pr` для GitLab MR.
 - Board опционален. Без provider config task-aware skills продолжают board-less, а code retrieval
   не блокируется.
 

--- a/docs/superpowers/briefs/2026-07-31-PRI-227-remove-reviewer-skill-name-duplication.md
+++ b/docs/superpowers/briefs/2026-07-31-PRI-227-remove-reviewer-skill-name-duplication.md
@@ -1,0 +1,53 @@
+# Brief — PRI-227 Убрать дублирование reviewer из имён skills
+https://ru.yougile.com/team/686c049c8af8/#PRI-227
+
+## Task
+
+- Источник: reviewer store после sync; канонический ключ `ID-281`, alias `PRI-227`, статус «Бэклог».
+- Сохранить namespace `rag-reviewer`, но атомарно заменить каждый frontmatter `name: reviewer_*` на basename каталога (`ask`, `review-pr`, `solve-task`, включая будущий `decompose-task`).
+- Обновить cross-skill references, EN/RU README, CLAUDE.md, AGENTS.md, plugin README, hook attribution и test fixtures без смешения старой и новой схемы.
+- Добавить единый guard: имя frontmatter равно имени каталога, уникально и не начинается с `reviewer_`.
+- Проверить Claude/Codex payload и установку; описать breaking migration, cache/plugin update, New Chat/new CLI session и Reload Window для IDE.
+- Критерии в описании задачи, а не отдельном `criteria[]`; решение об alias допустимо только если нет двойного отображения.
+
+## Related work
+
+- PRI-143 — использовать прецедент унификации dimension-skills для атомарного удаления общего boilerplate во всех skill-поверхностях.
+- PRI-210 / PR mimfort/rag_for_git#104 — сохранить data-driven inventory `plugin/skills/*/SKILL.md` и проверку общего Claude/Codex payload при миграции имён.
+
+(dropped 5: PRI-142/164/273/161/114 близки по prompt/docs/task-контексту, но не задают migration skill invocation names.)
+
+## Subsystems
+
+- tests/skills — статические проверки содержимого skill prompts и общих reference-блоков; место для одного structure guard.
+- tests/install — фейковые Claude/Codex CLI и payload/install проверки без внешней инфраструктуры.
+- plugin/hooks — attribution для `rag-reviewer:solve-task`; требуется обновить строку при новом invocation name.
+
+## Relevant code
+
+- reviewer/install_codex.py:591 — snapshot validation перечисляет директории с `SKILL.md`; сохранить динамический discovery, добавив/покрыв новый инвариант имён.
+- reviewer/install_codex.py:637 — Codex payload обязан указывать `./skills/`, включать зарегистрированные skill directories и исключать `_common`.
+- reviewer/install_codex.py:774 — legacy-skill migration сопоставляет каталоги payload и установленного набора; проверить влияние переименованных frontmatter на upgrade/cache path.
+- reviewer/install.py:910 — tarball extraction возвращает имена каталогов, поэтому short invocation name должен следовать каталожному inventory, не отдельному registry.
+- reviewer/install.py:986 — skill payload hash строится по каталогам и файлам; массовое переименование frontmatter требует регенерации/cachebuster и проверки обновления.
+- reviewer/install_codex.py:1024 — Codex install верифицирует snapshot и установленный plugin до legacy migration; это blast radius для payload/manifest regression tests.
+
+(dropped 9: низкоуровневые JSON/symlink/config helpers и generic MCP lifecycle не меняют naming contract напрямую.)
+
+## Test exemplars
+
+- tests/install/test_codex_plugin_payload.py:268 — динамически собирает каталоги `plugin/skills/*/SKILL.md` и проверяет README markers; заменить ожидания `reviewer_{name}` на short names и добавить общий guard.
+- tests/skills/test_configure_review_skill.py:11 — точечная проверка старого `name: reviewer_configure-review`; заменить на общий test всех skills, а не новые per-skill assertions.
+- tests/install/test_install.py:629 — tarball fixture подтверждает, что installer возвращает basename каталога (`review-pr`); использовать для consistency между payload и invocation.
+- tests/install/test_skills_stamp.py:64 — fixture для stamp нескольких directory names; проверить обновление/установку mixed skill set после migration.
+
+(dropped 11: tests snapshot hardening, CLI stamps и unrelated installer cases не проверяют display/invocation name непосредственно.)
+
+## Constraints / open questions
+
+- `get_task_context(PRI-227)` не вернул linked tasks или touched code; related work дополнено семантическим search и PR-104 diff.
+- Поиск задачи вернул canonical `ID-281`; filename и heading сохраняют board key `PRI-227`.
+- Нужно подтвердить реальный platform contract для alias: добавлять его только если Claude/Codex не показывают две команды; иначе документировать breaking rename.
+- До изменения выполнить repo-wide поиск старых invocation strings, включая non-Python docs, hook metadata и fixtures: retrieval их покрывает неполно.
+
+Собран на: mid/gpt-5.6-terra, режим: subagent

--- a/docs/superpowers/plans/2026-07-31-pri-227-short-skill-names.md
+++ b/docs/superpowers/plans/2026-07-31-pri-227-short-skill-names.md
@@ -1,0 +1,568 @@
+# PRI-227 Short Skill Names Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace every duplicated `reviewer_*` skill name with its directory basename while keeping the `rag-reviewer` plugin namespace consistent across Claude Code, Codex, hooks, installers, tests, and active documentation.
+
+**Architecture:** Treat `plugin/skills/<name>/` as the only skill-name inventory and enforce `frontmatter.name == <name>` with one data-driven test. Keep one shared plugin payload for Claude and Codex, update all active references atomically, and regenerate the Codex payload digest instead of adding aliases, wrappers, or host-specific mappings.
+
+**Tech Stack:** Markdown/YAML skill files, Python 3.11+, pytest, existing Claude/Codex installer fakes, JSON plugin manifests.
+
+**Design:** `docs/superpowers/specs/2026-07-31-pri-227-short-skill-names-design.md`
+
+## Global Constraints
+
+- Keep the plugin namespace exactly `rag-reviewer`.
+- Every `plugin/skills/*/SKILL.md` frontmatter `name` must equal its parent-directory basename.
+- Skill names must be unique and must not start with `reviewer_`.
+- Do not add aliases, compatibility wrappers, or host-specific payload transforms.
+- Do not create the future `decompose-task` skill in PRI-227.
+- Do not rename skill directories.
+- Do not rewrite historical files under `docs/superpowers/briefs/`, `docs/superpowers/specs/`, or `docs/superpowers/plans/`.
+- Active Claude examples use `/rag-reviewer:<name>`; active Codex examples use `$rag-reviewer:<name>`.
+- Shared cross-skill prose and client-neutral runtime messages use `rag-reviewer:<name>` without inventing a client-specific alias.
+- Preserve the already-canonical hook attribution `rag-reviewer:solve-task`.
+- Use Russian comments, docstrings, and Conventional Commit messages; do not add self-attribution.
+- Unit tests must not access external services or localhost.
+
+The complete rename map is:
+
+| Directory | Old frontmatter name | New frontmatter name |
+|---|---|---|
+| `ask` | `reviewer_ask` | `ask` |
+| `configure-review` | `reviewer_configure-review` | `configure-review` |
+| `create-task` | `reviewer_create-task` | `create-task` |
+| `finish-task` | `reviewer_finish-task` | `finish-task` |
+| `maintainability-review` | `reviewer_maintainability-review` | `maintainability-review` |
+| `performance-review` | `reviewer_performance-review` | `performance-review` |
+| `pr-walkthrough` | `reviewer_pr-walkthrough` | `pr-walkthrough` |
+| `review-pr` | `reviewer_review-pr` | `review-pr` |
+| `solve-task` | `reviewer_solve-task` | `solve-task` |
+| `summarize-subsystems` | `reviewer_summarize-subsystems` | `summarize-subsystems` |
+| `sync-codebase` | `reviewer_sync-codebase` | `sync-codebase` |
+| `sync-tasks` | `reviewer_sync-tasks` | `sync-tasks` |
+
+---
+
+### Task 1: Make directory basenames the enforced skill-name contract
+
+**Files:**
+
+- Create: `tests/skills/test_skill_names.py`
+- Modify: `plugin/skills/ask/SKILL.md:1-3`
+- Modify: `plugin/skills/configure-review/SKILL.md:1-3`
+- Modify: `plugin/skills/create-task/SKILL.md:1-3`
+- Modify: `plugin/skills/finish-task/SKILL.md:1-3`
+- Modify: `plugin/skills/maintainability-review/SKILL.md:1-3`
+- Modify: `plugin/skills/performance-review/SKILL.md:1-3`
+- Modify: `plugin/skills/pr-walkthrough/SKILL.md:1-3`
+- Modify: `plugin/skills/review-pr/SKILL.md:1-3`
+- Modify: `plugin/skills/solve-task/SKILL.md:1-3`
+- Modify: `plugin/skills/summarize-subsystems/SKILL.md:1-3`
+- Modify: `plugin/skills/sync-codebase/SKILL.md:1-3`
+- Modify: `plugin/skills/sync-tasks/SKILL.md:1-3`
+- Modify: `tests/skills/test_configure_review_skill.py:1-15`
+- Modify: `tests/skills/test_create_task_skill.py:1-12`
+- Modify: `tests/skills/test_finish_task_skill.py:1-13`
+
+**Interfaces:**
+
+- Consumes: skill discovery by `plugin/skills/*/SKILL.md`; no hard-coded registry.
+- Produces: `registered_skill_files() -> tuple[Path, ...]`, `frontmatter_name(path: Path) -> str`, and `registered_skill_names() -> tuple[str, ...]` in the test module for later active-surface guards.
+
+- [ ] **Step 1: Write the failing structure guard**
+
+Create `tests/skills/test_skill_names.py` with the exact dynamic inventory and diagnostics:
+
+```python
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+SKILLS_ROOT = ROOT / "plugin" / "skills"
+
+
+def registered_skill_files() -> tuple[Path, ...]:
+    return tuple(sorted(SKILLS_ROOT.glob("*/SKILL.md")))
+
+
+def frontmatter_name(path: Path) -> str:
+    text = path.read_text(encoding="utf-8")
+    assert text.startswith("---\n"), f"{path}: нет начального YAML frontmatter"
+    header = text.split("---", 2)[1]
+    values = [
+        line.removeprefix("name:").strip()
+        for line in header.splitlines()
+        if line.startswith("name:")
+    ]
+    assert len(values) == 1, f"{path}: ожидался ровно один frontmatter name"
+    return values[0]
+
+
+def registered_skill_names() -> tuple[str, ...]:
+    return tuple(frontmatter_name(path) for path in registered_skill_files())
+
+
+def test_frontmatter_names_match_skill_directories():
+    mismatches = [
+        (path.relative_to(ROOT).as_posix(), path.parent.name, frontmatter_name(path))
+        for path in registered_skill_files()
+        if frontmatter_name(path) != path.parent.name
+    ]
+    assert mismatches == [], f"path, expected, actual: {mismatches}"
+
+
+def test_frontmatter_names_are_unique_and_have_no_reviewer_prefix():
+    names = registered_skill_names()
+    assert len(names) == len(set(names)), names
+    assert [name for name in names if name.startswith("reviewer_")] == []
+```
+
+- [ ] **Step 2: Run the guard and verify the current schema fails**
+
+Run:
+
+```bash
+.venv/bin/pytest tests/skills/test_skill_names.py -q
+```
+
+Expected: both tests fail and enumerate all 12 current `reviewer_*` frontmatter names.
+
+- [ ] **Step 3: Rename every frontmatter value and remove duplicated per-skill naming tests**
+
+Apply the complete rename table from Global Constraints to all 12 `SKILL.md` files. Do not change descriptions or bodies in this step.
+
+Delete only these now-redundant tests:
+
+```python
+test_skill_exists_with_frontmatter_name
+test_create_task_name_follows_reviewer_prefix
+test_finish_task_name_follows_reviewer_prefix
+```
+
+Update the module docstring in `test_configure_review_skill.py` so it calls the skill
+`configure-review`, not by its removed frontmatter name. Leave the behavior-specific tests intact.
+
+- [ ] **Step 4: Run the naming guard and the affected behavior tests**
+
+Run:
+
+```bash
+.venv/bin/pytest \
+  tests/skills/test_skill_names.py \
+  tests/skills/test_configure_review_skill.py \
+  tests/skills/test_create_task_skill.py \
+  tests/skills/test_finish_task_skill.py -q
+```
+
+Expected: PASS; `_common` is absent from the inventory because it has no `SKILL.md`.
+
+- [ ] **Step 5: Commit the canonical naming contract**
+
+```bash
+git add plugin/skills tests/skills/test_skill_names.py \
+  tests/skills/test_configure_review_skill.py \
+  tests/skills/test_create_task_skill.py \
+  tests/skills/test_finish_task_skill.py
+git commit -m "refactor(skills): сократить frontmatter-имена (PRI-227)"
+```
+
+---
+
+### Task 2: Remove legacy names from shared skill prose and runtime messages
+
+**Files:**
+
+- Modify: `tests/skills/test_skill_names.py`
+- Modify: `plugin/skills/_common/dimension-scope.md:16`
+- Modify: `plugin/skills/_common/tool-usage.md:11`
+- Modify: `plugin/skills/ask/SKILL.md:41`
+- Modify: `plugin/skills/configure-review/SKILL.md:38-40`
+- Modify: `plugin/skills/maintainability-review/SKILL.md:12,47`
+- Modify: `plugin/skills/performance-review/SKILL.md:12,36`
+- Modify: `plugin/skills/solve-task/SKILL.md:3,36,64,72,295,299,309`
+- Modify: `plugin/skills/summarize-subsystems/SKILL.md:29`
+- Modify: `plugin/skills/sync-codebase/SKILL.md:70-73`
+- Modify: `reviewer/entrypoints/mcp_server.py:287-398`
+- Modify: `reviewer/mcp/service.py:959`
+- Modify: `tests/skills/test_configure_review_skill.py:94-130`
+- Modify: `tests/skills/test_preflight_guardrail.py:20-27`
+- Modify: `tests/skills/test_create_task_skill.py:8-45`
+- Modify: `tests/skills/test_finish_task_skill.py:8-48`
+
+**Interfaces:**
+
+- Consumes: `registered_skill_files()` and `registered_skill_names()` from Task 1.
+- Produces: `_legacy_skill_names() -> tuple[str, ...]`, `_text_files(root: Path) -> tuple[Path, ...]`, and `_legacy_offenders(paths: tuple[Path, ...]) -> list[str]` for the documentation guard in Task 3.
+
+- [ ] **Step 1: Add a failing guard for active code, plugin, and test surfaces**
+
+Append this scanner to `tests/skills/test_skill_names.py`:
+
+```python
+TEXT_SUFFIXES = {".md", ".py", ".json", ".toml", ".yml", ".yaml"}
+
+
+def _legacy_skill_names() -> tuple[str, ...]:
+    return tuple(f"reviewer_{path.parent.name}" for path in registered_skill_files())
+
+
+def _text_files(root: Path) -> tuple[Path, ...]:
+    return tuple(
+        sorted(
+            path
+            for path in root.rglob("*")
+            if path.is_file()
+            and path.suffix in TEXT_SUFFIXES
+            and "__pycache__" not in path.parts
+        )
+    )
+
+
+def _legacy_offenders(paths: tuple[Path, ...]) -> list[str]:
+    offenders: list[str] = []
+    legacy = _legacy_skill_names()
+    for path in paths:
+        text = path.read_text(encoding="utf-8")
+        for name in legacy:
+            if name in text:
+                offenders.append(f"{path.relative_to(ROOT)}: {name}")
+    return offenders
+
+
+def test_active_code_and_plugin_surfaces_have_no_legacy_skill_names():
+    paths = (
+        *_text_files(ROOT / "plugin"),
+        *_text_files(ROOT / "reviewer"),
+        *_text_files(ROOT / "tests"),
+    )
+    assert _legacy_offenders(paths) == []
+```
+
+The legacy tokens are constructed dynamically, so the guard does not contain the strings it rejects.
+
+- [ ] **Step 2: Run the guard and verify it reports all remaining active references**
+
+Run:
+
+```bash
+.venv/bin/pytest \
+  tests/skills/test_skill_names.py::test_active_code_and_plugin_surfaces_have_no_legacy_skill_names \
+  -q
+```
+
+Expected: FAIL with references from skill prose, `_common`, runtime docstrings/messages, and old test expectations.
+
+- [ ] **Step 3: Replace shared references with client-neutral canonical names**
+
+Use these exact replacement rules on active plugin/runtime text:
+
+```text
+/reviewer_review-pr              -> rag-reviewer:review-pr
+/reviewer_sync-codebase          -> rag-reviewer:sync-codebase
+/reviewer_sync-tasks             -> rag-reviewer:sync-tasks
+/reviewer_summarize-subsystems   -> rag-reviewer:summarize-subsystems
+/reviewer_create-task            -> rag-reviewer:create-task
+/reviewer_finish-task            -> rag-reviewer:finish-task
+reviewer_review-pr               -> rag-reviewer:review-pr
+reviewer_sync-codebase           -> rag-reviewer:sync-codebase
+reviewer_sync-tasks              -> rag-reviewer:sync-tasks
+```
+
+Do not replace MCP identifiers such as `mcp__plugin_rag-reviewer_reviewer__`; those name an MCP namespace, not a skill.
+
+For user-facing runtime messages in `reviewer/mcp/service.py`, use:
+
+```python
+"note": "(base-индекс пуст — выполните rag-reviewer:sync-codebase)"
+```
+
+Update `reviewer/entrypoints/mcp_server.py` docstrings to name
+`rag-reviewer:summarize-subsystems` and `rag-reviewer:pr-walkthrough`.
+
+Update test expectations to the same canonical tokens, for example:
+
+```python
+assert re.search(r"paths\.ignore.*rag-reviewer:sync-codebase", rules.group())
+assert "rag-reviewer:summarize-subsystems" in text
+```
+
+Keep `plugin/hooks/brief_guard.py::SOLVE_ATTRIBUTION` and
+`tests/hooks/test_brief_guard.py::_SOLVE_ATTRIBUTION` exactly
+`"rag-reviewer:solve-task"`; they are already correct.
+
+- [ ] **Step 4: Run the active-surface guard and targeted skill/hook tests**
+
+Run:
+
+```bash
+.venv/bin/pytest \
+  tests/skills/test_skill_names.py \
+  tests/skills/test_preflight_guardrail.py \
+  tests/skills/test_configure_review_skill.py \
+  tests/skills/test_create_task_skill.py \
+  tests/skills/test_finish_task_skill.py \
+  tests/hooks/test_brief_guard.py -q
+```
+
+Expected: PASS with no legacy skill token under `plugin/`, `reviewer/`, or `tests/`.
+
+- [ ] **Step 5: Commit cross-skill and runtime migration**
+
+```bash
+git add plugin/skills reviewer/entrypoints/mcp_server.py reviewer/mcp/service.py \
+  tests/skills tests/hooks/test_brief_guard.py
+git commit -m "refactor(skills): обновить внутренние ссылки (PRI-227)"
+```
+
+---
+
+### Task 3: Update active documentation and document the breaking migration
+
+**Files:**
+
+- Modify: `tests/skills/test_skill_names.py`
+- Modify: `tests/install/test_codex_plugin_payload.py:268-285`
+- Modify: `README.md:55-75,238-270,375-480,510-555`
+- Modify: `README.ru.md:55-75,241-273,378-482,512-557`
+- Modify: `CLAUDE.md:52-82,145-154`
+- Modify: `AGENTS.md:1-65`
+- Modify: `plugin/README.md:1-20,38-78`
+
+**Interfaces:**
+
+- Consumes: `_legacy_offenders()` and `registered_skill_names()` from Tasks 1-2.
+- Produces: an active-doc guard and bilingual migration instructions used by installer/payload tests.
+
+- [ ] **Step 1: Add failing documentation contract tests**
+
+Append to `tests/skills/test_skill_names.py`:
+
+```python
+ACTIVE_DOCS = (
+    ROOT / "README.md",
+    ROOT / "README.ru.md",
+    ROOT / "CLAUDE.md",
+    ROOT / "AGENTS.md",
+    ROOT / "plugin" / "README.md",
+)
+
+
+def test_active_docs_have_no_legacy_skill_names():
+    assert _legacy_offenders(ACTIVE_DOCS) == []
+
+
+def test_bilingual_readmes_list_every_canonical_skill():
+    for readme in (ROOT / "README.md", ROOT / "README.ru.md"):
+        text = readme.read_text(encoding="utf-8")
+        missing = [
+            name
+            for name in registered_skill_names()
+            if f"/rag-reviewer:{name}" not in text
+        ]
+        assert missing == [], f"{readme.name}: {missing}"
+
+
+def test_migration_docs_require_fresh_sessions():
+    for readme in ACTIVE_DOCS:
+        text = readme.read_text(encoding="utf-8")
+        assert "rag-reviewer:" in text
+    combined = "\n".join(path.read_text(encoding="utf-8") for path in ACTIVE_DOCS)
+    assert "New Chat" in combined
+    assert "new CLI session" in combined
+    assert "Reload Window" in combined
+```
+
+Update `test_real_payload_registers_every_skill_directory_dynamically()` in
+`tests/install/test_codex_plugin_payload.py`:
+
+```python
+for name in expected:
+    marker = f"/rag-reviewer:{name}"
+    assert marker in english
+    assert marker in russian
+```
+
+- [ ] **Step 2: Run the documentation tests and verify the old names fail**
+
+Run:
+
+```bash
+.venv/bin/pytest \
+  tests/skills/test_skill_names.py::test_active_docs_have_no_legacy_skill_names \
+  tests/skills/test_skill_names.py::test_bilingual_readmes_list_every_canonical_skill \
+  tests/skills/test_skill_names.py::test_migration_docs_require_fresh_sessions \
+  tests/install/test_codex_plugin_payload.py::test_real_payload_registers_every_skill_directory_dynamically \
+  -q
+```
+
+Expected: FAIL on the old README/CLAUDE/AGENTS/plugin README invocations and headings.
+
+- [ ] **Step 3: Rewrite active docs to the canonical public syntax**
+
+Apply these rules:
+
+```text
+Claude examples: /rag-reviewer:<directory-name>
+Codex examples:  $rag-reviewer:<directory-name>
+Reference headings: <directory-name>
+```
+
+Ensure both root README skill references enumerate all 12 canonical names. Add the missing
+`create-task` entry to `AGENTS.md` and `plugin/README.md`.
+
+Add this migration message in equivalent English and Russian wording near the install/update instructions:
+
+```text
+This release removes the redundant reviewer_ segment from every skill name.
+Legacy skill invocations are unsupported: update the plugin/cache, use the short
+names listed below, then open a New Chat or new CLI session. In an IDE, also use
+Reload Window.
+```
+
+Do not spell out a legacy full skill token in active docs; describe the removed
+`reviewer_` segment generically so the no-legacy guard remains enforceable.
+
+Keep the existing commands:
+
+```bash
+uvx --from rag-reviewer@latest reviewer install codex
+uvx --from rag-reviewer@latest reviewer install codex --dry-run
+uvx --from rag-reviewer@latest reviewer install claude-code
+codex plugin list --json
+claude plugin list --json
+```
+
+Change every active invocation, including dry-run examples, troubleshooting notes, and
+CLAUDE.md flow descriptions. Do not touch `docs/superpowers/**`.
+
+- [ ] **Step 4: Run bilingual docs, skill-name, and payload inventory tests**
+
+Run:
+
+```bash
+.venv/bin/pytest \
+  tests/skills/test_skill_names.py \
+  tests/skills/test_readme_grounding_block.py \
+  tests/install/test_codex_plugin_payload.py::test_real_payload_registers_every_skill_directory_dynamically \
+  -q
+```
+
+Expected: PASS; every registered directory has a Claude-style marker in both root READMEs and no active doc contains a removed full name.
+
+- [ ] **Step 5: Commit the documentation migration**
+
+```bash
+git add README.md README.ru.md CLAUDE.md AGENTS.md plugin/README.md \
+  tests/skills/test_skill_names.py tests/install/test_codex_plugin_payload.py
+git commit -m "docs(skills): описать короткие invocation names (PRI-227)"
+```
+
+---
+
+### Task 4: Regenerate payload metadata and verify both installation surfaces
+
+**Files:**
+
+- Modify (generated): `plugin/.codex-plugin/plugin.json`
+- Modify (generated projection): `.codex-plugin/plugin.json`
+- Verify unchanged unless base version drift exists: `plugin/.claude-plugin/plugin.json`
+- Verify unchanged unless source asset drift exists: `plugin/assets/icon.svg`
+
+**Interfaces:**
+
+- Consumes: the final shared `plugin/` payload from Tasks 1-3.
+- Produces: a Codex cachebuster version whose digest matches that exact payload, plus verified Claude/Codex install behavior.
+
+- [ ] **Step 1: Prove the committed manifest digest is stale after payload changes**
+
+Run:
+
+```bash
+.venv/bin/python scripts/update_codex_plugin_manifest.py --check
+```
+
+Expected: exit 1 with a `manifest version ... != ...` or canonical projection mismatch. If it passes, inspect `git diff plugin/` and confirm the skill files actually changed before continuing.
+
+- [ ] **Step 2: Regenerate canonical and projected plugin metadata**
+
+Run:
+
+```bash
+.venv/bin/python scripts/update_codex_plugin_manifest.py
+```
+
+Expected: `Codex plugin manifests synchronized`. The `+codex.<12-hex-digest>` suffix changes in both Codex manifests, while the base version stays aligned with `pyproject.toml`.
+
+- [ ] **Step 3: Verify generated metadata and installer fakes**
+
+Run:
+
+```bash
+.venv/bin/python scripts/update_codex_plugin_manifest.py --check
+.venv/bin/pytest \
+  tests/install/test_codex_plugin_payload.py \
+  tests/install/test_codex_install.py \
+  tests/install/test_codex_cli.py \
+  tests/install/test_claude_install.py \
+  tests/install/test_claude_cli.py -q
+```
+
+Expected: PASS. The payload registers all 12 skill directories, excludes `_common`, has a valid digest, and preserves one enabled `rag-reviewer` plugin for each client.
+
+- [ ] **Step 4: Run the complete relevant unit and static verification**
+
+Run:
+
+```bash
+.venv/bin/pytest tests/skills tests/hooks tests/install -q
+.venv/bin/ruff check plugin reviewer tests
+git diff --check
+.venv/bin/python scripts/update_codex_plugin_manifest.py --check
+```
+
+Expected: all commands pass without network or localhost access.
+
+- [ ] **Step 5: Run safe installer and client smoke checks**
+
+Always run the read-only/local checks:
+
+```bash
+uvx --from . reviewer install codex --dry-run
+codex plugin list --json
+claude plugin list --json
+```
+
+Expected:
+
+- Codex dry-run proposes one enabled `rag-reviewer` plugin and exactly one `reviewer` MCP server.
+- Codex and Claude plugin listings contain one enabled `rag-reviewer` entry.
+- No listing exposes a second compatibility plugin or wrapper skill.
+
+If an authenticated Claude Code CLI is available, additionally run:
+
+```bash
+claude --plugin-dir ./plugin \
+  -p "/rag-reviewer:ask где находится проверка payload digest?" \
+  --permission-mode bypassPermissions
+```
+
+Expected: Claude accepts `/rag-reviewer:ask`; `/skills`/debug output does not expose the removed long form. If the CLI or authentication is unavailable, record that exact skipped smoke check in the handoff; do not claim it passed.
+
+- [ ] **Step 6: Commit generated payload metadata**
+
+```bash
+git add plugin/.codex-plugin/plugin.json .codex-plugin/plugin.json \
+  plugin/.claude-plugin/plugin.json plugin/assets/icon.svg
+git commit -m "chore(plugin): обновить cachebuster skills (PRI-227)"
+```
+
+- [ ] **Step 7: Confirm only intended files changed**
+
+Run:
+
+```bash
+git status --short
+git log -5 --oneline
+```
+
+Expected: no new task-owned changes remain. Pre-existing user untracked files remain untouched. The branch contains four PRI-227 implementation commits after the design/plan documentation commits.

--- a/docs/superpowers/specs/2026-07-31-pri-227-short-skill-names-design.md
+++ b/docs/superpowers/specs/2026-07-31-pri-227-short-skill-names-design.md
@@ -1,0 +1,168 @@
+# PRI-227 — Короткие имена skills
+
+Источник: `docs/superpowers/briefs/2026-07-31-PRI-227-remove-reviewer-skill-name-duplication.md`.
+
+## Цель
+
+Убрать повтор `reviewer` из публичных имён skills, сохранив namespace плагина
+`rag-reviewer`. После миграции имя каждого skill определяется basename его каталога:
+
+```text
+plugin/skills/<skill-name>/SKILL.md
+                    ↕
+frontmatter name: <skill-name>
+```
+
+Claude Code должен показывать `/rag-reviewer:<skill-name>`, а Codex —
+`$rag-reviewer:<skill-name>`. Старые имена вида
+`rag-reviewer:reviewer_<skill-name>` перестают поддерживаться.
+
+## Решения
+
+### Атомарное breaking-переименование
+
+Все зарегистрированные `plugin/skills/*/SKILL.md` переводятся на новый контракт одним
+изменением. Каталоги skills, namespace плагина и структура общего Claude/Codex payload
+не меняются. Compatibility wrappers, aliases и host-specific преобразование payload не
+добавляются: документированных безопасных aliases нет, а отдельные wrapper-skills
+создали бы вторые команды и нарушили критерий отсутствия старых имён.
+
+Переименование охватывает все существующие skills. Будущий `decompose-task` не входит в
+эту задачу как новая функция, но при добавлении обязан сразу иметь
+`name: decompose-task`, потому что общий guard применяется к любому новому каталогу с
+`SKILL.md`.
+
+### Канонический inventory
+
+Единственный inventory — каталоги первого уровня под `plugin/skills/`, содержащие
+`SKILL.md`. Служебный `_common` не регистрируется, поскольку собственного `SKILL.md` у
+него нет. Installer и payload по-прежнему используют динамическое обнаружение
+каталогов; отдельный реестр публичных имён не вводится.
+
+Frontmatter каждого найденного файла обязан удовлетворять трём инвариантам:
+
+1. `name` в точности равен basename каталога;
+2. имена уникальны;
+3. имя не начинается с `reviewer_`.
+
+Первый инвариант делает каталог и frontmatter одним контрактом, второй даёт понятную
+диагностику при ошибочном inventory, третий явно защищает цель PRI-227.
+
+### Поверхности миграции
+
+Обновляются только актуальные потребители имён:
+
+- frontmatter всех зарегистрированных skills;
+- cross-skill ссылки внутри `plugin/skills/`;
+- `README.md`, `README.ru.md`, `CLAUDE.md`, `AGENTS.md` и `plugin/README.md`;
+- актуальные комментарии и fixtures в `tests/`;
+- hook attribution и его тесты, если значение не соответствует новому каноническому
+  имени;
+- Claude/Codex payload, manifest и installer expectations.
+
+`plugin/hooks/brief_guard.py` уже использует каноническое
+`rag-reviewer:solve-task`; его значение сохраняется и покрывается тестом. Миграция не
+должна механически менять уже корректные строки.
+
+Исторические артефакты в `docs/superpowers/briefs/`,
+`docs/superpowers/specs/` и `docs/superpowers/plans/` не переписываются: они фиксируют
+состояние и решения прошлых задач и не являются активной пользовательской
+документацией.
+
+## Поток данных
+
+1. Разработчик добавляет или изменяет каталог `plugin/skills/<name>/`.
+2. Structure guard читает все `plugin/skills/*/SKILL.md` и проверяет каноническое имя.
+3. Installer собирает общий payload из тех же каталогов без переименования.
+4. Claude Code добавляет namespace плагина и показывает
+   `/rag-reviewer:<name>`.
+5. Codex устанавливает тот же payload и показывает `$rag-reviewer:<name>`.
+
+Ни один слой после frontmatter не переводит имя и не содержит параллельной таблицы
+aliases. Благодаря этому Claude и Codex не могут разойтись из-за двух независимых
+mapping-слоёв.
+
+## Guard и диагностика
+
+Добавляется один data-driven тест, который:
+
+- динамически находит все зарегистрированные skill-файлы;
+- разбирает только YAML frontmatter;
+- сравнивает `name` с именем каталога;
+- проверяет уникальность и запрещённый префикс;
+- при ошибке сообщает путь, ожидаемое и фактическое имя.
+
+Точечные assertions вроде `name: reviewer_configure-review` и
+`name: reviewer_finish-task` удаляются или заменяются проверками поведения конкретного
+skill. Naming contract больше не дублируется в per-skill тестах.
+
+Отдельная проверка активных поверхностей запрещает старые invocation-строки в
+production-коде, plugin skills, актуальной документации, hooks и tests. Исторические
+superpowers-артефакты задаются явным исключением, чтобы тест не требовал переписывать
+историю. Проверка должна ловить именно публичные имена и cross-skill references, а не
+произвольные внутренние Python-идентификаторы с допустимым словом `reviewer`.
+
+## Packaging и установка
+
+Существующее динамическое обнаружение каталогов в installer сохраняется. Тесты должны
+доказать, что:
+
+- Claude и Codex получают один и тот же набор каталогов skills;
+- `_common` не попадает в зарегистрированный набор;
+- snapshot/hash меняется после правок payload и проходит штатную проверку cachebuster;
+- Codex manifest продолжает ссылаться на `./skills/`;
+- локальная загрузка Claude через `--plugin-dir ./plugin` видит короткие имена;
+- dry-run/fixture-сценарии обновления не сохраняют старые invocation names.
+
+Реальные внешние API в тестах не вызываются. CLI и файловая система используются через
+существующие fakes/fixtures.
+
+## Breaking migration
+
+Актуальная документация содержит таблицу или компактный список перехода со старого
+формата на новый и требует:
+
+1. обновить глобальный плагин штатной командой installer;
+2. удалить или обновить устаревший cache штатным upgrade-потоком;
+3. открыть New Chat или новую CLI-сессию;
+4. в IDE выполнить Reload Window;
+5. использовать только новые invocation names.
+
+Legacy alias не обещается. Вызов старого имени должен отсутствовать в селекторе, а не
+перенаправляться скрыто.
+
+## Проверка
+
+Минимальная проверка изменения:
+
+1. data-driven structure guard для всех skills;
+2. существующие `tests/skills/` после обновления cross-references;
+3. hook tests для `rag-reviewer:solve-task`;
+4. Claude/Codex payload и installer tests;
+5. repo-wide проверка отсутствия старых invocation-строк на активных поверхностях;
+6. локальная проверка `claude --plugin-dir ./plugin`;
+7. Codex plugin payload/manifest verification и installer dry-run;
+8. полный релевантный pytest-набор и `git diff --check`.
+
+Если локальный Claude/Codex CLI недоступен, автоматические тесты остаются обязательными,
+а пропущенная smoke-проверка явно фиксируется в отчёте вместо ложного успеха.
+
+## Вне scope
+
+- aliases, wrappers и поддержка старых invocation names;
+- host-specific payload для Claude или Codex;
+- создание `decompose-task`;
+- изменение namespace `rag-reviewer`;
+- переименование каталогов skills;
+- переписывание исторических superpowers-артефактов;
+- несвязанный рефакторинг installer или hooks.
+
+## Критерии готовности
+
+- каждый зарегистрированный skill имеет `name`, равный basename каталога;
+- Claude и Codex используют короткие namespaced invocation names;
+- старые invocation-строки отсутствуют на всех активных поверхностях;
+- новый guard отклоняет mismatch, duplicate и префикс `reviewer_`;
+- общий payload и оба install-пути проходят проверки;
+- breaking migration и требования к новой сессии/Reload Window документированы;
+- исторические артефакты сохранены без массового редактирования.

--- a/plugin/.codex-plugin/plugin.json
+++ b/plugin/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "rag-reviewer",
-  "version": "0.4.2+codex.d174a66ebfd3",
+  "version": "0.4.2+codex.e01aedcc17e0",
   "description": "Agentic PR review: hybrid RAG + code graph via MCP, review skills for Codex",
   "repository": "https://github.com/mimfort/rag_for_git",
   "license": "MIT",

--- a/plugin/README.md
+++ b/plugin/README.md
@@ -1,6 +1,6 @@
 # rag-reviewer — Claude Code and Codex plugin payload
 
-Корень Claude Code-плагина для скиллов `/rag-reviewer:reviewer_*`. Полная документация
+Корень Claude Code-плагина для скиллов `/rag-reviewer:<short-name>`. Полная документация
 проекта — в корневых [README.md](../README.md) (англ.) и [README.ru.md](../README.ru.md) (рус.).
 
 ## Что внутри
@@ -10,14 +10,15 @@
   `_common` и вложенные references доставляются как вспомогательные файлы, но не регистрируются как
   скиллы.
 - Скиллы (`plugin/skills/*/SKILL.md`):
-  `/rag-reviewer:reviewer_review-pr` · `/rag-reviewer:reviewer_solve-task` ·
-  `/rag-reviewer:reviewer_sync-codebase` · `/rag-reviewer:reviewer_sync-tasks` ·
-  `/rag-reviewer:reviewer_performance-review` · `/rag-reviewer:reviewer_maintainability-review` ·
-  `/rag-reviewer:reviewer_ask` ·
-  `/rag-reviewer:reviewer_pr-walkthrough` ·
-  `/rag-reviewer:reviewer_configure-review` ·
-  `/rag-reviewer:reviewer_summarize-subsystems` ·
-  `/rag-reviewer:reviewer_finish-task`.
+  `/rag-reviewer:review-pr` · `/rag-reviewer:solve-task` ·
+  `/rag-reviewer:sync-codebase` · `/rag-reviewer:sync-tasks` ·
+  `/rag-reviewer:performance-review` · `/rag-reviewer:maintainability-review` ·
+  `/rag-reviewer:ask` ·
+  `/rag-reviewer:pr-walkthrough` ·
+  `/rag-reviewer:configure-review` ·
+  `/rag-reviewer:summarize-subsystems` ·
+  `/rag-reviewer:create-task` ·
+  `/rag-reviewer:finish-task`.
 
 ## Требования
 
@@ -74,5 +75,5 @@ Reviewer-тулы доступны не только в ревью PR — их �
 ## Headless
 
 ```bash
-claude --plugin-dir . -p "/rag-reviewer:reviewer_review-pr owner/repo#123 --dry-run" --permission-mode bypassPermissions
+claude --plugin-dir . -p "/rag-reviewer:review-pr owner/repo#123 --dry-run" --permission-mode bypassPermissions
 ```

--- a/plugin/skills/_common/dimension-scope.md
+++ b/plugin/skills/_common/dimension-scope.md
@@ -13,5 +13,5 @@ Standalone: ask the user which diff to review if the scope is not clear:
 Do not pick a scope yourself unless the user already made it clear. If the
 resulting diff is empty, stop and say there is nothing to review.
 
-Inside `/reviewer_review-pr`: the orchestrator provides the diffs of all units (path + patch)
+Inside `rag-reviewer:review-pr`: the orchestrator provides the diffs of all units (path + patch)
 — review those.

--- a/plugin/skills/_common/tool-usage.md
+++ b/plugin/skills/_common/tool-usage.md
@@ -8,7 +8,7 @@ Tool discipline (shared):
 - If a signature or contract changes, use `find_callers` to locate all call
   sites and verify with `read_file` / `get_changed_file_diff` that they stay consistent.
 
-## PR-session tools (inside `/reviewer_review-pr`)
+## PR-session tools (inside `rag-reviewer:review-pr`)
 
 - `search_code` — usages of a symbol/string;
 - `get_related_symbols` — graph neighbours (calls / implementations / tests);

--- a/plugin/skills/ask/SKILL.md
+++ b/plugin/skills/ask/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: reviewer_ask
+name: ask
 description: Answer grounded questions about the codebase (onboarding / Q&A) using the reviewer RAG + code graph. Use when the user asks how the code works, where something lives, or to explain a subsystem ("where is auth", "how does X work", "explain the indexing flow", "как устроено…", "где у нас…", "объясни код"). Requires a built base index + graph (reviewer MCP server). Not for reviewing PRs.
 ---
 

--- a/plugin/skills/ask/SKILL.md
+++ b/plugin/skills/ask/SKILL.md
@@ -38,7 +38,7 @@ Plus the harness file tools (`Read`, `Grep`, `Glob`) to read source from the loc
    already checked index freshness earlier in this session, skip this — run
    `uvx --from rag-reviewer reviewer status <path> --branch <branch> --json` and read `drift`. If
    `drift > 0`, emit exactly **one banner line**, in Russian:
-   «⚠ индекс отстаёт на N коммитов, ответ может не учитывать свежие изменения → `/reviewer_sync-codebase`».
+   «⚠ индекс отстаёт на N коммитов, ответ может не учитывать свежие изменения → `rag-reviewer:sync-codebase`».
    Do NOT block, reindex, ask for confirmation, or call `sync_board` — this is warn-only. Cost ≈ 0
    Voyage (reads `index_meta` + local git). **Fail-open:** any error → skip the banner silently
    (Q&A is latency-sensitive).

--- a/plugin/skills/configure-review/SKILL.md
+++ b/plugin/skills/configure-review/SKILL.md
@@ -35,9 +35,9 @@ enter the index. Do not use a filesystem walk to find them.
 
 ## Rebuild guidance
 
-- Changed `paths.ignore` → suggest `/reviewer_sync-codebase`.
-- Changed `summary_cluster_depth` → suggest `/reviewer_summarize-subsystems`.
-- Changed `summary_cluster_depth_overrides` → suggest `/reviewer_summarize-subsystems`.
+- Changed `paths.ignore` → suggest `rag-reviewer:sync-codebase`.
+- Changed `summary_cluster_depth` → suggest `rag-reviewer:summarize-subsystems`.
+- Changed `summary_cluster_depth_overrides` → suggest `rag-reviewer:summarize-subsystems`.
 - Changed `summary_topk_threshold` → no rebuild needed.
 - Changed `context_limits` → no rebuild needed.
 

--- a/plugin/skills/configure-review/SKILL.md
+++ b/plugin/skills/configure-review/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: reviewer_configure-review
+name: configure-review
 description: Configure or update a repo's .review.yml context layer and generic task-board metadata without secrets. Use when the user asks to set up or tune review config, context depth, ignored tracked paths, retrieval limits, or board selection.
 ---
 

--- a/plugin/skills/create-task/SKILL.md
+++ b/plugin/skills/create-task/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: reviewer_create-task
+name: create-task
 description: Create a task on a configured board with canonical server-side structure. Use when the user asks to file or create a task on the board.
 ---
 

--- a/plugin/skills/finish-task/SKILL.md
+++ b/plugin/skills/finish-task/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: reviewer_finish-task
+name: finish-task
 description: After a task's PR is created, offer to close the task on the configured board and reindex it. Use when the user says a PR is up or asks to close or finish a task.
 ---
 

--- a/plugin/skills/maintainability-review/SKILL.md
+++ b/plugin/skills/maintainability-review/SKILL.md
@@ -9,7 +9,7 @@ description: "Review code changes only for maintainability risks: unnecessary co
 
 <!-- include: _common/tool-usage.md -->
 <!-- include: _common/reviewer-grounding.md -->
-In `/reviewer_review-pr` use the PR-session tools above. Standalone (no PR session): use
+In `rag-reviewer:review-pr` use the PR-session tools above. Standalone (no PR session): use
 the session-less tools per the reviewer-grounding block when reviewer is connected and the
 index is fresh; otherwise fall back to grep/Read.
 
@@ -44,7 +44,7 @@ governs the current workspace.
 
 Prefer this order:
 
-1. In `/reviewer_review-pr`, read `CLAUDE.md` or `AGENTS.md` via `read_file`; in standalone,
+1. In `rag-reviewer:review-pr`, read `CLAUDE.md` or `AGENTS.md` via `read_file`; in standalone,
    read them from disk.
 2. Read the nearby implementation to understand existing patterns.
 3. Compare the change against the established local style before flagging it.

--- a/plugin/skills/maintainability-review/SKILL.md
+++ b/plugin/skills/maintainability-review/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: reviewer_maintainability-review
+name: maintainability-review
 description: "Review code changes only for maintainability risks: unnecessary complexity, poor readability, duplication, weak separation of concerns, and misalignment with repository conventions. Use when the user explicitly asks for maintainability review, code quality review, clean code review, complexity review, readability review, simplification review, or how to simplify changed code without changing behavior."
 ---
 

--- a/plugin/skills/performance-review/SKILL.md
+++ b/plugin/skills/performance-review/SKILL.md
@@ -9,7 +9,7 @@ description: Review code changes only for performance and efficiency risks (N+1 
 
 <!-- include: _common/tool-usage.md -->
 <!-- include: _common/reviewer-grounding.md -->
-In `/reviewer_review-pr` use the PR-session tools above. Standalone (no PR session): use
+In `rag-reviewer:review-pr` use the PR-session tools above. Standalone (no PR session): use
 the session-less tools per the reviewer-grounding block when reviewer is connected and the
 index is fresh; otherwise fall back to grep/Read.
 
@@ -33,7 +33,7 @@ Prioritize findings such as:
 
 1. Read the diff first.
 2. Open only the nearby code needed to understand whether the changed path is
-   performance-sensitive. In `/reviewer_review-pr` use the reviewer MCP tools: `read_file`,
+   performance-sensitive. In `rag-reviewer:review-pr` use the reviewer MCP tools: `read_file`,
    `search_code`, `find_callers`.
 3. Prefer concrete findings over vague perf speculation.
 4. If a concern depends on an assumption, state that assumption explicitly.

--- a/plugin/skills/performance-review/SKILL.md
+++ b/plugin/skills/performance-review/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: reviewer_performance-review
+name: performance-review
 description: Review code changes only for performance and efficiency risks (N+1 queries, repeated work, bad asymptotics, missing batching/caching, blocking I/O, memory growth). Use when the user explicitly asks for a performance review of a diff/PR.
 ---
 

--- a/plugin/skills/pr-walkthrough/SKILL.md
+++ b/plugin/skills/pr-walkthrough/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: reviewer_pr-walkthrough
+name: pr-walkthrough
 description: Build a human-facing reading guide for a GitHub pull request (where to start, what each file changes, what it impacts) using the reviewer PR session + code graph. Use when the user asks to walk a human reviewer through a PR ("PR walkthrough", "гид по PR", "как читать этот PR", "проведи по PR"). NOT a bug review (see review-pr). Requires the reviewer MCP server + base index.
 ---
 

--- a/plugin/skills/review-pr/SKILL.md
+++ b/plugin/skills/review-pr/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: reviewer_review-pr
+name: review-pr
 description: Review a GitHub pull request with the RAG + code-graph pipeline (reviewer MCP server). Use when the user asks to review a PR ("review PR 123", "заревьюй PR", a PR URL). Requires ParadeDB/Neo4j running and a built base index.
 ---
 

--- a/plugin/skills/solve-task/SKILL.md
+++ b/plugin/skills/solve-task/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: solve-task
-description: Gather disciplined context for solving a task, then hand off to development. Use when the user asks to solve/implement a task ("solve PRI-4", "/reviewer_solve-task <key or description>", "реши задачу X"). Reads a keyed task from the reviewer store, pulls related/similar tasks and relevant code, distills a brief, and enters brainstorming. Requires the reviewer MCP server.
+description: Gather disciplined context for solving a task, then hand off to development. Use when the user asks to solve/implement a task ("solve PRI-4", "rag-reviewer:solve-task <key or description>", "реши задачу X"). Reads a keyed task from the reviewer store, pulls related/similar tasks and relevant code, distills a brief, and enters brainstorming. Requires the reviewer MCP server.
 ---
 
 # Solve Task
@@ -33,7 +33,7 @@ brief to `superpowers:brainstorming` (which leads to writing-plans → subagent-
       for that branch:
       - `drift == 0` → continue;
       - `drift > 0` → tell the user (in Russian) «индекс отстаёт на N коммитов» and **ask for
-        confirmation**: reindex now? **Yes** → delegate to `/reviewer_sync-codebase`
+        confirmation**: reindex now? **Yes** → delegate to `rag-reviewer:sync-codebase`
         (`--path <path> --ref <branch>`), which reindexes and reports problems, then continue;
         **No** → continue on the stale index and record the gap under **Constraints / open
         questions** in the brief;
@@ -61,7 +61,7 @@ brief to `superpowers:brainstorming` (which leads to writing-plans → subagent-
       - `summaries == 0` (summaries not built yet) → tell the user (in Russian): «Сводки подсистем
         не построены — архитектурный приор будет пустым. Как поступим?» and present **three
         options**:
-        1. «Прогреть сейчас» → delegate to `/reviewer_summarize-subsystems`, wait for it to
+        1. «Прогреть сейчас» → delegate to `rag-reviewer:summarize-subsystems`, wait for it to
            complete, then continue. (Good if using the default model.)
         2. «Прогрею сам» → **PAUSE HERE** and wait for the user to write something like «готово»,
            «прогрел», «done» or any confirmation that they have run their own tool (e.g. an
@@ -69,7 +69,7 @@ brief to `superpowers:brainstorming` (which leads to writing-plans → subagent-
            `uvx --from rag-reviewer reviewer status <path> --branch <branch> --json` and verify
            `summaries > 0`, then continue.
         3. «Пропустить» → note in brief under **Constraints**: «сводки подсистем не построены;
-           `/reviewer_summarize-subsystems` не запускался». Continue without them.
+           `rag-reviewer:summarize-subsystems` не запускался». Continue without them.
       - `summaries` is `null`, or the key is absent (deploy older than this field) → fall back to
         the legacy probe: call `get_subsystem_summaries(repo, branch)` and use the returned count
         with the same three options; unlike the main path, this fallback's option 2 re-verifies by
@@ -292,11 +292,11 @@ Use the session-less tools above.
    subagent-driven-development/TDD). Your job ends at the handoff — do NOT plan or implement here.
 
    **After the PR is created (later in the dev cycle):** offer to close the task with the
-   `/reviewer_finish-task` skill — it appends the PR link to the task and marks it done (bumping
+   `rag-reviewer:finish-task` skill — it appends the PR link to the task and marks it done (bumping
    last-modified so the sync re-indexes the closed task). Skip in board-less mode (no task key).
 
    **Board-less mode:** when the user's formulation has no task key and a board IS configured,
-   you may offer `/reviewer_create-task` first — it files the task with the canonical structure,
+   you may offer `rag-reviewer:create-task` first — it files the task with the canonical structure,
    so the work gets a key, a URL and a place in the task corpus before implementation starts.
 
 ## Failure handling (fail-open)
@@ -306,7 +306,7 @@ Use the session-less tools above.
   the missing task context.
 - Neo4j down → `get_task_context` / `index_task` graph parts degrade (empty + warning); build the
   brief from `search_tasks` + `search_codebase`.
-- Empty task corpus (no prior `/reviewer_sync-tasks` or reviews) → `search_tasks` is empty; use
+- Empty task corpus (no prior `rag-reviewer:sync-tasks` or reviews) → `search_tasks` is empty; use
   `search_codebase` + the user's formulation and note the missing task context.
 - Postgres down → `search_codebase` / `search_tasks` return empty; build the brief from the user's
   formulation alone and note the missing task context; still hand off to brainstorming.

--- a/plugin/skills/solve-task/SKILL.md
+++ b/plugin/skills/solve-task/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: reviewer_solve-task
+name: solve-task
 description: Gather disciplined context for solving a task, then hand off to development. Use when the user asks to solve/implement a task ("solve PRI-4", "/reviewer_solve-task <key or description>", "реши задачу X"). Reads a keyed task from the reviewer store, pulls related/similar tasks and relevant code, distills a brief, and enters brainstorming. Requires the reviewer MCP server.
 ---
 

--- a/plugin/skills/summarize-subsystems/SKILL.md
+++ b/plugin/skills/summarize-subsystems/SKILL.md
@@ -26,7 +26,7 @@ Plus `list_subsystem_clusters`, `index_subsystem_summary` and `prune_subsystem_s
 <!-- include: _common/branch-selection.md -->
 
 2. **List clusters.** Call `list_subsystem_clusters(repo, branch)`. Empty / `note` about an empty
-   index → tell the user (in Russian) to run `/reviewer_sync-codebase` first, then stop. The response
+   index → tell the user (in Russian) to run `rag-reviewer:sync-codebase` first, then stop. The response
    carries `depth` (the applied cluster depth), `depth_source` (`env` | `.review.yml` | `arg`),
    `deferred` (stale clusters held back this pass under the cost cap, env `SUMMARY_REBUILD_CAP`),
    `orphans` (stored summaries whose `cluster_key` is no longer a current cluster), and the

--- a/plugin/skills/summarize-subsystems/SKILL.md
+++ b/plugin/skills/summarize-subsystems/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: reviewer_summarize-subsystems
+name: summarize-subsystems
 description: Precompute concise per-subsystem summaries (GraphRAG community summaries) over the base code index, so ask / PR-walkthrough get a cheap high-level prior. Use when the user asks to build/refresh subsystem summaries ("просуммируй подсистемы", "построй обзоры модулей", "summarize subsystems"). Requires a built base index + the reviewer MCP server.
 ---
 

--- a/plugin/skills/sync-codebase/SKILL.md
+++ b/plugin/skills/sync-codebase/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: reviewer_sync-codebase
+name: sync-codebase
 description: Build or update the reviewer base index (vector store + code graph) from a local repo clone. Use when the user asks to "index the codebase", "build the index", "sync the code", "rebuild the graph", "просиндексируй код", "построй индекс".
 ---
 

--- a/plugin/skills/sync-codebase/SKILL.md
+++ b/plugin/skills/sync-codebase/SKILL.md
@@ -67,7 +67,7 @@ Parse from $ARGUMENTS (all optional):
   npm install -g @sourcegraph/scip-python
   ```
   Then re-run — `GRAPH_BACKEND=auto` picks it up automatically.
-- After `reviewer index`, individual PR reviews (`reviewer_review-pr`) trigger **incremental**
+- After `reviewer index`, individual PR reviews (`rag-reviewer:review-pr`) trigger **incremental**
   re-sync of changed files automatically via `prepare_review`. Full re-index is only needed when
   the base branch diverges significantly or after a fresh deploy.
-- To sync tasks from the configured registered task board, use `reviewer_sync-tasks` instead.
+- To sync tasks from the configured registered task board, use `rag-reviewer:sync-tasks` instead.

--- a/plugin/skills/sync-tasks/SKILL.md
+++ b/plugin/skills/sync-tasks/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: reviewer_sync-tasks
+name: sync-tasks
 description: Warm the task graph and vector store by synchronizing a configured task board through the reviewer MCP server. Use when the user asks to sync or index board tasks.
 ---
 

--- a/reviewer/entrypoints/mcp_server.py
+++ b/reviewer/entrypoints/mcp_server.py
@@ -284,7 +284,7 @@ def create_server(service: MCPReviewService) -> FastMCP:
                                 min_size: int | None = None,
                                 cap: int | None = None) -> dict:
         """Кластеризовать base-граф кода по путям модулей для скилла
-        /reviewer_summarize-subsystems. Возвращает {branch, deferred, clusters:[...]},
+        rag-reviewer:summarize-subsystems. Возвращает {branch, deferred, clusters:[...]},
         где каждый кластер содержит cluster_key, num_members, files, top_symbols
         (по центральности), source_hash и stale (true, если сводка отсутствует
         или её source_hash устарел). Без PR-сессии; branch по умолчанию —
@@ -301,7 +301,7 @@ def create_server(service: MCPReviewService) -> FastMCP:
     def index_subsystem_summary(repo: str, branch: str, cluster_key: str,
                                 title: str, summary: str, source_hash: str) -> dict:
         """Persist one subsystem summary (idempotent upsert keyed by
-        repo+branch+cluster_key). Called by /reviewer_summarize-subsystems after the
+        repo+branch+cluster_key). Called by rag-reviewer:summarize-subsystems after the
         LLM writes title+summary for a cluster. source_hash ties the summary to the
         cluster's current content for staleness."""
         return service.index_subsystem_summary(
@@ -329,7 +329,7 @@ def create_server(service: MCPReviewService) -> FastMCP:
         """Prune subsystem summaries orphaned by a depth change or removed modules.
         Re-derives current cluster_keys from the base index at the resolved depth and
         deletes summaries outside that set. Call ONLY after a full (uncapped) pass of
-        /reviewer_summarize-subsystems — deferred clusters are not orphans. Empty base
+        rag-reviewer:summarize-subsystems — deferred clusters are not orphans. Empty base
         → no-op. Returns {pruned, kept}. No PR session; branch defaults to primary."""
         return service.prune_subsystem_summaries(repo, branch)
 
@@ -337,7 +337,7 @@ def create_server(service: MCPReviewService) -> FastMCP:
     def backfill_summary_embeddings(repo: str, branch: str | None = None) -> dict:
         """Self-heal: embed any subsystem summaries with a NULL embedding from their
         stored title+summary (no LLM). Idempotent — a later run embeds nothing.
-        Called by /reviewer_summarize-subsystems after the LLM pass so older summaries
+        Called by rag-reviewer:summarize-subsystems after the LLM pass so older summaries
         become searchable by proximity. Returns {embedded}. No PR session; branch
         defaults to primary."""
         return service.backfill_summary_embeddings(repo, branch)
@@ -395,7 +395,7 @@ def create_server(service: MCPReviewService) -> FastMCP:
     def post_pr_walkthrough(repo: str, pr: int, markdown: str) -> dict:
         """Post a human-facing PR reading guide (walkthrough) as a PR review comment,
         separate from bug findings (carries a <!-- ai-walkthrough --> marker, empty
-        inline comments). Outward-facing: the /reviewer_pr-walkthrough skill calls this
+        inline comments). Outward-facing: the rag-reviewer:pr-walkthrough skill calls this
         only on explicit user request. Requires an active prepare_review session."""
         return service.post_pr_walkthrough(repo, pr, markdown)
 

--- a/reviewer/mcp/service.py
+++ b/reviewer/mcp/service.py
@@ -956,7 +956,7 @@ class MCPReviewService:
         raw = self.components.store.list_base_members(repo, resolved)
         if not raw:
             return {"branch": resolved, "deferred": 0, "clusters": [],
-                    "note": "(base-индекс пуст — выполните /reviewer_sync-codebase)"}
+                    "note": "(base-индекс пуст — выполните rag-reviewer:sync-codebase)"}
         members = [Member(node_id=f"{p}#{s}", path=p, content_hash=h, start_line=sl,
                           skeleton_hash=sk)
                    for p, s, h, sl, sk in raw]

--- a/tests/docs/test_board_provider_docs.py
+++ b/tests/docs/test_board_provider_docs.py
@@ -220,7 +220,7 @@ def test_root_review_yml_is_parseable_generic_config_with_key_pattern():
 def test_readme_sync_error_hints_use_registry_setup_and_current_config_fallback():
     for rel in ("README.md", "README.ru.md"):
         text = _read(rel)
-        sync_section = _skill_section(text, "reviewer_sync-tasks")
+        sync_section = _skill_section(text, "rag-reviewer:sync-tasks")
         assert "TASK_BOARD_*" not in sync_section
         assert "reviewer init" in sync_section
         assert "reviewer check" in sync_section
@@ -233,5 +233,5 @@ def test_readme_sync_error_hints_use_registry_setup_and_current_config_fallback(
 def test_readme_solve_workflow_does_not_list_index_task():
     for rel in ("README.md", "README.ru.md"):
         text = _read(rel)
-        solve_section = _skill_section(text, "reviewer_solve-task")
+        solve_section = _skill_section(text, "rag-reviewer:solve-task")
         assert "index_task" not in solve_section

--- a/tests/docs/test_board_provider_docs.py
+++ b/tests/docs/test_board_provider_docs.py
@@ -220,7 +220,7 @@ def test_root_review_yml_is_parseable_generic_config_with_key_pattern():
 def test_readme_sync_error_hints_use_registry_setup_and_current_config_fallback():
     for rel in ("README.md", "README.ru.md"):
         text = _read(rel)
-        sync_section = _skill_section(text, "rag-reviewer:sync-tasks")
+        sync_section = _skill_section(text, "sync-tasks")
         assert "TASK_BOARD_*" not in sync_section
         assert "reviewer init" in sync_section
         assert "reviewer check" in sync_section
@@ -233,5 +233,5 @@ def test_readme_sync_error_hints_use_registry_setup_and_current_config_fallback(
 def test_readme_solve_workflow_does_not_list_index_task():
     for rel in ("README.md", "README.ru.md"):
         text = _read(rel)
-        solve_section = _skill_section(text, "rag-reviewer:solve-task")
+        solve_section = _skill_section(text, "solve-task")
         assert "index_task" not in solve_section

--- a/tests/docs/test_readme_onboarding.py
+++ b/tests/docs/test_readme_onboarding.py
@@ -165,7 +165,7 @@ def test_each_registered_skill_has_its_own_heading_in_both_readmes():
     }
 
     for skill in _registered_skills():
-        marker = f"reviewer_{skill}"
+        marker = f"### `{skill}`"
         assert any(marker in heading for heading in english_headings), marker
         assert any(marker in heading for heading in russian_headings), marker
 
@@ -234,7 +234,7 @@ def test_gitlab_only_check_limitation_is_explicit():
         assert "`GITHUB_TOKEN`" in text
         assert "`GITLAB_TOKEN`" in text
         assert "GitLab-only" in text
-        assert "dry-run `rag-reviewer:review-pr`" in text
+        assert "dry-run `/rag-reviewer:review-pr`" in text
         assert "validate `GITLAB_TOKEN` by indexing" not in text
 
 

--- a/tests/docs/test_readme_onboarding.py
+++ b/tests/docs/test_readme_onboarding.py
@@ -234,7 +234,7 @@ def test_gitlab_only_check_limitation_is_explicit():
         assert "`GITHUB_TOKEN`" in text
         assert "`GITLAB_TOKEN`" in text
         assert "GitLab-only" in text
-        assert "dry-run `reviewer_review-pr`" in text
+        assert "dry-run `rag-reviewer:review-pr`" in text
         assert "validate `GITLAB_TOKEN` by indexing" not in text
 
 

--- a/tests/install/test_codex_plugin_payload.py
+++ b/tests/install/test_codex_plugin_payload.py
@@ -282,6 +282,6 @@ def test_real_payload_registers_every_skill_directory_dynamically():
     english = (ROOT / "README.md").read_text(encoding="utf-8")
     russian = (ROOT / "README.ru.md").read_text(encoding="utf-8")
     for name in expected:
-        marker = f"reviewer_{name}"
+        marker = f"/rag-reviewer:{name}"
         assert marker in english
         assert marker in russian

--- a/tests/skills/test_configure_review_skill.py
+++ b/tests/skills/test_configure_review_skill.py
@@ -94,9 +94,9 @@ def test_skill_maps_rebuilds_to_the_changed_setting_only():
     text = SKILL.read_text(encoding="utf-8")
     rules = re.search(r"## Rebuild guidance.*?(?=\n## )", text, re.DOTALL)
     assert rules
-    assert re.search(r"paths\.ignore.*reviewer_sync-codebase", rules.group())
-    assert re.search(r"summary_cluster_depth.*reviewer_summarize-subsystems", rules.group())
-    assert re.search(r"summary_cluster_depth_overrides.*reviewer_summarize-subsystems", rules.group())
+    assert re.search(r"paths\.ignore.*rag-reviewer:sync-codebase", rules.group())
+    assert re.search(r"summary_cluster_depth.*rag-reviewer:summarize-subsystems", rules.group())
+    assert re.search(r"summary_cluster_depth_overrides.*rag-reviewer:summarize-subsystems", rules.group())
     assert re.search(r"summary_topk_threshold.*no rebuild", rules.group())
     assert re.search(r"context_limits.*no rebuild", rules.group())
 
@@ -119,8 +119,8 @@ def test_skill_has_complete_deterministic_context_limit_presets():
 def test_skill_suggests_rebuilds_without_running():
     text = SKILL.read_text(encoding="utf-8")
     assert "do NOT run" in text                     # не запускает пересбор сам
-    assert "reviewer_sync-codebase" in text         # при смене ignore
-    assert "reviewer_summarize-subsystems" in text  # при смене depth/threshold
+    assert "rag-reviewer:sync-codebase" in text         # при смене ignore
+    assert "rag-reviewer:summarize-subsystems" in text  # при смене depth/threshold
 
 
 def test_skill_asks_for_project_scope():

--- a/tests/skills/test_configure_review_skill.py
+++ b/tests/skills/test_configure_review_skill.py
@@ -1,4 +1,4 @@
-"""Guard: скилл reviewer_configure-review — интерактивная настройка контекст-слоя
+"""Guard: скилл configure-review — интерактивная настройка контекст-слоя
 .review.yml (PRI-168). Скилл автономен (только git + правка файла), редактирует
 ровно контекст-слой и не клоберит чужие ключи, пересбор не запускает.
 """
@@ -7,11 +7,6 @@ from pathlib import Path
 
 SKILL = (Path(__file__).resolve().parents[2]
          / "plugin" / "skills" / "configure-review" / "SKILL.md")
-
-
-def test_skill_exists_with_frontmatter_name():
-    text = SKILL.read_text(encoding="utf-8")
-    assert "name: reviewer_configure-review" in text
 
 
 def test_skill_instructs_russian_output():

--- a/tests/skills/test_create_task_skill.py
+++ b/tests/skills/test_create_task_skill.py
@@ -6,10 +6,6 @@ SKILL = ROOT / "plugin" / "skills" / "create-task" / "SKILL.md"
 SOLVE = ROOT / "plugin" / "skills" / "solve-task" / "SKILL.md"
 
 
-def test_create_task_name_follows_reviewer_prefix():
-    assert "name: reviewer_create-task" in SKILL.read_text(encoding="utf-8")
-
-
 def test_create_task_calls_write_tool_and_resyncs():
     t = SKILL.read_text(encoding="utf-8")
     assert "create_task(" in t

--- a/tests/skills/test_finish_task_skill.py
+++ b/tests/skills/test_finish_task_skill.py
@@ -6,11 +6,6 @@ SKILL = ROOT / "plugin" / "skills" / "finish-task" / "SKILL.md"
 SOLVE = ROOT / "plugin" / "skills" / "solve-task" / "SKILL.md"
 
 
-def test_finish_task_name_follows_reviewer_prefix():
-    # Все скиллы плагина инвокаются как /reviewer_<name>; кросс-ссылки зовут /reviewer_finish-task.
-    assert "name: reviewer_finish-task" in SKILL.read_text(encoding="utf-8")
-
-
 def test_finish_task_calls_write_tool_and_resyncs():
     t = SKILL.read_text(encoding="utf-8")
     assert "finish_task(" in t          # зовёт серверный write-тул

--- a/tests/skills/test_preflight_guardrail.py
+++ b/tests/skills/test_preflight_guardrail.py
@@ -17,14 +17,14 @@ def test_solve_task_has_preflight():
     assert "reviewer status" in text and "--json" in text   # читает машиночитаемый статус
     assert "drift" in text                                  # проверяет дрейф
     assert "sync_board(" in text                            # прогрев корпуса задач
-    assert "reviewer_sync-codebase" in text                 # делегирование reindex
+    assert "rag-reviewer:sync-codebase" in text             # делегирование reindex
 
 
 def test_ask_has_warn_only_freshness():
     text = ASK.read_text(encoding="utf-8")
     assert "--json" in text and "reviewer status" in text   # читает машиночитаемый статус
     assert "отстаёт на" in text                             # warn-баннер про дрейф (рус.)
-    assert "reviewer_sync-codebase" in text                 # баннер указывает на reindex-скил
+    assert "rag-reviewer:sync-codebase" in text             # баннер указывает на reindex-скил
     # облегчённый режим: НЕ зовёт sync_board и не реиндексирует
     assert "sync_board(" not in text
 

--- a/tests/skills/test_skill_names.py
+++ b/tests/skills/test_skill_names.py
@@ -1,0 +1,40 @@
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+SKILLS_ROOT = ROOT / "plugin" / "skills"
+
+
+def registered_skill_files() -> tuple[Path, ...]:
+    return tuple(sorted(SKILLS_ROOT.glob("*/SKILL.md")))
+
+
+def frontmatter_name(path: Path) -> str:
+    text = path.read_text(encoding="utf-8")
+    assert text.startswith("---\n"), f"{path}: нет начального YAML frontmatter"
+    header = text.split("---", 2)[1]
+    values = [
+        line.removeprefix("name:").strip()
+        for line in header.splitlines()
+        if line.startswith("name:")
+    ]
+    assert len(values) == 1, f"{path}: ожидался ровно один frontmatter name"
+    return values[0]
+
+
+def registered_skill_names() -> tuple[str, ...]:
+    return tuple(frontmatter_name(path) for path in registered_skill_files())
+
+
+def test_frontmatter_names_match_skill_directories():
+    mismatches = [
+        (path.relative_to(ROOT).as_posix(), path.parent.name, frontmatter_name(path))
+        for path in registered_skill_files()
+        if frontmatter_name(path) != path.parent.name
+    ]
+    assert mismatches == [], f"path, expected, actual: {mismatches}"
+
+
+def test_frontmatter_names_are_unique_and_have_no_reviewer_prefix():
+    names = registered_skill_names()
+    assert len(names) == len(set(names)), names
+    assert [name for name in names if name.startswith("reviewer_")] == []

--- a/tests/skills/test_skill_names.py
+++ b/tests/skills/test_skill_names.py
@@ -3,12 +3,19 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parents[2]
 SKILLS_ROOT = ROOT / "plugin" / "skills"
 TEXT_SUFFIXES = {".md", ".py", ".json", ".toml", ".yml", ".yaml"}
-ACTIVE_DOCS = (
+SESSION_REFRESH_DOCS = (
     ROOT / "README.md",
     ROOT / "README.ru.md",
     ROOT / "CLAUDE.md",
     ROOT / "AGENTS.md",
     ROOT / "plugin" / "README.md",
+)
+ACTIVE_DOCS = (
+    *SESSION_REFRESH_DOCS,
+    ROOT / "GEMINI.md",
+    ROOT / ".mimocode" / "INSTALL.md",
+    ROOT / ".kimi-code" / "INSTALL.md",
+    ROOT / ".opencode" / "INSTALL.md",
 )
 
 
@@ -88,6 +95,15 @@ def test_active_docs_have_no_legacy_skill_names():
     assert _legacy_offenders(ACTIVE_DOCS) == []
 
 
+def test_active_docs_have_no_generic_legacy_skill_pattern():
+    offenders = [
+        path.relative_to(ROOT).as_posix()
+        for path in ACTIVE_DOCS
+        if "reviewer_*" in path.read_text(encoding="utf-8")
+    ]
+    assert offenders == []
+
+
 def test_bilingual_readmes_list_every_canonical_skill():
     for readme in (ROOT / "README.md", ROOT / "README.ru.md"):
         text = readme.read_text(encoding="utf-8")
@@ -100,10 +116,10 @@ def test_bilingual_readmes_list_every_canonical_skill():
 
 
 def test_migration_docs_require_fresh_sessions():
-    for readme in ACTIVE_DOCS:
+    for readme in SESSION_REFRESH_DOCS:
         text = readme.read_text(encoding="utf-8")
         assert "rag-reviewer:" in text
-    combined = "\n".join(path.read_text(encoding="utf-8") for path in ACTIVE_DOCS)
+    combined = "\n".join(path.read_text(encoding="utf-8") for path in SESSION_REFRESH_DOCS)
     assert "New Chat" in combined
     assert "new CLI session" in combined
     assert "Reload Window" in combined

--- a/tests/skills/test_skill_names.py
+++ b/tests/skills/test_skill_names.py
@@ -2,6 +2,7 @@ from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[2]
 SKILLS_ROOT = ROOT / "plugin" / "skills"
+TEXT_SUFFIXES = {".md", ".py", ".json", ".toml", ".yml", ".yaml"}
 
 
 def registered_skill_files() -> tuple[Path, ...]:
@@ -25,6 +26,33 @@ def registered_skill_names() -> tuple[str, ...]:
     return tuple(frontmatter_name(path) for path in registered_skill_files())
 
 
+def _legacy_skill_names() -> tuple[str, ...]:
+    return tuple(f"reviewer_{path.parent.name}" for path in registered_skill_files())
+
+
+def _text_files(root: Path) -> tuple[Path, ...]:
+    return tuple(
+        sorted(
+            path
+            for path in root.rglob("*")
+            if path.is_file()
+            and path.suffix in TEXT_SUFFIXES
+            and "__pycache__" not in path.parts
+        )
+    )
+
+
+def _legacy_offenders(paths: tuple[Path, ...]) -> list[str]:
+    offenders: list[str] = []
+    legacy = _legacy_skill_names()
+    for path in paths:
+        text = path.read_text(encoding="utf-8")
+        for name in legacy:
+            if name in text:
+                offenders.append(f"{path.relative_to(ROOT)}: {name}")
+    return offenders
+
+
 def test_frontmatter_names_match_skill_directories():
     mismatches = [
         (path.relative_to(ROOT).as_posix(), path.parent.name, frontmatter_name(path))
@@ -38,3 +66,12 @@ def test_frontmatter_names_are_unique_and_have_no_reviewer_prefix():
     names = registered_skill_names()
     assert len(names) == len(set(names)), names
     assert [name for name in names if name.startswith("reviewer_")] == []
+
+
+def test_active_code_and_plugin_surfaces_have_no_legacy_skill_names():
+    paths = (
+        *(path for path in _text_files(ROOT / "plugin") if path != ROOT / "plugin" / "README.md"),
+        *_text_files(ROOT / "reviewer"),
+        *_text_files(ROOT / "tests"),
+    )
+    assert _legacy_offenders(paths) == []

--- a/tests/skills/test_skill_names.py
+++ b/tests/skills/test_skill_names.py
@@ -3,6 +3,13 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parents[2]
 SKILLS_ROOT = ROOT / "plugin" / "skills"
 TEXT_SUFFIXES = {".md", ".py", ".json", ".toml", ".yml", ".yaml"}
+ACTIVE_DOCS = (
+    ROOT / "README.md",
+    ROOT / "README.ru.md",
+    ROOT / "CLAUDE.md",
+    ROOT / "AGENTS.md",
+    ROOT / "plugin" / "README.md",
+)
 
 
 def registered_skill_files() -> tuple[Path, ...]:
@@ -75,3 +82,28 @@ def test_active_code_and_plugin_surfaces_have_no_legacy_skill_names():
         *_text_files(ROOT / "tests"),
     )
     assert _legacy_offenders(paths) == []
+
+
+def test_active_docs_have_no_legacy_skill_names():
+    assert _legacy_offenders(ACTIVE_DOCS) == []
+
+
+def test_bilingual_readmes_list_every_canonical_skill():
+    for readme in (ROOT / "README.md", ROOT / "README.ru.md"):
+        text = readme.read_text(encoding="utf-8")
+        missing = [
+            name
+            for name in registered_skill_names()
+            if f"/rag-reviewer:{name}" not in text
+        ]
+        assert missing == [], f"{readme.name}: {missing}"
+
+
+def test_migration_docs_require_fresh_sessions():
+    for readme in ACTIVE_DOCS:
+        text = readme.read_text(encoding="utf-8")
+        assert "rag-reviewer:" in text
+    combined = "\n".join(path.read_text(encoding="utf-8") for path in ACTIVE_DOCS)
+    assert "New Chat" in combined
+    assert "new CLI session" in combined
+    assert "Reload Window" in combined


### PR DESCRIPTION
Задача: [PRI-227](https://ru.yougile.com/team/686c049c8af8/#PRI-227)
<!-- reviewer:task-link -->

## Summary

- make every skill frontmatter name match its directory basename
- migrate active cross-skill references and client documentation to short names
- add guards for naming consistency and stale invocations across supported clients
- regenerate the Codex plugin payload cachebuster

## Verification

- `.venv/bin/pytest -q` — 2647 passed, 1 skipped
- `.venv/bin/ruff check plugin reviewer tests`
- `.venv/bin/python scripts/update_codex_plugin_manifest.py --check`
- Claude short-name smoke: `/rag-reviewer:ask`
