### PR TITLE
style(tests): заменить lambda-присваивания на partial (E731)

### DIFF
--- a/tests/tasks/test_subtask_store.py
+++ b/tests/tasks/test_subtask_store.py
@@ -5,6 +5,7 @@ import tomllib
 from concurrent.futures import ThreadPoolExecutor
 from dataclasses import FrozenInstanceError, fields, replace
 from datetime import UTC, datetime
+from functools import partial
 from pathlib import Path
 from threading import Barrier, Event, Lock
 
@@ -850,20 +851,20 @@ def test_database_and_lock_errors_propagate(failure: str) -> None:
 
     if failure == "schema":
         factory.database.schema_error = expected
-        call = lambda: store.load("missing")
+        call = partial(store.load, "missing")
     elif failure == "load":
         factory.database.load_error = expected
-        call = lambda: store.load("missing")
+        call = partial(store.load, "missing")
     elif failure == "acquire":
         factory.database.acquire_error = expected
-        call = lambda: _enter_parent_lock(store)
+        call = partial(_enter_parent_lock, store)
     elif failure == "unlock":
         factory.database.unlock_error = expected
-        call = lambda: _enter_parent_lock(store)
+        call = partial(_enter_parent_lock, store)
     else:
         store.load("missing")
         factory.pools[0].connection_error = expected
-        call = lambda: store.load("missing")
+        call = partial(store.load, "missing")
 
     with pytest.raises(RuntimeError) as exc_info:
         call()


### PR DESCRIPTION
Пять E731 в `tests/tasks/test_subtask_store.py` — единственное, что мешало `ruff check .` быть зелёным на `dev`.

Присваивания `call = lambda: ...` заменены на `functools.partial`; поведение теста не меняется, `call()` вызывается там же и так же.

Проверено: `ruff check .` → All checks passed; `pytest -q` → 3420 passed.