### PR TITLE
fix(install): не учитывать метаданные ФС в payload digest плагина

### DIFF
--- a/reviewer/install_codex.py
+++ b/reviewer/install_codex.py
@@ -24,7 +24,9 @@ _NORMALIZED_VERSION = "0.0.0+codex.normalized"
 _FORBIDDEN_PAYLOAD_PARTS = {".git", ".env", ".venv", "build", "dist"}
 # Байткод — производное от .py, которые уже в digest: запуск хуков плагина не должен
 # ломать install (payload_digest падал на plugin/hooks/__pycache__/*.pyc).
-_IGNORED_PAYLOAD_PARTS = {"__pycache__"}
+# Метаданные файлового менеджера (.DS_Store, Thumbs.db) появляются сами от простого
+# просмотра каталога и в payload не входят — иначе --check краснеет на пустом месте.
+_IGNORED_PAYLOAD_PARTS = {"__pycache__", ".DS_Store", "Thumbs.db"}
 _IGNORED_PAYLOAD_SUFFIXES = {".pyc", ".pyo"}
 _WINDOWS_REPARSE_POINT = 0x400
 

--- a/tests/install/test_codex_plugin_payload.py
+++ b/tests/install/test_codex_plugin_payload.py
@@ -83,6 +83,22 @@ def test_payload_digest_ignores_python_bytecode_artifacts(tmp_path):
     assert payload_digest(plugin) == clean
 
 
+def test_payload_digest_ignores_os_metadata_artifacts(tmp_path):
+    """Finder/Explorer сами кладут .DS_Store и Thumbs.db в рабочее дерево —
+    payload от этого не меняется, иначе --check краснеет на пустом месте."""
+    plugin = tmp_path / "plugin"
+    skills = plugin / "skills"
+    skills.mkdir(parents=True)
+    (skills / "SKILL.md").write_text("ask")
+    clean = payload_digest(plugin)
+
+    (plugin / ".DS_Store").write_bytes(b"\x00\x00\x00\x01Bud1")
+    (skills / ".DS_Store").write_bytes(b"\x00\x00\x00\x01Bud1")
+    (skills / "Thumbs.db").write_bytes(b"\xd0\xcf\x11\xe0")
+
+    assert payload_digest(plugin) == clean
+
+
 @pytest.mark.parametrize("part", (".git", ".env", ".venv", "build", "dist"))
 def test_payload_digest_still_rejects_forbidden_paths(tmp_path, part):
     """Секреты и артефакты сборки в payload остаются жёсткой ошибкой."""


### PR DESCRIPTION
`payload_digest` обходит `plugin/` по файловой системе и игнорирует только `__pycache__`/`.pyc`. Поэтому `plugin/.DS_Store`, который Finder создаёт сам от простого просмотра каталога, попадал в хеш: локальный `update_codex_plugin_manifest.py` писал в манифест один digest, а CI на чистом checkout ожидал другой — `--check` краснел на пустом месте. Ровно это уронило первый прогон CI на #153.

`.DS_Store` и `Thumbs.db` добавлены в `_IGNORED_PAYLOAD_PARTS` рядом с `__pycache__`.

Digest закоммиченного payload не меняется: этих файлов в git нет и не было, поэтому манифесты остаются прежними (`--check` проходит и до, и после правки). Меняется только устойчивость к мусору в рабочем дереве.

`_FORBIDDEN_PAYLOAD_PARTS` не тронут — `.git`/`.env`/`.venv`/`build`/`dist` по-прежнему жёсткая ошибка, guard-тест на это есть.

Проверено: `ruff check .` → All checks passed; `pytest -q` → 3421 passed; `update_codex_plugin_manifest.py --check` проходит и с подложенным `plugin/.DS_Store`, и без него.