### PR TITLE
chore(dev): добавить pre-commit хук с ruff

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,36 @@
+#!/bin/sh
+# Не даёт закоммитить Python с ошибками ruff.
+#
+# Включается один раз на клон:  git config core.hooksPath .githooks
+# Обойти разово:                git commit --no-verify
+#
+# Проверяются только staged .py — чужие правки в рабочем дереве коммит не блокируют.
+# Ruff читает файл с диска, поэтому у частично проиндексированного файла он видит
+# рабочую версию, а не то, что реально уйдёт в коммит. Для линта это приемлемо:
+# хуже ложное срабатывание, чем пропущенная ошибка.
+set -eu
+
+root=$(git rev-parse --show-toplevel)
+
+if [ -x "$root/.venv/bin/ruff" ]; then
+    ruff="$root/.venv/bin/ruff"
+elif command -v ruff >/dev/null 2>&1; then
+    ruff=ruff
+else
+    # Нет dev-окружения — это проблема машины, а не кода: предупреждаем, но не
+    # блокируем коммит (иначе клон без `pip install -e ".[dev]"` окажется заперт).
+    echo "pre-commit: ruff не найден, проверка пропущена" >&2
+    echo "            поставь его так: python -m venv .venv && .venv/bin/pip install -e \".[dev]\"" >&2
+    exit 0
+fi
+
+staged=$(git diff --cached --name-only --diff-filter=ACMR -- '*.py')
+[ -n "$staged" ] || exit 0
+
+# shellcheck disable=SC2086 # пути без пробелов — ruff получает их отдельными аргументами
+if ! printf '%s\n' "$staged" | xargs "$ruff" check --force-exclude --; then
+    echo "" >&2
+    echo "pre-commit: ruff нашёл ошибки — коммит остановлен." >&2
+    echo "            почини их или закоммить в обход: git commit --no-verify" >&2
+    exit 1
+fi

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,6 +36,7 @@ docker compose --profile test rm -sfv paradedb-test neo4j-test
 
 # Линт
 .venv/bin/ruff check .        # line-length 100, target py311
+git config core.hooksPath .githooks   # один раз на клон: pre-commit гоняет ruff по staged .py
 
 # CLI (после pip install -e .)
 reviewer check --board-project jira=PRI           # проверить окружение и project-scoped board permissions

--- a/README.md
+++ b/README.md
@@ -682,7 +682,12 @@ Create an isolated environment and install development dependencies:
 ```bash
 python -m venv .venv
 .venv/bin/pip install -e ".[dev]"
+git config core.hooksPath .githooks
 ```
+
+The last command enables the tracked `pre-commit` hook: it runs `ruff check` on staged `.py`
+files and blocks the commit when they are not clean. Git cannot enable hooks automatically, so
+every clone opts in once. Bypass a single commit with `git commit --no-verify`.
 
 Unit tests prohibit external and localhost sockets and exclude integration tests by default:
 

--- a/README.ru.md
+++ b/README.ru.md
@@ -670,7 +670,12 @@ reviewer serve
 ```bash
 python -m venv .venv
 .venv/bin/pip install -e ".[dev]"
+git config core.hooksPath .githooks
 ```
+
+Последняя команда включает версионируемый хук `pre-commit`: он гоняет `ruff check` по staged
+`.py` и не даёт закоммитить, пока они не чистые. Git не умеет включать хуки сам, поэтому каждый
+клон подключает их один раз. Разовый обход — `git commit --no-verify`.
 
 Unit tests запрещают external/localhost sockets и по умолчанию исключают integration:
 


### PR DESCRIPTION
Версионируемый `.githooks/pre-commit`: гоняет `ruff check` по staged `.py` и останавливает коммит, если они не чистые.

Без фреймворка `pre-commit` — новых зависимостей не добавляет, в репо его и не было. Ruff берётся из `.venv/bin/ruff`, иначе из PATH.

Решения, которые стоит отревьюить:

- **Проверяются только staged `.py`**, а не весь репозиторий: чужие правки в рабочем дереве не должны блокировать твой коммит. Побочный эффект — у частично проиндексированного файла ruff видит рабочую версию, а не то, что уйдёт в коммит; для линта это приемлемо (ложное срабатывание лучше пропуска), в комментарии к хуку это записано.
- **Отсутствие ruff = предупреждение, а не блокировка.** Клон без `pip install -e ".[dev]"" иначе оказался бы заперт — это проблема машины, а не кода.
- **Хук нужно включить один раз на клон** (`git config core.hooksPath .githooks`) — git не умеет включать хуки из репозитория сам. Команда добавлена в раздел разработки обоих README и в CLAUDE.md.

Разовый обход — `git commit --no-verify`.

Проверено вживую: коммит с `import os` без использования блокируется с внятным сообщением, чистый файл коммитится, guard-тесты доков зелёные (489 passed).