### PR TITLE
feat(init): разделить global и repo onboarding (PRI-223 B)

### DIFF
--- a/docs/superpowers/briefs/2026-08-07-PRI-223-redesign-reviewer-init.md
+++ b/docs/superpowers/briefs/2026-08-07-PRI-223-redesign-reviewer-init.md
@@ -1,203 +1,56 @@
-# Brief — PRI-223 Перепроектировать reviewer init: конфигурация, repo-onboarding и токены
+# Brief — PRI-223 Часть B: передел мастера reviewer init
 https://ru.yougile.com/team/686c049c8af8/#PRI-223
 
 ## Task
-`reviewer init` сейчас выводит единый плоский каталог глобальных, репозиторных и опциональных
-полей (`reviewer/install.py:182-275`), включая глобальные `DEFAULT_REPO`/`REVIEW_BRANCHES`
-(группа «Мульти-репо / ветки», `install.py:219-233`), хотя repo обычно берётся из git remote
-(`cli.py:48-60`), а `REVIEW_BRANCHES` резолвится через единый Settings для всех репозиториев
-(`settings.py:97,134-138`; `services/branch.py:15-25`). PRI-221 уже дала home-слои конфига
-(`~/.config/rag-reviewer/review.yml` + `repos/<owner>/<name>.yml`), но только для policy —
-ветки и мастер их не используют. Нужно: разделить onboarding на глобальный (runtime/credentials)
-и per-repo (remote/ветки) шаги; завести в home per-repo YAML блок
-`repository.primary_branch`/`repository.index_branches`; перевести index/status/prepare_review/
-sync-codebase/session-less MCP-тулы и branch validation на per-repo branch config; убрать
-`DEFAULT_REPO`, `REVIEW_BRANCHES`, `WEB_ADMIN_*`, legacy `TASK_BOARD_MCP` из мастера (runtime-
-фолбэк сохранить); спрашивать credentials только выбранного provider'а с минимальными правами;
-добавить `reviewer config show` для эффективных веток; научить `configure-review` писать ветки
-в home per-repo YAML; неразрушающая миграция `DEFAULT_REPO`/`REVIEW_BRANCHES` из env. 15
-критериев приёмки покрывают: отсутствие лишних вопросов при fresh init, авто-detect
-owner/name+primary branch, изоляцию второго репо, независимые `index_branches`, запись
-configure-review в правильный файл с сохранением ключей/комментариев, отсутствие циклической
-зависимости bootstrap↔`.review.yml`, запрет секретов в YAML, provider-scoped credentials,
-YouGile без admin-прав, `--yes`/`--dry-run` безопасность, идемпотентный повторный init, обратную
-совместимость старых env, `config show` с source веток, обновление README (RU+EN), тесты.
+- Данные получены из reviewer store после sync; нормализованный ключ `ID-277`, алиас `PRI-223`.
+- Реализовать только часть B: разделить `reviewer init` на глобальный runtime/credentials шаг и repo-onboarding с autodetect remote/primary branch.
+- Убрать из стандартного мастера вопросы multirepo, `DEFAULT_REPO`, `REVIEW_BRANCHES`, `WEB_ADMIN_*` и legacy `TASK_BOARD_MCP`, сохранив runtime-поддержку старых env.
+- Перед записью показать файлы, несекретные значения и provenance; после записи показать effective config.
+- Критерии: fresh init без лишних вопросов; owner/name и primary branch видны до записи; второй repo изолирован; `--yes`/`--dry-run` без prompt/network; повторный init сохраняет advanced-настройки.
 
 ## Related work
-- **PRI-221 (ID-274, done, PR #150)** — прямой предшественник: ввела `reviewer/config/layers.py`
-  (`resolve_policy_data`, `home_repo_path`, `build_config_report`, `migrate_repo_config`,
-  `HomeConfigError`), `home_repo_path(repo)` → `~/.config/rag-reviewer/repos/<owner>/<name>.yml`,
-  `reviewer config show`/`migrate` CLI-команды и secret-quarantine (`_credential_path`,
-  `_secret_names`). PRI-223 расширяет ЭТУ ЖЕ инфраструктуру блоком `repository.*`, а не строит
-  новую — модель мержа (верхний ключ целиком, home-repo > `.review.yml` > home-global > env) и
-  паттерн provenance/`ResolutionMeta` нужно скопировать 1:1 для веток.
-- **PRI-169 (ID-169, done)** — предыдущая ревизия того же `WIZARD_GROUPS`/`ENV_TEMPLATE`/
-  `configure-review` SKILL.md: добавляла GitLab VCS, веб-админку, `YOUGILE_API_BASE` в мастер.
-  Показывает точный шаблон правки install.py (`_GROUP_HEADERS`, `ENV_TEMPLATE`) и
-  `tests/test_install_wizard.py`/`tests/install/test_install_wizard.py` — та же матрица тестов,
-  которую PRI-223 теперь ЧАСТИЧНО ОТКАТЫВАЕТ (убирает группу «Мульти-репо / ветки», WEB_ADMIN_*
-  из стандартного мастера).
-- **PRI-168 (ID-168, done)** — исходная спека скилла `configure-review`; текущий SKILL.md
-  (`plugin/skills/configure-review/SKILL.md`) уже реализует выбор target
-  (home per-repo vs `.review.yml`) для policy-ключей — тот же UX-паттерн (шаг 1 pipeline) нужно
-  расширить вопросом про primary/index branches.
-- **PRI-225 (ID-279, done, PR #153)** — добела свежий пример добавления generic-блока в per-repo
-  YAML (`task_board.sync_filter`): показывает, как валидировать новый блок в `layers.py`, как
-  писать «работает и в home per-repo, и в committed `.review.yml`», и как обновлять
-  `configure-review` и тесты для нового ключа — прямой шаблон для `repository.primary_branch`/
-  `index_branches`.
-- (dropped 3: PRI-133 GitLab-провайдер/креды VCS в .review.yml — про VCS-платформу, не про
-  onboarding/branch-конфиг, credentials-фокус уже покрыт setup.py/registry.py, читанными напрямую;
-  PRI-122 исходный мастер онбординга — полностью замещён/расширен PRI-169, читать устаревший
-  снимок избыточно; PRI-210 Codex автоустановка плагина — про payload-digest установки плагина в
-  IDE, не про содержимое `reviewer init`)
+- PRI-223 / PR #159 — часть A уже ввела effective per-repo branch config; часть B должна потреблять её публичные API, не реализовывать ветки заново.
+- PRI-221 / PR #150 — переиспользовать `home_repo_path`, строгую проверку home YAML и provenance вместо отдельного формата repo-конфига.
+- PRI-122 / PR #21 — исходный мастер onboarding задаёт baseline поведения, которое теперь разделяется на global и repo шаги.
+- PRI-169 — предыдущая правка полей `reviewer init`; её тестовые паттерны подходят для удаления полей без потери существующих advanced env.
+- (dropped 4: launcher, GitLab provider, Codex install и status используют иные механизмы и не задают реализацию части B.)
 
 ## Subsystems
-- `reviewer/config` — Settings (70+ env-параметров, включая `default_repo`/`review_branches`),
-  `layers.py` (home/committed резолв policy, provenance), `TaskBoardConfig`,
-  `ProviderCredentialSource` — ядро, которое расширяется блоком `repository.*`.
-- `reviewer/entrypoints` — CLI (`init`, `config show/migrate`, `index`, `status`) и MCP-сервер;
-  все команды, которые сейчас читают `settings.review_branches_list()`/`primary_branch()`
-  напрямую, должны перейти на per-repo резолв.
-- `reviewer` (корневой кластер) — `install.py` (WIZARD_GROUPS, prompt_groups, render_env) —
-  главный файл переделки мастера.
-- `tests/config` — 110 unit-тестов слоя конфига (layers, settings, review_branches,
-  provider_credentials, task_board) — шаблон для новых тестов per-repo branch config.
-- `reviewer/tasks` — 11 board-адаптеров + `registry.py`/`setup.py` — источник
-  `CredentialFieldSpec`/`ProviderSetupSpec` для provider-scoped credential UX (п.9-10 задачи).
-- `reviewer/services` — `branch.py` (`resolve_branch`, ветка-агностичный резолв) и
-  `review_service.py` (`review_branches_list()` гейт для PR) — оба должны стать per-repo-aware.
-- (dropped 2: `reviewer/launcher` — TUI поверх Click-команд, не меняет семантику onboarding, для
-  PRI-223 нерелевантен; `reviewer/graph`/`reviewer/retrieval` — не касаются конфигурации/веток)
+- `reviewer/entrypoints` — команда `init`, orchestration prompt/preview/write/check и финальный effective-config output.
+- `reviewer` — `install.py` описывает env-поля, группы, prompting и безопасный render.
+- `reviewer/config` — home per-repo path, branch resolution и provenance, уже созданные частями PRI-221/A.
+- `tests/install` — контракт интерактивного, `--yes` и `--dry-run` режимов.
+- `tests/config` — изоляция per-repo YAML и проверка источников effective config.
 
 ## Relevant code
-- `reviewer/install.py:182-275` — `WIZARD_GROUPS`: группа «Мульти-репо / ветки»
-  (`DEFAULT_REPO`, `REVIEW_BRANCHES`, строки 219-233) и «Веб-админка» (258-275) — убрать из
-  стандартного мастера; `board_env_group(_default_board_registry())` (257) — существующий паттерн
-  provider-driven группы для credentials, переиспользовать для «спрашивать только выбранного
-  provider'а».
-- `reviewer/install.py:283-368` — `read_env`, `_GROUP_HEADERS`, `render_env`, `prompt_groups` —
-  функции, которые правит мастер; `prompt_groups` (319) — точка, где нужно добавить repo-шаг
-  (git remote autodetect + branch prompt), не смешивая его с EnvGroup/`.env`-моделью.
-- `reviewer/entrypoints/cli.py:828-940` — команда `init`: интерактивный поток (board provider
-  choice → `configure_board_provider`), место для нового отдельного repo-onboarding шага и вызова
-  `reviewer config show` в конце.
-- `reviewer/entrypoints/cli.py:48-60` (`_resolve_repo`) — текущий фолбэк-каскад
-  `--repo → git remote → DEFAULT_REPO → ошибка`; после задачи `DEFAULT_REPO` остаётся
-  compat-фолбэком, но home per-repo YAML должен резолвиться раньше.
-- `reviewer/entrypoints/cli.py:113-179` (`_config_context`, `config_show`, `config_migrate`) —
-  существующий `reviewer config` group; `primary_branch()` вызывается на строке 120 из глобальных
-  Settings — сюда встраивается per-repo branch resolution и новая ветка вывода в `config show`.
-- `reviewer/entrypoints/cli.py:630,684,701-714,735,743` — все текущие места, которые берут ветку
-  из `s.primary_branch()`/`s.review_branches_list()` (index/status/search команды) — blast radius
-  перевода на per-repo резолв (grep подтвердил ровно эти строки + `mcp/service.py:1336-1349,2227`
-  и `services/review_service.py:35-38,202`).
-- `reviewer/config/settings.py:91-97,134-138` — `default_repo`, `review_branches` env-поля и
-  `review_branches_list()`/`primary_branch()` — методы остаются как runtime-фолбэк (п.8 задачи),
-  но перестают быть единственным источником.
-- `reviewer/services/branch.py:15-38` — `resolve_branch(requested, current, settings)` — сейчас
-  берёт allowlist только из `settings.review_branches_list()`; нужно параметризовать по
-  per-repo `index_branches`, сохранив сигнатуру для вызывающих (branch-agnostic паттерн для CLI
-  search/solve-task).
-- `reviewer/config/layers.py:60-72` (`reviewer_config_root`, `home_repo_path`) — уже даёт путь
-  `~/.config/rag-reviewer/repos/<owner>/<name>.yml`; новый блок `repository.primary_branch`/
-  `index_branches` пишется туда же через тот же `_read_mapping`/секрет-quarantine контракт
-  (`_secret_names`, `_credential_path`, строки 87-151).
-- `reviewer/config/layers.py:1-58` — `HomeConfigError`/`HomeCredentialError`/`HomePolicyError`,
-  `ResolutionMeta`, `MigrationResult` — типы ошибок и provenance-модель, которую блок веток должен
-  использовать (не изобретать новую).
-- `reviewer/policy/policy.py:86-132` (`ReviewPolicy.load_data`/`load`) — образец «явные ключи
-  data перекрывают Settings-дефолты только если заданы»; `repository.*` — параллельная, но
-  отдельная от `ReviewPolicy` структура (ветки не являются policy).
-- `reviewer/tasks/boards/registry.py:19-27,36-66` — `CredentialFieldSpec` (env/label/secret/
-  required/default/aliases) и `BoardProviderSpec`/`ProviderSetupSpec` (help_url, help_text,
-  acquisition) — контракт, который уже несёт «label» для credential-полей; задача просит
-  дополнить его текстом про минимальные права/read-write-операции — либо расширить
-  `ProviderSetupSpec.help_text`, либо `CredentialFieldSpec`.
-- `reviewer/tasks/boards/setup.py:154-243` (`acquire_yougile_key`) — рабочий companies→key
-  auto-flow + manual fallback, упомянутый в задаче как образец «без обязательных admin-прав»;
-  `_manual_yougile_key` (вызывается на 168,238) и `_setup_url`/`spec.setup.help_url_builder`
-  (246-248) — где добавляется описание allowOnlyOpenId/минимальных прав.
-- `reviewer/tasks/boards/yougile.py:90-` (`provider_spec`) — `CredentialFieldSpec(env="YOUGILE_API_KEY", secret=True, ...)`; задача явно просит описать минимальные права здесь (п.10).
-- `plugin/skills/configure-review/SKILL.md:22-34` — pipeline шаг 1: уже спрашивает
-  home-per-repo-vs-`.review.yml` target для policy; естественное место добавить вопрос про
-  primary/index branches и запись в `home_repo_path` (п.5 задачи).
-
-(dropped 1: `reviewer/mcp/service.py` полные 1300+ строк — грепом подтверждены только точные
-номера строк 235,1336-1349,2227 как места чтения `review_branches_list`/`primary_branch`; читать
-файл целиком не потребовалось, использованы grep-подтверждённые строки)
+- `reviewer/entrypoints/cli.py:828` — `init` сейчас смешивает env prompt, board setup, preview, запись и post-check; здесь разделить global и repo stages.
+- `reviewer/entrypoints/cli.py:844` — текущий поток читает один `.env`, а `--dry-run` рендерит только его; preview должен охватить оба назначения без записи и сети.
+- `reviewer/entrypoints/cli.py:924` — unknown/advanced env сохраняются через `extra`; этот инвариант нужен повторному init.
+- `reviewer/install.py:319` — `prompt_groups(..., yes)` уже гарантирует current-or-default без prompt в CI; repo stage должен иметь такой же явный noninteractive контракт.
+- `reviewer/install.py:105` — `EnvField`/`EnvGroup` моделируют только `.env`; repo YAML не следует встраивать в эти типы как псевдо-env.
+- `reviewer/gitutil.py:42` — `remote_url` уже fail-soft читает `origin`; использовать его для autodetect, не дублировать subprocess parsing.
+- `reviewer/services/repo_id.py:24` — `derive_repo_from_remote` уже нормализует remote в repo id; отсутствие/неподдерживаемый remote должно давать управляемый fallback.
+- `reviewer/services/branch.py:28` — `current_git_branch` даёт локальную ветку fail-soft; primary branch выбирать через effective API части A с autodetect fallback, не через committed `.review.yml` bootstrap.
+- `reviewer/config/layers.py:69` — `home_repo_path(repo)` задаёт канонический per-repo destination.
+- `reviewer/config/layers.py:257` — `resolve_policy_data` и `ResolutionMeta` задают существующий паттерн sources/shadowing для effective preview.
+- `reviewer/entrypoints/cli.py:136` — `config show` уже выводит effective config/provenance; переиспользовать после onboarding вместо второго отчётного формата.
+- (dropped 10: runtime consumers веток, MCP, board provider internals и launcher не меняются в части B.)
 
 ## Test exemplars
-- `tests/config/test_layers.py:27-52` (`test_layers_replace_top_level_values_and_report_sources`) —
-  канонический паттерн проверки резолва слоёв через `resolve_policy_data(repo, branch, fetch_fn,
-  config_root=tmp_path)`: пишет `tmp_path/review.yml` и `tmp_path/repos/o/r.yml`, мокает
-  committed-fetch лямбдой, проверяет `data[...]`, `meta.sources[...]`, `meta.shadowed[...]` —
-  прямой шаблон для тестов резолва `repository.primary_branch`/`index_branches`.
-- `tests/config/test_layers.py:110-136` (`test_subgroup_repo_uses_nested_home_path`,
-  `test_dotted_repo_name_appends_yaml_suffix_without_colliding`) — паттерны для owner-подгрупп
-  (GitLab) и repo-имён с точками — нужно повторить для branch-конфига, т.к. путь тот же
-  `home_repo_path`.
-- `tests/config/test_layers.py:210-236` (`test_credential_file_is_skipped_without_echoing_value`,
-  `test_max_tokens_is_not_misclassified_as_secret`) — паттерн проверки «секрет в YAML отклоняется
-  без эха значения» — прямой тест для критерия 7 задачи применительно к новому блоку.
-- `tests/config/test_layers.py:365-380` (`test_migrate_creates_file_and_second_call_is_noop`,
-  `test_migrate_refuses_different_destination`) — идемпотентность миграции; шаблон для новой
-  миграции `DEFAULT_REPO`/`REVIEW_BRANCHES` → home per-repo YAML.
-- `tests/config/test_review_branches.py:4-25` (`test_review_branches_default_is_main`,
-  `test_review_branches_parsed_from_csv`, `test_review_branches_empty_falls_back_to_main`) —
-  текущие тесты чисто env-branches; после задачи потребуют дополнения per-repo-override
-  вариантами (mock `monkeypatch.setenv`, без БД/сети — соответствует unit-контракту репозитория).
-- `tests/install/test_install_wizard.py:99-136`
-  (`test_prompt_groups_yes_uses_current_values`, `..._yes_skips_optional_groups`,
-  `test_render_env_includes_board_api_key_and_hint`) — паттерн мокинга `prompt_groups`/
-  `render_env` без реального click-ввода; тот же подход нужен для тестов нового repo-onboarding
-  шага.
-- `tests/install/test_install_wizard.py:276-314`
-  (`test_init_interactive_configures_selected_registry_provider`) — полный пример: мокает
-  `reviewer.install.prompt_groups`, `ClickSetupIO.choose`, `configure_board_provider`,
-  `click.confirm` (через `iter([...])`), запускает `CliRunner().invoke(cli, ["init"])` и проверяет
-  записанный `.env` — прямой шаблон для теста «после выбора provider запрашиваются только его
-  credentials» (критерий 8).
-- `tests/install/test_board_setup.py:171-` (`test_jira_setup_opens_official_page_only_after_...`) —
-  найден по релевантности (cliff обрезал контекст) для setup-flow конкретного провайдера;
-  подтверждает, что паттерн «open help page → confirm → validate» уже тестируется по каждому
-  provider — можно скопировать структуру теста для доработки YouGile-хинтов о минимальных правах.
-- (dropped 0 — все найденные тестовые примеры прямо релевантны выбранным граням задачи)
+- `tests/install/test_install_wizard.py:152` — `--dry-run` не создаёт каталог/файл, не prompt-ит и скрывает секреты.
+- `tests/install/test_install_wizard.py:173` — preview редактирует legacy и неизвестные secret-like extras без утечки значений.
+- `tests/install/test_install_wizard.py:200` — `--dry-run` и `--yes` не запускают provider acquisition, validation, browser или network setup.
+- `tests/install/test_install_wizard.py:164` — `--yes` сохраняет unknown advanced env keys.
+- `tests/config/test_layers.py:135` — существующий home-файл остаётся неизменным при конфликте; repo-onboarding нужен неразрушающий update с отдельными тестами двух repo.
+- (dropped 5: provider-specific setup и integration migration tests относятся к частям C/A.)
 
 ## Constraints / open questions
-- `get_task_context` не дал связанных задач/PR — граф задач по PRI-223 пуст; весь related work
-  собран через `search_tasks` + прямое чтение кода, без готового списка «linked issues».
-- Voyage-лимиты (3 RPM/10K TPM) намеренно экономились: сделано 2 `search_codebase`-запроса (один
-  обрезан по cliff-cutoff — «15 из 111», «10 из 23» — есть ещё релевантные совпадения за
-  обрезом, не дотянутые повторным вызовом с большим ceiling); один `get_subsystem_summaries` и
-  один `search_tasks` (тоже обрезан — «8 из 30»; за обрезом могут быть ещё релевантные задачи,
-  не проверено). Остальная кодовая грунтовка — прямые `Read`/`grep`, т.к. задача сама называла
-  конкретные файлы.
-- Граф кода (`related_symbols`/`callers`/`implementations`/`definition`) не вызывался: узловых
-  node_id вида `path#fqn` для функций-целей (`prompt_groups`, `resolve_branch`,
-  `resolve_policy_data`) в сниппетах не потребовалось — blast radius на чтение веток закрыт
-  прямым `grep` по `review_branches_list|primary_branch` (дал точные номера строк во всех
-  вызывающих модулях). Если реализация захочет точный caller-граф `resolve_branch`, это отдельный
-  дешёвый `callers` вызов на этапе кода.
-- В `reviewer/config/layers.py` (950 строк) прочитаны только первые ~160 строк (типы ошибок,
-  `home_repo_path`, secret-quarantine) — сама функция `resolve_policy_data`/`build_config_report`/
-  `migrate_repo_config` (тела) не вычитаны построчно; при реализации блока `repository.*`
-  потребуется полностью прочитать эти функции, а не полагаться на сигнатуры из тестов.
-- Не найден (и не искался целенаправленно) код, описывающий, как MCP session-less тулы
-  (`search_codebase`, `related_symbols` и т.п. в `mcp/service.py`) резолвят branch без явного
-  `--branch` — есть только grep-совпадения строк 1336-1349/2227; полный путь резолва в MCP-слое
-  не прочитан целиком.
-- Задача явно выносит вне скоупа PRI-221 «читать `.review.yml` из рабочего дерева» — PRI-223
-  наследует это ограничение: bootstrap веток тоже не может зависеть от committed `.review.yml`
-  (критерий 6), только от home-слоя/git remote/CLI.
-- ProviderSetupSpec/CredentialFieldSpec (`registry.py:20-66`) сейчас не имеют выделенного поля под
-  «минимальные права»/«read vs write операции» — придётся решить, расширять ли dataclass или
-  переиспользовать `help_text`; в брифе зафиксирован только факт отсутствия поля, решение не
-  принято.
+- [existing_artifacts] `docs/superpowers/specs/2026-08-07-PRI-223-per-repo-branch-config-design.md` и `docs/superpowers/plans/2026-08-07-PRI-223-per-repo-branch-config.md` описывают часть A, не дизайн части B.
+- Граница части B жёсткая: provider-scoped credentials/minimal permissions остаются частью C; configure-review и двуязычная документация остаются частью D.
+- `criteria=[]` в store, но описание содержит полный раздел «Критерии приёмки»; для B применяются критерии 1, 2, 3, 10 и 11.
+- Branch bootstrap не должен читать committed `.review.yml` до выбора branch; источник только git/CLI/home per-repo/global/env fallback части A.
+- `--yes` и `--dry-run` не должны выполнять интерактивные или сетевые операции; preview никогда не показывает секреты.
+- PR #159 проверен через GitHub и присутствует в обновлённом `dev` (`4978334`); часть B создаётся поверх него.
+- Сводки подсистем уже были прогреты; в этом запуске они не обновлялись по прямому указанию пользователя.
 
-Собран на: mid tier (Sonnet-class), режим: subagent
-
-## Токены (этап solve-task)
-Модель: claude-opus-5
-fresh-in 220 · out 306.8K · cache-write 1.9M · cache-read 11.5M
-Всего: 13.7M токенов
+Собран на: mid tier (session model gpt-5.6-sol), режим: inline

--- a/docs/superpowers/plans/2026-08-08-PRI-223-reviewer-init-onboarding.md
+++ b/docs/superpowers/plans/2026-08-08-PRI-223-reviewer-init-onboarding.md
@@ -1,0 +1,1187 @@
+# PRI-223 Reviewer Init Onboarding Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Разделить `reviewer init` на independently runnable global и repo stages с offline git autodetect, preview-before-write и сохранением legacy/advanced config.
+
+**Architecture:** Pure repo detection/planning/apply живёт в новом `reviewer/config/onboarding.py`, а `reviewer/entrypoints/cli.py` только собирает user input и оркестрирует планы. Global `.env` продолжает использовать существующие `install.py` render/redaction helpers; repo YAML использует public branch resolver и общую create/append/noop механику с migration.
+
+**Tech Stack:** Python 3.11–3.13, Click, dataclasses, pathlib, PyYAML, pytest, Ruff.
+
+---
+
+## File Map
+
+- Modify `reviewer/gitutil.py`: offline git-root и local `origin/HEAD` helpers.
+- Create `reviewer/config/onboarding.py`: immutable repo detection/config plans, validation, preview and apply.
+- Modify `reviewer/config/branches.py`: общий renderer/publisher `repository` block для migration и onboarding.
+- Modify `reviewer/install.py`: standard wizard fields без repo/web/legacy board MCP.
+- Modify `reviewer/entrypoints/cli.py`: `--scope`, `--repo`, unified preview, final confirmation, apply and effective branch output.
+- Modify `reviewer/launcher/metadata.py`: `init` details отражают два target layers.
+- Modify `tests/test_gitutil.py`: git helper tests.
+- Create `tests/config/test_onboarding.py`: pure plan/apply tests.
+- Modify `tests/config/test_branches_migrate.py`: regression общей persistence.
+- Modify `tests/install/test_install_wizard.py` and `tests/test_install_wizard.py`: wizard compatibility contract.
+- Create `tests/entrypoints/test_cli_init_onboarding.py`: scope/noninteractive/interactive orchestration tests.
+- Modify `tests/launcher/test_catalog.py`: Click choice and repo option remain discoverable.
+
+## Global Constraints
+
+- Не читать committed `.review.yml` для branch bootstrap.
+- Не использовать network git commands (`fetch`, `ls-remote`, `remote show`).
+- `--yes` и `--dry-run` не вызывают prompt, browser, provider setup, check или VCS policy lookup.
+- До unified preview/final confirmation не создавать directories и не писать files.
+- Existing `repository` block не перезаписывать; existing removed env keys сохранять через `extra`.
+- Часть C provider-scoped credentials и часть D configure-review/docs не реализуются здесь.
+- Каждый production change проходит RED → GREEN и отдельный focused commit.
+
+---
+
+### Task 1: Offline Git Repository Detection
+
+**Files:**
+- Modify: `reviewer/gitutil.py:7-47`
+- Test: `tests/test_gitutil.py`
+
+- [ ] **Step 1: Write failing git helper tests**
+
+Update imports and add:
+
+```python
+from reviewer.gitutil import (
+    changed_files,
+    commits_behind,
+    file_at_ref,
+    remote_default_branch,
+    remote_url,
+    repo_root,
+)
+
+
+def test_repo_root_returns_top_level_from_nested_path(tmp_path):
+    repo = tmp_path / "repo"
+    nested = repo / "a" / "b"
+    nested.mkdir(parents=True)
+    _run("git", "init", "-q", cwd=repo)
+
+    assert repo_root(str(nested)) == str(repo.resolve())
+    assert repo_root(str(tmp_path / "missing")) is None
+
+
+def test_remote_default_branch_reads_local_origin_head(tmp_path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _run("git", "init", "-q", cwd=repo)
+    _run("git", "symbolic-ref", "refs/remotes/origin/HEAD", "refs/remotes/origin/dev", cwd=repo)
+
+    assert remote_default_branch(str(repo)) == "dev"
+
+
+def test_remote_default_branch_missing_ref_is_none(tmp_path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _run("git", "init", "-q", cwd=repo)
+
+    assert remote_default_branch(str(repo)) is None
+
+
+def test_remote_default_branch_uses_only_local_symbolic_ref(monkeypatch):
+    calls = []
+
+    def fake_git(repo, *args):
+        calls.append((repo, args))
+        return "refs/remotes/origin/dev\n"
+
+    monkeypatch.setattr("reviewer.gitutil._git", fake_git)
+
+    assert remote_default_branch("/repo") == "dev"
+    assert calls == [
+        ("/repo", ("symbolic-ref", "--quiet", "refs/remotes/origin/HEAD"))
+    ]
+```
+
+- [ ] **Step 2: Run tests and verify RED**
+
+Run: `.venv/bin/pytest tests/test_gitutil.py -q`
+
+Expected: collection error because `repo_root` and `remote_default_branch` do not exist.
+
+- [ ] **Step 3: Implement fail-soft local helpers**
+
+Add to `reviewer/gitutil.py`:
+
+```python
+def repo_root(path: str = ".") -> str | None:
+    """Вернуть absolute git top-level либо None вне рабочего дерева."""
+    try:
+        return _git(path, "rev-parse", "--show-toplevel").strip() or None
+    except (OSError, subprocess.CalledProcessError):
+        return None
+
+
+def remote_default_branch(repo: str) -> str | None:
+    """Вернуть default branch из локального origin/HEAD без обращения к сети."""
+    try:
+        ref = _git(repo, "symbolic-ref", "--quiet", "refs/remotes/origin/HEAD").strip()
+    except (OSError, subprocess.CalledProcessError):
+        return None
+    prefix = "refs/remotes/origin/"
+    return ref.removeprefix(prefix) if ref.startswith(prefix) else None
+```
+
+- [ ] **Step 4: Run focused tests and lint**
+
+Run: `.venv/bin/pytest tests/test_gitutil.py -q && .venv/bin/ruff check reviewer/gitutil.py tests/test_gitutil.py`
+
+Expected: all tests pass; Ruff reports no errors.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add reviewer/gitutil.py tests/test_gitutil.py
+git commit -m "feat(init): определяет repo и primary branch локально"
+```
+
+---
+
+### Task 2: Pure Repo Onboarding Plan and Persistence
+
+**Files:**
+- Create: `reviewer/config/onboarding.py`
+- Modify: `reviewer/config/branches.py:127-194`
+- Create: `tests/config/test_onboarding.py`
+- Modify: `tests/config/test_branches_migrate.py`
+
+- [ ] **Step 1: Write failing detection/planning tests**
+
+Create `tests/config/test_onboarding.py` with helpers and core cases:
+
+```python
+from pathlib import Path
+
+import yaml
+
+from reviewer.config.onboarding import (
+    RepositoryConfigPlan,
+    RepositoryDetection,
+    apply_repository_config,
+    detect_repository,
+    parse_branch_csv,
+    plan_repository_config,
+)
+from reviewer.config.settings import Settings
+
+
+def _settings(monkeypatch, branches="main"):
+    monkeypatch.setenv("REVIEW_BRANCHES", branches)
+    return Settings(_env_file=None)
+
+
+def test_detect_repository_prefers_cli_repo(monkeypatch, tmp_path):
+    monkeypatch.setattr("reviewer.config.onboarding.repo_root", lambda _path: str(tmp_path))
+    monkeypatch.setattr(
+        "reviewer.config.onboarding.remote_url",
+        lambda _path: "https://github.com/remote/name.git",
+    )
+    monkeypatch.setattr("reviewer.config.onboarding.remote_default_branch", lambda _path: "dev")
+
+    result = detect_repository(".", "CLI/Repo", settings=_settings(monkeypatch))
+
+    assert result == RepositoryDetection(
+        root=tmp_path,
+        repo="cli/repo",
+        repo_source="cli",
+        primary="dev",
+        primary_source="git:origin/HEAD",
+    )
+
+
+def test_detect_repository_falls_back_to_effective_primary(monkeypatch, tmp_path):
+    monkeypatch.setattr("reviewer.config.onboarding.repo_root", lambda _path: str(tmp_path))
+    monkeypatch.setattr(
+        "reviewer.config.onboarding.remote_url",
+        lambda _path: "https://github.com/o/r.git",
+    )
+    monkeypatch.setattr("reviewer.config.onboarding.remote_default_branch", lambda _path: None)
+
+    result = detect_repository(".", None, settings=_settings(monkeypatch, "release,main"))
+
+    assert result.repo == "o/r"
+    assert result.primary == "release"
+    assert result.primary_source == "env"
+
+
+def test_plan_uses_detected_primary_when_effective_index_is_incompatible(monkeypatch, tmp_path):
+    detection = RepositoryDetection(tmp_path, "o/r", "git:origin", "dev", "git:origin/HEAD")
+
+    plan = plan_repository_config(
+        detection,
+        settings=_settings(monkeypatch, "main,master"),
+        config_root=tmp_path,
+    )
+
+    assert plan.primary == "dev"
+    assert plan.index == ("dev",)
+    assert plan.action == "create"
+
+
+def test_parse_branch_csv_requires_primary_in_unique_nonempty_index():
+    assert parse_branch_csv("dev, main", "dev") == ("dev", "main")
+    for raw in ("", "dev,dev", "dev,,main"):
+        try:
+            parse_branch_csv(raw, "dev")
+        except ValueError:
+            pass
+        else:
+            raise AssertionError(f"expected ValueError for {raw!r}")
+```
+
+- [ ] **Step 2: Write failing apply/idempotency tests**
+
+Append:
+
+```python
+def test_apply_creates_and_repeat_is_byte_for_byte_noop(monkeypatch, tmp_path):
+    detection = RepositoryDetection(tmp_path, "o/r", "git:origin", "dev", "git:origin/HEAD")
+    plan = plan_repository_config(
+        detection,
+        settings=_settings(monkeypatch),
+        index=("dev", "main"),
+        config_root=tmp_path,
+    )
+
+    apply_repository_config(plan)
+    first = plan.path.read_text(encoding="utf-8")
+    apply_repository_config(
+        plan_repository_config(
+            detection,
+            settings=_settings(monkeypatch),
+            config_root=tmp_path,
+        )
+    )
+
+    assert plan.path.read_text(encoding="utf-8") == first
+    assert yaml.safe_load(first)["repository"] == {
+        "primary_branch": "dev",
+        "index_branches": ["dev", "main"],
+    }
+
+
+def test_apply_appends_without_losing_comments(monkeypatch, tmp_path):
+    path = tmp_path / "repos/o/r.yml"
+    path.parent.mkdir(parents=True)
+    path.write_text("# keep me\nmax_comments: 7\n", encoding="utf-8")
+    detection = RepositoryDetection(tmp_path, "o/r", "cli", "2.0", "default")
+    plan = plan_repository_config(
+        detection,
+        settings=_settings(monkeypatch),
+        index=("2.0", "on", "feature{x}"),
+        config_root=tmp_path,
+    )
+
+    apply_repository_config(plan)
+    text = path.read_text(encoding="utf-8")
+
+    assert "# keep me" in text
+    assert yaml.safe_load(text)["repository"]["index_branches"] == [
+        "2.0",
+        "on",
+        "feature{x}",
+    ]
+
+
+def test_existing_repository_is_noop(monkeypatch, tmp_path):
+    path = tmp_path / "repos/o/r.yml"
+    path.parent.mkdir(parents=True)
+    original = "repository:\n  index_branches: [trunk]\n  future: keep\n"
+    path.write_text(original, encoding="utf-8")
+    detection = RepositoryDetection(tmp_path, "o/r", "git:origin", "dev", "git:origin/HEAD")
+
+    plan = plan_repository_config(
+        detection,
+        settings=_settings(monkeypatch),
+        config_root=tmp_path,
+    )
+    apply_repository_config(plan)
+
+    assert plan.action == "noop"
+    assert path.read_text(encoding="utf-8") == original
+```
+
+- [ ] **Step 3: Run tests and verify RED**
+
+Run: `.venv/bin/pytest tests/config/test_onboarding.py -q`
+
+Expected: collection error because `reviewer.config.onboarding` does not exist.
+
+- [ ] **Step 4: Extract reusable repository block publisher**
+
+In `reviewer/config/branches.py`, replace `_render_block` with a primary-aware renderer and add a
+single publisher used by migration and onboarding:
+
+```python
+def render_repository_block(primary: str, index: tuple[str, ...], *, migrated: bool = False) -> str:
+    data = {BRANCHES_KEY: {"primary_branch": primary, "index_branches": list(index)}}
+    body = yaml.safe_dump(data, allow_unicode=True, sort_keys=False)
+    if not migrated:
+        return body
+    return (
+        "# Отслеживаемые ветки репозитория (перенесено из REVIEW_BRANCHES).\n"
+        + body
+    )
+
+
+def publish_repository_block(path: Path, source: str, block: str) -> str:
+    """Create/append/noop repository block and return the applied action."""
+    try:
+        existing = path.read_text(encoding="utf-8")
+    except FileNotFoundError:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        try:
+            with open(path, "x", encoding="utf-8") as handle:
+                handle.write(block)
+        except FileExistsError:
+            return "noop"
+        return "create"
+    if BRANCHES_KEY in _read_mapping(existing, source):
+        return "noop"
+    separator = "" if not existing or existing.endswith("\n") else "\n"
+    path.write_text(existing + separator + "\n" + block, encoding="utf-8")
+    return "append"
+```
+
+Update `migrate_repo_branches` to call
+`render_repository_block(index[0], index, migrated=True)` and `publish_repository_block(...)`,
+replacing its existing direct create/append block with:
+
+```python
+action = publish_repository_block(destination, source, block)
+return BranchMigrationResult(
+    path=destination,
+    created=action == "create",
+    noop=action == "noop",
+)
+```
+
+- [ ] **Step 5: Implement `reviewer/config/onboarding.py`**
+
+Create the module with immutable data and no Click dependency:
+
+```python
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+import yaml
+from typing import Literal
+
+from reviewer.config.branches import (
+    publish_repository_block,
+    render_repository_block,
+    resolve_repo_branches,
+)
+from reviewer.config.layers import _read_mapping, home_repo_path, reviewer_config_root
+from reviewer.config.settings import Settings
+from reviewer.gitutil import remote_default_branch, remote_url, repo_root
+from reviewer.services.repo_id import derive_repo_from_remote, normalize_repo
+
+PlanAction = Literal["create", "append", "noop"]
+
+
+@dataclass(frozen=True)
+class RepositoryDetection:
+    root: Path
+    repo: str
+    repo_source: str
+    primary: str
+    primary_source: str
+
+
+@dataclass(frozen=True)
+class RepositoryConfigPlan:
+    path: Path
+    repo: str
+    primary: str
+    index: tuple[str, ...]
+    repo_source: str
+    primary_source: str
+    action: PlanAction
+    preview: str
+
+
+def parse_branch_csv(raw: str, primary: str) -> tuple[str, ...]:
+    parts = [part.strip() for part in raw.split(",")]
+    if not parts or any(not part for part in parts):
+        raise ValueError("index branches должны быть непустым CSV")
+    if len(parts) != len(set(parts)):
+        raise ValueError("index branches содержат дубли")
+    if primary not in parts:
+        raise ValueError(f"primary branch {primary!r} отсутствует в index branches")
+    return tuple(parts)
+
+
+def detect_repository(
+    path: str,
+    repo_override: str | None,
+    *,
+    settings: Settings,
+) -> RepositoryDetection | None:
+    root_value = repo_root(path)
+    if root_value is None:
+        return None
+    root = Path(root_value)
+    if repo_override:
+        repo = normalize_repo(repo_override)
+        repo_source = "cli"
+    else:
+        repo = derive_repo_from_remote(remote_url(root_value) or "")
+        if repo is None:
+            return None
+        repo_source = "git:origin"
+    branches = resolve_repo_branches(repo, settings=settings)
+    detected = remote_default_branch(root_value)
+    return RepositoryDetection(
+        root=root,
+        repo=repo,
+        repo_source=repo_source,
+        primary=detected or branches.primary,
+        primary_source="git:origin/HEAD" if detected else branches.source,
+    )
+
+
+def plan_repository_config(
+    detection: RepositoryDetection,
+    *,
+    settings: Settings,
+    primary: str | None = None,
+    index: tuple[str, ...] | None = None,
+    config_root: Path | None = None,
+) -> RepositoryConfigPlan:
+    root = config_root or reviewer_config_root()
+    path = home_repo_path(detection.repo, root)
+    effective = resolve_repo_branches(detection.repo, settings=settings, config_root=root)
+    if effective.source == f"home:repos/{detection.repo}.yml":
+        selected_primary = effective.primary
+        selected_index = effective.index
+        action: PlanAction = "noop"
+    else:
+        selected_primary = primary or detection.primary
+        selected_index = index or (
+            effective.index if selected_primary in effective.index else (selected_primary,)
+        )
+        parse_branch_csv(",".join(selected_index), selected_primary)
+        try:
+            existing = path.read_text(encoding="utf-8")
+        except FileNotFoundError:
+            action = "create"
+        else:
+            action = "noop" if "repository" in _read_mapping(
+                existing, f"home:repos/{detection.repo}.yml"
+            ) else "append"
+    preview = render_repository_block(selected_primary, selected_index)
+    return RepositoryConfigPlan(
+        path=path,
+        repo=detection.repo,
+        primary=selected_primary,
+        index=selected_index,
+        repo_source=detection.repo_source,
+        primary_source=detection.primary_source,
+        action=action,
+        preview=preview,
+    )
+
+
+def apply_repository_config(plan: RepositoryConfigPlan) -> None:
+    if plan.action == "noop":
+        return
+    action = publish_repository_block(
+        plan.path,
+        f"home:repos/{plan.repo}.yml",
+        plan.preview,
+    )
+    if action not in {plan.action, "noop"}:
+        raise RuntimeError(f"ожидалось действие {plan.action}, выполнено {action}")
+```
+
+- [ ] **Step 6: Run focused tests and existing migration regressions**
+
+Run: `.venv/bin/pytest tests/config/test_onboarding.py tests/config/test_branches_migrate.py tests/config/test_branches.py -q`
+
+Expected: all tests pass.
+
+- [ ] **Step 7: Lint and commit**
+
+Run: `.venv/bin/ruff check reviewer/config/onboarding.py reviewer/config/branches.py tests/config/test_onboarding.py tests/config/test_branches_migrate.py`
+
+Then:
+
+```bash
+git add reviewer/config/onboarding.py reviewer/config/branches.py tests/config/test_onboarding.py tests/config/test_branches_migrate.py
+git commit -m "feat(config): добавляет план repo onboarding"
+```
+
+---
+
+### Task 3: Standard Wizard Contract Cleanup
+
+**Files:**
+- Modify: `reviewer/install.py:29-35,132-179,182-316`
+- Modify: `tests/install/test_install_wizard.py`
+- Modify: `tests/test_install_wizard.py`
+
+- [ ] **Step 1: Change tests to the new standard-field contract**
+
+Replace assertions that require removed fields:
+
+```python
+REMOVED_STANDARD_KEYS = {
+    "DEFAULT_REPO",
+    "REVIEW_BRANCHES",
+    "WEB_ADMIN_USER",
+    "WEB_ADMIN_PASSWORD",
+    "TASK_BOARD_MCP",
+}
+
+
+def test_fresh_wizard_omits_repo_web_and_legacy_board_mcp():
+    keys = {field.key for group in inst.WIZARD_GROUPS for field in group.fields}
+    assert keys.isdisjoint(REMOVED_STANDARD_KEYS)
+
+
+def test_runtime_template_keeps_compatibility_keys():
+    template_keys = _keys_from_text(inst.ENV_TEMPLATE)
+    assert REMOVED_STANDARD_KEYS <= template_keys
+
+
+def test_render_env_preserves_removed_existing_keys_as_extra():
+    values = {field.key: field.default for group in inst.WIZARD_GROUPS for field in group.fields}
+    extra = {key: f"existing-{key.lower()}" for key in REMOVED_STANDARD_KEYS}
+
+    rendered = inst.render_env(values, extra)
+
+    for key, value in extra.items():
+        assert f"{key}={value}" in rendered
+```
+
+Update board registry assertions to require exactly
+`{"TASK_BOARD_KEY_PATTERN", "TASK_BOARD_URL_TEMPLATE"}` as common fields and adjust the field
+count from `registry_fields + 3` to `registry_fields + 2`.
+
+- [ ] **Step 2: Run tests and verify RED**
+
+Run: `.venv/bin/pytest tests/install/test_install_wizard.py tests/test_install_wizard.py -q`
+
+Expected: failures because removed keys are still present in `WIZARD_GROUPS`.
+
+- [ ] **Step 3: Remove only standard wizard declarations**
+
+In `reviewer/install.py`:
+
+```python
+COMMON_BOARD_ENV_KEYS = frozenset(
+    {
+        "TASK_BOARD_KEY_PATTERN",
+        "TASK_BOARD_URL_TEMPLATE",
+    }
+)
+```
+
+Remove the `TASK_BOARD_MCP` `EnvField`, the complete `Мульти-репо / ветки` `EnvGroup`, the
+complete `Веб-админка` `EnvGroup`, and their `_GROUP_HEADERS` entries. Keep
+`_ENV_TEMPLATE_BASE`, `.env.example`, `Settings`, and compatibility comments unchanged.
+
+- [ ] **Step 4: Run focused tests**
+
+Run: `.venv/bin/pytest tests/install/test_install_wizard.py tests/test_install_wizard.py -q`
+
+Expected: all tests pass.
+
+- [ ] **Step 5: Lint and commit**
+
+```bash
+.venv/bin/ruff check reviewer/install.py tests/install/test_install_wizard.py tests/test_install_wizard.py
+```
+
+---
+
+### Task 4: CLI Scope and Noninteractive Unified Preview
+
+**Files:**
+- Modify: `reviewer/entrypoints/cli.py:97-103,1083-1195`
+- Create: `tests/entrypoints/test_cli_init_onboarding.py`
+
+- [ ] **Step 1: Write scope/dry-run/yes tests**
+
+Create tests with a helper that isolates env and home paths:
+
+```python
+from pathlib import Path
+
+from click.testing import CliRunner
+
+from reviewer.entrypoints.cli import cli
+
+
+def _isolate(monkeypatch, tmp_path):
+    env = tmp_path / "runtime.env"
+    monkeypatch.setattr("reviewer.install.default_env_path", lambda: env)
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "xdg"))
+    return env
+
+
+def _detection(tmp_path):
+    from reviewer.config.onboarding import RepositoryDetection
+
+    return RepositoryDetection(
+        root=tmp_path,
+        repo="o/r",
+        repo_source="git:origin",
+        primary="dev",
+        primary_source="git:origin/HEAD",
+    )
+
+
+def test_init_scope_global_never_detects_repo(monkeypatch, tmp_path):
+    env = _isolate(monkeypatch, tmp_path)
+    monkeypatch.setattr(
+        "reviewer.entrypoints.cli.detect_repository",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(AssertionError("repo detection called")),
+    )
+
+    result = CliRunner().invoke(cli, ["init", "--scope", "global", "--yes"])
+
+    assert result.exit_code == 0, result.output
+    assert env.exists()
+
+
+def test_init_scope_repo_does_not_rewrite_env(monkeypatch, tmp_path):
+    env = _isolate(monkeypatch, tmp_path)
+    env.write_text("SENTINEL=unchanged\n", encoding="utf-8")
+    monkeypatch.setattr(
+        "reviewer.entrypoints.cli.detect_repository",
+        lambda *_args, **_kwargs: _detection(tmp_path),
+    )
+
+    result = CliRunner().invoke(cli, ["init", "--scope", "repo", "--yes"])
+
+    assert result.exit_code == 0, result.output
+    assert env.read_text(encoding="utf-8") == "SENTINEL=unchanged\n"
+    assert (tmp_path / "xdg/rag-reviewer/repos/o/r.yml").exists()
+
+
+def test_init_dry_run_previews_both_targets_without_writes(monkeypatch, tmp_path):
+    env = _isolate(monkeypatch, tmp_path)
+    monkeypatch.setattr(
+        "reviewer.entrypoints.cli.detect_repository",
+        lambda *_args, **_kwargs: _detection(tmp_path),
+    )
+    monkeypatch.setattr(
+        "reviewer.entrypoints.cli.apply_repository_config",
+        lambda _plan: (_ for _ in ()).throw(AssertionError("repo write called")),
+    )
+    monkeypatch.setattr(
+        "click.prompt",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(AssertionError("prompt called")),
+    )
+
+    result = CliRunner().invoke(cli, ["init", "--dry-run"])
+
+    assert result.exit_code == 0, result.output
+    assert str(env) in result.output
+    assert "repos/o/r.yml" in result.output
+    assert "git:origin/HEAD" in result.output
+    assert not env.exists()
+    assert not (tmp_path / "xdg").exists()
+
+
+def test_init_yes_never_enters_provider_or_post_network_stages(monkeypatch, tmp_path):
+    _isolate(monkeypatch, tmp_path)
+    monkeypatch.setattr(
+        "reviewer.entrypoints.cli.detect_repository",
+        lambda *_args, **_kwargs: _detection(tmp_path),
+    )
+    monkeypatch.setattr(
+        "reviewer.tasks.boards.setup.configure_board_provider",
+        lambda *_args: (_ for _ in ()).throw(AssertionError("provider setup called")),
+    )
+    monkeypatch.setattr(
+        "reviewer.entrypoints.cli._run_codex_target",
+        lambda **_kwargs: (_ for _ in ()).throw(AssertionError("client install called")),
+    )
+
+    result = CliRunner().invoke(cli, ["init", "--yes"])
+
+    assert result.exit_code == 0, result.output
+```
+
+- [ ] **Step 2: Run tests and verify RED**
+
+Run: `.venv/bin/pytest tests/entrypoints/test_cli_init_onboarding.py -q`
+
+Expected: Click rejects `--scope`/`--repo`, and onboarding imports do not exist in CLI.
+
+- [ ] **Step 3: Add CLI options and small plan helpers**
+
+Import onboarding symbols and add:
+
+```python
+from reviewer.config.onboarding import (
+    RepositoryConfigPlan,
+    apply_repository_config,
+    detect_repository,
+    parse_branch_csv,
+    plan_repository_config,
+)
+
+
+@dataclass(frozen=True)
+class _GlobalInitPlan:
+    path: Path
+    content: str
+    preview: str
+    source: str
+
+
+def _render_init_preview(
+    global_plan: _GlobalInitPlan | None,
+    repo_plan: RepositoryConfigPlan | None,
+) -> None:
+    click.echo("# reviewer init preview")
+    if global_plan is not None:
+        click.echo(f"\nfile: {global_plan.path}")
+        click.echo(f"source: {global_plan.source}")
+        click.echo(global_plan.preview)
+    if repo_plan is not None:
+        click.echo(f"\nfile: {repo_plan.path}")
+        click.echo(f"action: {repo_plan.action}")
+        click.echo(f"repo: {repo_plan.repo} ({repo_plan.repo_source})")
+        click.echo(f"primary: {repo_plan.primary} ({repo_plan.primary_source})")
+        click.echo(repo_plan.preview)
+```
+
+Extend Click declaration and signature:
+
+```python
+@click.option(
+    "--scope",
+    type=click.Choice(("all", "global", "repo")),
+    default="all",
+    show_default=True,
+)
+@click.option("--repo", "repo_opt", default=None, help="owner/name для repo stage")
+def init(
+    path_opt: str | None,
+    yes: bool,
+    dry_run: bool,
+    scope: str,
+    repo_opt: str | None,
+) -> None:
+```
+
+- [ ] **Step 4: Refactor command into plan/preview/apply phases**
+
+Keep current board setup logic, but execute it only for global scope and interactive mode. The
+command body must follow this concrete shape:
+
+```python
+run_global = scope in {"all", "global"}
+run_repo = scope in {"all", "repo"}
+settings = Settings()
+global_plan = None
+repo_plan = None
+
+if run_global:
+    dest = Path(path_opt).expanduser() if path_opt else inst.default_env_path()
+    current = inst.read_env(dest)
+    values = inst.prompt_groups(inst.WIZARD_GROUPS, current=current, yes=yes or dry_run)
+    extra = {
+        key: value
+        for key, value in current.items()
+        if key not in {field.key for group in inst.WIZARD_GROUPS for field in group.fields}
+    }
+    content = inst.render_env(values, extra)
+    global_plan = _GlobalInitPlan(
+        path=dest,
+        content=content,
+        preview=inst.render_env_preview(values, extra),
+        source=f"existing:{dest}" if dest.is_file() else "wizard defaults/input",
+    )
+
+if run_repo:
+    detection = detect_repository(".", repo_opt, settings=settings)
+    if detection is None:
+        message = "repo не определён: запустите из git repository или передайте --repo owner/name"
+        if scope == "repo":
+            raise click.ClickException(message)
+        click.echo(f"repo stage пропущен: {message}")
+    else:
+        repo_plan = plan_repository_config(detection, settings=settings)
+
+_render_init_preview(global_plan, repo_plan)
+if dry_run:
+    return
+if not yes and not click.confirm("\nЗаписать показанные изменения?", default=True):
+    click.echo("Отменено — файлы не изменены.")
+    return
+if global_plan is not None:
+    global_plan.path.parent.mkdir(parents=True, exist_ok=True)
+    global_plan.path.write_text(global_plan.content, encoding="utf-8")
+    click.echo(f"✓ Записан {global_plan.path}")
+if repo_plan is not None:
+    apply_repository_config(repo_plan)
+    click.echo(f"✓ Repo config: {repo_plan.action} → {repo_plan.path}")
+```
+
+Preserve existing interactive provider setup between global values collection and content render;
+preserve reviewer check/Codex prompts only after successful apply and only without `--yes`.
+
+- [ ] **Step 5: Run focused CLI and legacy tests**
+
+Run: `.venv/bin/pytest tests/entrypoints/test_cli_init_onboarding.py tests/install/test_install_wizard.py -q`
+
+Expected: all tests pass.
+
+- [ ] **Step 6: Lint and commit**
+
+```bash
+.venv/bin/ruff check reviewer/entrypoints/cli.py tests/entrypoints/test_cli_init_onboarding.py
+```
+
+---
+
+### Task 5: Interactive Correction and Preview-Before-Write Guard
+
+**Files:**
+- Modify: `reviewer/entrypoints/cli.py`
+- Modify: `tests/entrypoints/test_cli_init_onboarding.py`
+
+- [ ] **Step 1: Add failing interactive tests**
+
+Append:
+
+```python
+def test_init_interactive_can_correct_detected_branches(monkeypatch, tmp_path):
+    _isolate(monkeypatch, tmp_path)
+    monkeypatch.setattr(
+        "reviewer.entrypoints.cli.detect_repository",
+        lambda *_args, **_kwargs: _detection(tmp_path),
+    )
+    monkeypatch.setattr("reviewer.install.prompt_groups", lambda *_args, **_kwargs: {})
+    answers = iter(["release", "release,main"])
+    monkeypatch.setattr("click.prompt", lambda *_args, **_kwargs: next(answers))
+    monkeypatch.setattr("click.confirm", lambda *_args, **_kwargs: True)
+    monkeypatch.setattr("reviewer.entrypoints.cli._shutil.which", lambda _name: None)
+
+    result = CliRunner().invoke(cli, ["init", "--scope", "repo"])
+
+    assert result.exit_code == 0, result.output
+    data = yaml.safe_load((tmp_path / "xdg/rag-reviewer/repos/o/r.yml").read_text())
+    assert data["repository"] == {
+        "primary_branch": "release",
+        "index_branches": ["release", "main"],
+    }
+
+
+def test_init_rejects_preview_before_first_write(monkeypatch, tmp_path):
+    env = _isolate(monkeypatch, tmp_path)
+    monkeypatch.setattr(
+        "reviewer.entrypoints.cli.detect_repository",
+        lambda *_args, **_kwargs: _detection(tmp_path),
+    )
+    monkeypatch.setattr("reviewer.install.prompt_groups", lambda *_args, **_kwargs: {})
+    monkeypatch.setattr("click.prompt", lambda _text, default, **_kwargs: default)
+    confirmations = iter([False, False])  # provider disabled, final write rejected
+    monkeypatch.setattr("click.confirm", lambda *_args, **_kwargs: next(confirmations))
+
+    result = CliRunner().invoke(cli, ["init"])
+
+    assert result.exit_code == 0, result.output
+    assert "Отменено" in result.output
+    assert not env.exists()
+    assert not (tmp_path / "xdg").exists()
+
+
+def test_init_scope_repo_missing_detection_is_hard_error(monkeypatch, tmp_path):
+    _isolate(monkeypatch, tmp_path)
+    monkeypatch.setattr("reviewer.entrypoints.cli.detect_repository", lambda *_args, **_kwargs: None)
+
+    result = CliRunner().invoke(cli, ["init", "--scope", "repo", "--yes"])
+
+    assert result.exit_code != 0
+    assert "--repo owner/name" in result.output
+
+
+def test_init_interactive_asks_repo_when_remote_is_unrecognized(monkeypatch, tmp_path):
+    _isolate(monkeypatch, tmp_path)
+    detection = _detection(tmp_path)
+    calls = iter([None, detection])
+    monkeypatch.setattr(
+        "reviewer.entrypoints.cli.detect_repository",
+        lambda *_args, **_kwargs: next(calls),
+    )
+    answers = iter(["o/r", "dev", "dev"])
+    monkeypatch.setattr("click.prompt", lambda *_args, **_kwargs: next(answers))
+    monkeypatch.setattr("click.confirm", lambda *_args, **_kwargs: True)
+
+    result = CliRunner().invoke(cli, ["init", "--scope", "repo"])
+
+    assert result.exit_code == 0, result.output
+    assert (tmp_path / "xdg/rag-reviewer/repos/o/r.yml").exists()
+```
+
+- [ ] **Step 2: Run tests and verify RED**
+
+Run: `.venv/bin/pytest tests/entrypoints/test_cli_init_onboarding.py -q`
+
+Expected: branch correction test writes detected `dev`, not requested `release`.
+
+- [ ] **Step 3: Add interactive branch correction loop**
+
+Before `plan_repository_config` in interactive repo mode, retry detection once with an explicitly
+entered repo id, then collect branches:
+
+```python
+detection = detect_repository(".", repo_opt, settings=settings)
+if detection is None and not yes and not dry_run and repo_opt is None:
+    entered_repo = click.prompt("Repository (owner/name)", default="", show_default=False).strip()
+    if entered_repo:
+        detection = detect_repository(".", entered_repo, settings=settings)
+
+if detection is None:
+    message = "repo не определён: запустите из git repository или передайте --repo owner/name"
+    if scope == "repo":
+        raise click.ClickException(message)
+    click.echo(f"repo stage пропущен: {message}")
+
+primary = detection.primary
+index = None
+initial_plan = plan_repository_config(detection, settings=settings)
+if initial_plan.action != "noop" and not yes and not dry_run:
+    primary = click.prompt("Primary branch", default=detection.primary).strip()
+    while True:
+        raw_index = click.prompt("Index branches (CSV)", default=primary)
+        try:
+            index = parse_branch_csv(raw_index, primary)
+        except ValueError as exc:
+            click.echo(f"Некорректные ветки: {exc}")
+            continue
+        break
+repo_plan = plan_repository_config(
+    detection,
+    settings=settings,
+    primary=primary,
+    index=index,
+)
+```
+
+If the initial plan is `noop`, skip branch prompts and keep its effective values.
+
+- [ ] **Step 4: Run CLI tests**
+
+Run: `.venv/bin/pytest tests/entrypoints/test_cli_init_onboarding.py -q`
+
+Expected: all tests pass.
+
+- [ ] **Step 5: Run existing provider flow regression**
+
+Run: `.venv/bin/pytest tests/install/test_install_wizard.py::test_init_interactive_configures_selected_registry_provider tests/install/test_install_wizard.py::test_init_noninteractive_modes_never_touch_provider_setup_stages -q`
+
+Expected: both pass after updating test confirmation sequences for the final preview prompt.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add reviewer/entrypoints/cli.py tests/entrypoints/test_cli_init_onboarding.py tests/install/test_install_wizard.py
+```
+
+---
+
+### Task 6: Effective Output and Launcher Contract
+
+**Files:**
+- Modify: `reviewer/entrypoints/cli.py:97-103,159-207`
+- Modify: `reviewer/launcher/metadata.py:55-60`
+- Modify: `tests/entrypoints/test_cli_init_onboarding.py`
+- Modify: `tests/launcher/test_catalog.py`
+
+- [ ] **Step 1: Add failing output/catalog tests**
+
+Append CLI assertion:
+
+```python
+def test_init_repo_prints_effective_branch_source_and_follow_up(monkeypatch, tmp_path):
+    _isolate(monkeypatch, tmp_path)
+    monkeypatch.setattr(
+        "reviewer.entrypoints.cli.detect_repository",
+        lambda *_args, **_kwargs: _detection(tmp_path),
+    )
+
+    result = CliRunner().invoke(cli, ["init", "--scope", "repo", "--yes"])
+
+    assert result.exit_code == 0, result.output
+    assert "branches:" in result.output
+    assert "home:repos/o/r.yml" in result.output
+    assert "reviewer config show --repo o/r" in result.output
+```
+
+Add launcher schema assertion:
+
+```python
+def test_init_schema_exposes_scope_and_repo_options():
+    init = next(item for item in build_catalog(cli) if item.path == ("init",))
+    by_name = {parameter.name: parameter for parameter in init.params}
+
+    assert by_name["scope"].choices == ("all", "global", "repo")
+    assert by_name["repo_opt"].option_strings == ("--repo",)
+```
+
+- [ ] **Step 2: Run tests and verify RED**
+
+Run: `.venv/bin/pytest tests/entrypoints/test_cli_init_onboarding.py tests/launcher/test_catalog.py -q`
+
+Expected: CLI output assertions fail; launcher metadata may need updated details.
+
+- [ ] **Step 3: Extract and reuse branches report helper**
+
+Add near `_render_config_report`:
+
+```python
+def _branches_report(branches) -> dict[str, object]:
+    return {
+        "branches": {
+            "primary": branches.primary,
+            "index": list(branches.index),
+            "source": branches.source,
+        }
+    }
+```
+
+Use `_branches_report(branches)` in `config_show` instead of the inline payload. After repo apply,
+resolve and render locally:
+
+```python
+effective = resolve_repo_branches(repo_plan.repo, settings=settings)
+_render_config_report(_branches_report(effective))
+click.echo(f"Полный отчёт: reviewer config show --repo {repo_plan.repo}")
+```
+
+This path must not call `_config_context`, VCS, or policy resolution.
+
+- [ ] **Step 4: Update launcher text**
+
+Change `reviewer/launcher/metadata.py`:
+
+```python
+("init",): CommandPresentation(
+    summary="Настроить reviewer",
+    details="Планирует и настраивает global .env и per-repo branch config с preview до записи.",
+    effects=(Effect.WRITE,),
+    scenarios=("Первичная настройка", "Добавление репозитория", "Смена credentials"),
+    keywords=("config", "env", "repository", "wizard"),
+),
+```
+
+- [ ] **Step 5: Run focused tests and lint**
+
+Run: `.venv/bin/pytest tests/entrypoints/test_cli_init_onboarding.py tests/entrypoints/test_cli_config_show_branches.py tests/launcher/test_catalog.py -q`
+
+Run: `.venv/bin/ruff check reviewer/entrypoints/cli.py reviewer/launcher/metadata.py tests/entrypoints/test_cli_init_onboarding.py tests/launcher/test_catalog.py`
+
+Expected: tests and Ruff pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add reviewer/entrypoints/cli.py reviewer/launcher/metadata.py tests/entrypoints/test_cli_init_onboarding.py tests/launcher/test_catalog.py
+```
+
+---
+
+### Task 7: Acceptance Verification and Scope Guard
+
+**Files:**
+- Modify only if failures expose scoped defects.
+
+- [ ] **Step 1: Run complete focused onboarding/config suite**
+
+Run:
+
+```bash
+.venv/bin/pytest \
+  tests/test_gitutil.py \
+  tests/config/test_onboarding.py \
+  tests/config/test_branches.py \
+  tests/config/test_branches_migrate.py \
+  tests/install/test_install_wizard.py \
+  tests/test_install_wizard.py \
+  tests/entrypoints/test_cli_init_onboarding.py \
+  tests/entrypoints/test_cli_config_show_branches.py \
+  tests/launcher/test_catalog.py -q
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 2: Run neighboring CLI/config tests**
+
+Run:
+
+```bash
+.venv/bin/pytest \
+  tests/entrypoints/test_cli.py \
+  tests/entrypoints/test_config_commands.py \
+  tests/config/test_settings.py \
+  tests/config/test_layers.py -q
+```
+
+Expected: all tests pass; runtime legacy env behavior remains intact.
+
+- [ ] **Step 3: Run full unit suite**
+
+Run: `.venv/bin/pytest -q`
+
+Expected: all non-integration tests pass with no infrastructure/network access.
+
+- [ ] **Step 4: Run static and diff checks**
+
+Run: `.venv/bin/ruff check . && git diff --check`
+
+Expected: both commands exit 0.
+
+- [ ] **Step 5: Audit scope mechanically**
+
+Run:
+
+```bash
+git diff --name-only dev...HEAD
+git grep -n "DEFAULT_REPO\|REVIEW_BRANCHES\|WEB_ADMIN_\|TASK_BOARD_MCP" -- reviewer/install.py tests/install/test_install_wizard.py tests/test_install_wizard.py
+```
+
+Expected:
+
+- changed production files are limited to gitutil, config onboarding/branches, install, CLI and launcher metadata;
+- removed keys remain only in compatibility template/comments/tests, not `WIZARD_GROUPS` fields;
+- no provider registry/setup, configure-review skill or README changes.
+
+- [ ] **Step 6: Commit any verification-only fixes**
+
+If Step 1-5 required code changes, stage only this plan's production/test files and commit:
+
+```bash
+git add reviewer/gitutil.py reviewer/config/onboarding.py reviewer/config/branches.py reviewer/install.py reviewer/entrypoints/cli.py reviewer/launcher/metadata.py tests/test_gitutil.py tests/config/test_onboarding.py tests/config/test_branches_migrate.py tests/install/test_install_wizard.py tests/test_install_wizard.py tests/entrypoints/test_cli_init_onboarding.py tests/launcher/test_catalog.py
+git commit -m "fix(init): закрывает регрессии repo onboarding"
+```
+
+If no files changed, do not create an empty commit.
+
+---
+
+## Completion Criteria
+
+- Fresh `reviewer init` does not ask or generate removed standard fields.
+- `reviewer init --scope repo` configures a second repo without reading/writing global `.env`.
+- Repo ID and primary provenance appear in preview before any write.
+- `--yes` and `--dry-run` are prompt-free and network-free; dry-run is write-free.
+- Existing advanced env and existing per-repo YAML keys/comments survive repeated runs.
+- Effective branches and source are shown through the shared `config show` renderer contract.
+- Parts C and D remain untouched.

--- a/docs/superpowers/specs/2026-08-08-PRI-223-reviewer-init-onboarding-design.md
+++ b/docs/superpowers/specs/2026-08-08-PRI-223-reviewer-init-onboarding-design.md
@@ -1,0 +1,302 @@
+# PRI-223 (часть B) — Global/runtime и repo onboarding в reviewer init
+
+Задача: https://ru.yougile.com/team/686c049c8af8/#PRI-223
+Бриф: `docs/superpowers/briefs/2026-08-07-PRI-223-redesign-reviewer-init.md`
+
+## Скоуп
+
+Эта спека покрывает только часть B задачи PRI-223:
+
+- разделение `reviewer init` на global runtime/credentials и repo onboarding;
+- автоматическое определение repo из локального git remote и primary branch без сети;
+- удаление multirepo, `DEFAULT_REPO`, `REVIEW_BRANCHES`, `WEB_ADMIN_*` и legacy
+  `TASK_BOARD_MCP` из стандартных вопросов мастера;
+- общий preview затрагиваемых файлов, несекретных значений и provenance до первой записи;
+- неразрушающая повторная настройка второго репозитория.
+
+Покрываемые пункты «Что сделать»: 2, 7, оставшаяся часть 8, 11.
+Покрываемые критерии: 1, 2, 3, 10, 11.
+
+Вне скоупа:
+
+- provider-scoped credentials, минимальные права и YouGile acquisition flow — часть C;
+- правки skill `configure-review`, двуязычная документация и общий добор тестов — часть D;
+- изменение runtime-семантики legacy env — значения продолжают читаться `Settings`;
+- изменение branch resolution — часть A уже реализована и смержена PR #159.
+
+## Проблема
+
+Текущий `reviewer init` — один мастер одного `.env`. `WIZARD_GROUPS`
+(`reviewer/install.py:182-275`) смешивает runtime/credentials с repo-specific вопросами и
+advanced web-настройками. Команда `init` (`reviewer/entrypoints/cli.py:1083-1195`) смешивает
+prompting, provider setup, preview, запись и post-actions в одной функции.
+
+Из этого следуют четыре дефекта:
+
+1. Второй repo требует повторного прохода по глобальному `.env`, хотя branch config уже
+   изолирован в `home:repos/<owner>/<name>.yml`.
+2. Fresh wizard предлагает `DEFAULT_REPO` и `REVIEW_BRANCHES`, хотя repo выводится из remote, а
+   ветки после части A принадлежат per-repo home config.
+3. `--dry-run` показывает только `.env`; обычный интерактивный запуск вообще пишет без итогового
+   preview и общего подтверждения.
+4. Автодетект default branch отсутствует. Использовать сетевой `git remote show origin` нельзя:
+   критерий 10 запрещает сеть и в `--yes`, и в `--dry-run`.
+
+## Выбранный подход
+
+Сохраняем одну публичную команду и вводим явные стадии:
+
+```text
+reviewer init                         # --scope all: global + repo
+reviewer init --scope global          # только user-scope .env
+reviewer init --scope repo            # только текущий git repo
+reviewer init --scope repo --repo o/r # repo id явно, если remote отсутствует/нестандартен
+```
+
+Альтернативы отклонены:
+
+- расширить текущую монолитную `init`: минимальный diff, но planning, side effects и error paths
+  останутся неразделимыми и плохо тестируемыми;
+- добавить `init-global`/`init-repo`: границы чистые, но это лишние top-level команды и ненужная
+  миграция launcher/CLI-контракта.
+
+`--scope` — `click.Choice(("all", "global", "repo"))`, default `all`. Существующие `--path`,
+`--yes` и `--dry-run` сохраняют смысл. `--path` влияет только на global stage. Новый `--repo`
+задаёт canonical repo id для repo stage; без него используется `origin` текущего git root.
+
+## Global Stage
+
+### Стандартные поля
+
+Из `WIZARD_GROUPS` удаляются:
+
+- группа «Мульти-репо / ветки» целиком (`DEFAULT_REPO`, `REVIEW_BRANCHES`);
+- группа «Веб-админка» целиком (`WEB_ADMIN_USER`, `WEB_ADMIN_PASSWORD`);
+- `TASK_BOARD_MCP` из общей части board group.
+
+`TASK_BOARD_KEY_PATTERN`, `TASK_BOARD_URL_TEMPLATE` и текущие registry-driven provider fields
+остаются до части C. Часть B не меняет provider selection/setup flow.
+
+Удалённые поля не удаляются из `Settings`, `_ENV_TEMPLATE_BASE` или `.env.example`: это runtime
+compatibility и advanced reference. При повторном init они не входят в `wizard_keys`, поэтому
+попадают в `extra` и сохраняются с исходными значениями. Fresh generated `.env` их не содержит,
+потому что `render_env` выводит только wizard groups и реальные extra.
+
+### Preview
+
+Global plan содержит:
+
+- target `.env`;
+- provenance `existing:<path>` или `wizard defaults/input`;
+- полный будущий `.env`, пропущенный через существующий `render_env_preview`.
+
+Secret-like keys и credentials в URL остаются пустыми в preview по текущему контракту.
+
+## Repo Stage
+
+### Git detection
+
+В `reviewer/gitutil.py` добавляются две fail-soft функции без сети:
+
+```python
+def repo_root(path: str = ".") -> str | None: ...
+def remote_default_branch(repo: str) -> str | None: ...
+```
+
+`repo_root` использует `git -C <path> rev-parse --show-toplevel`.
+`remote_default_branch` использует локальный symbolic ref
+`refs/remotes/origin/HEAD` и возвращает имя без `origin/`. Он не вызывает `fetch`, `ls-remote`
+или `remote show`.
+
+Repo id выбирается в порядке:
+
+1. `reviewer init --repo owner/name` → provenance `cli`;
+2. `remote_url(root)` + `derive_repo_from_remote(...)` → provenance `git:origin`;
+3. repo stage недоступен.
+
+`DEFAULT_REPO` намеренно не участвует в onboarding autodetect: он остаётся runtime fallback для
+старых session-less вызовов, но не является владельцем нового repo config.
+
+Если git root отсутствует, `scope=repo` завершается понятной ошибкой, а `scope=all` завершает
+global stage и печатает команду повтора из git repository. Если root есть, но repo id не удалось
+получить, интерактивный режим предлагает ввести `owner/name`; noninteractive режим не prompt-ит:
+`scope=repo` возвращает ошибку с `--repo`, `scope=all` пропускает repo stage с той же подсказкой.
+
+### Branch candidate
+
+Сначала вызывается `resolve_repo_branches(repo, settings=...)` из части A.
+
+- Если source уже `home:repos/<repo>.yml`, существующий `repository` block считается
+  authoritative: stage показывает noop и ничего не переписывает.
+- Иначе primary candidate = локальный `origin/HEAD`, если он существует; fallback = effective
+  `RepoBranches.primary` (home global → env → default `main`).
+- Если candidate входит в effective `RepoBranches.index`, default index сохраняет effective list;
+  иначе default index = `(candidate,)`.
+
+Interactive запуск показывает repo id, primary и provenance, затем позволяет изменить primary и
+CSV index list. Primary обязан входить в index; parsing и validation переиспользуют инварианты
+`RepoBranches`. `--yes` и `--dry-run` принимают candidates без prompt.
+
+Текущая feature branch не используется как primary fallback: это часто случайная ветка задачи.
+
+### Repo config plan
+
+Новый модуль `reviewer/config/onboarding.py` отделяет вычисление от side effects:
+
+```python
+@dataclass(frozen=True)
+class RepositoryDetection:
+    root: Path
+    repo: str
+    repo_source: str
+    primary: str
+    primary_source: str
+
+@dataclass(frozen=True)
+class RepositoryConfigPlan:
+    path: Path
+    repo: str
+    primary: str
+    index: tuple[str, ...]
+    repo_source: str
+    primary_source: str
+    action: Literal["create", "append", "noop"]
+    preview: str
+
+def detect_repository(path: str, repo_override: str | None, *, settings: Settings) \
+        -> RepositoryDetection | None: ...
+def plan_repository_config(detection: RepositoryDetection, *, settings: Settings,
+                           primary: str | None = None,
+                           index: tuple[str, ...] | None = None,
+                           config_root: Path | None = None) \
+        -> RepositoryConfigPlan: ...
+def apply_repository_config(plan: RepositoryConfigPlan) -> None: ...
+```
+
+`config_root` допускается как keyword-only test seam у plan, аналогично
+`resolve_repo_branches`; apply получает уже вычисленный target path, а публичный CLI test seam
+не выставляет.
+
+Plan не создаёт директорий и не пишет файлы. `preview` показывает только будущий
+`repository.primary_branch` / `repository.index_branches`; секретов в этом блоке быть не может.
+
+### Non-destructive write
+
+Repo destination всегда вычисляется через `home_repo_path(repo)`.
+
+- отсутствующий файл создаётся exclusive;
+- файл без `repository` получает YAML block append-ом, сохраняя существующие keys/comments;
+- существующий `repository` даёт noop, без merge или overwrite;
+- unknown top-level и `repository` subkeys не удаляются;
+- повторный запуск byte-for-byte не меняет файл.
+
+Общую create/append/noop механику следует извлечь из `migrate_repo_branches`, чтобы migration и
+onboarding не расходились по quoting, race handling и comment preservation. Renderer пишет
+`primary_branch` явно и использует `yaml.safe_dump`, чтобы имена вроде `2.0`, `on` и
+`feature{x}` оставались строками.
+
+## Command Flow
+
+`reviewer init` работает в пяти фазах:
+
+1. Resolve scope и собрать current `.env` без записи.
+2. Собрать global plan: values и redacted content строятся во всех режимах, а интерактивный
+   provider setup запускается только без `--yes`/`--dry-run` и может использовать сеть.
+3. Выполнить offline repo detection, интерактивно скорректировать candidates и построить repo plan.
+4. Показать единый preview всех выбранных targets и provenance; в interactive mode запросить одно
+   финальное подтверждение. До него filesystem не меняется.
+5. Применить global/repo plans, затем вывести результаты и effective branch report.
+
+`--dry-run` выполняет фазы 1-4 в noninteractive режиме и завершает работу. Он не создаёт parent
+directories, не запускает provider setup, `reviewer check`, client install или policy VCS.
+
+`--yes` также не вызывает prompt, provider setup, browser, `reviewer check` или полный
+`config show`; он показывает preview и сразу применяет план.
+
+Для `scope=all` два файла не образуют транзакцию. Ошибка записи второго файла не откатывает первый:
+rollback конфигурации опаснее явного частичного результата. Команда сообщает каждый успешный
+target и завершается non-zero на ошибке. Ключевой инвариант — ни один target не меняется до preview
+и подтверждения.
+
+## Effective Output
+
+После успешной repo write/noop команда повторно вызывает `resolve_repo_branches` и выводит ту же
+структуру:
+
+```text
+branches:
+  primary: dev  (home:repos/mimfort/rag_for_git.yml)
+  index:   dev, main  (home:repos/mimfort/rag_for_git.yml)
+```
+
+Renderer/data builder извлекается из `config show` и переиспользуется `init`, чтобы не появилось
+второго формата provenance. Полный `reviewer config show` не вызывается автоматически: он читает
+committed policy через VCS и нарушил бы no-network контракт `--yes`. Команда печатает точный
+follow-up `reviewer config show --repo <repo>` для полного отчёта.
+
+## Error Handling
+
+- invalid `--repo` → Click error до preview;
+- no git root / no repo id → skip только в `scope=all`, hard error в `scope=repo`;
+- missing `origin/HEAD` → effective branch fallback, не network lookup;
+- invalid interactive branch CSV → повторный prompt; в noninteractive candidates уже валидны;
+- malformed existing home YAML / invalid `repository` → sanitized `HomeConfigError`, без fallback и
+  без записи;
+- existing `repository` → noop, не конфликт и не rewrite;
+- `click.Abort` до final confirmation → ни один target не изменён;
+- write error → non-zero с path и типом ошибки, без вывода secret values.
+
+## Testing
+
+Все тесты unit, без Postgres, Neo4j, localhost и внешней сети.
+
+`tests/test_gitutil.py`:
+
+- git root success/failure;
+- local `origin/HEAD` → branch без prefix;
+- missing symbolic ref → None;
+- helper никогда не вызывает сетевые git subcommands.
+
+`tests/config/test_onboarding.py`:
+
+- `--repo` выше remote; remote выше отсутствия repo id;
+- `origin/HEAD` выше effective branch fallback;
+- compatible effective index сохраняется, incompatible сокращается до detected primary;
+- existing per-repo block → noop;
+- create и append сохраняют unrelated YAML/comments;
+- ambiguous YAML branch names round-trip как строки;
+- repeat apply byte-for-byte noop;
+- два repo получают разные paths и не меняют конфиг друг друга.
+
+`tests/install/test_install_wizard.py` и `tests/test_install_wizard.py`:
+
+- fresh wizard keys не содержат удалённые поля;
+- `_ENV_TEMPLATE_BASE` / `.env.example` всё ещё содержат runtime compatibility keys;
+- existing удалённые keys сохраняются через `extra`;
+- board common fields больше не содержат `TASK_BOARD_MCP`.
+
+CLI tests:
+
+- `--scope global` не вызывает git/repo write;
+- `--scope repo` не читает и не меняет global `.env`;
+- default `all` показывает оба targets до первой записи;
+- interactive reject оставляет оба targets неизменными;
+- `--dry-run` не prompt-ит, не вызывает сеть и ничего не создаёт;
+- `--yes` не prompt-ит и не вызывает provider/check/config-show network paths;
+- no git/remote поведение различается для `all` и `repo` как описано выше;
+- preview redacts current, legacy и unknown secret-like env;
+- successful repo stage выводит effective branch source и follow-up command;
+- второй repo через `--scope repo` не меняет `.env` и первый repo file.
+
+## Риски
+
+- `origin/HEAD` не создан в некоторых старых клонах. Offline fallback намеренно использует
+  effective config, а interactive mode позволяет исправить значение; скрытый network fallback
+  запрещён.
+- Существующий `repository` block не редактируется мастером. Это сознательная защита
+  comments/unknown settings; изменение готового блока остаётся за частью D (`configure-review`)
+  или ручной правкой.
+- Global и repo writes не атомарны вместе. Preview-first и per-target result делают частичный
+  результат явным, а `--scope` позволяет безопасно повторить только незавершённую стадию.
+- Удалённые wizard fields остаются в `.env.example`, поэтому документация должна чётко отличать
+  standard onboarding от advanced/runtime fallback; это будет завершено частью D.

--- a/reviewer/config/branches.py
+++ b/reviewer/config/branches.py
@@ -367,7 +367,7 @@ def _read_locked_destination(
             or len(identities) != 1
         ):
             raise HomeConfigError(f"{source}: race при чтении destination")
-        with os.fdopen(os.dup(descriptor), encoding="utf-8") as handle:
+        with os.fdopen(os.dup(descriptor), encoding="utf-8", newline="") as handle:
             text = handle.read()
         after = (
             os.stat(path.name, dir_fd=parent_fd, follow_symlinks=False)
@@ -521,7 +521,7 @@ def _replace_destination(
                 existing.mode,
                 dir_fd=parent_fd,
             )
-            with os.fdopen(descriptor, "w", encoding="utf-8") as handle:
+            with os.fdopen(descriptor, "w", encoding="utf-8", newline="") as handle:
                 descriptor = -1
                 handle.write(content)
                 handle.flush()
@@ -541,6 +541,7 @@ def _replace_destination(
         with tempfile.NamedTemporaryFile(
             "w",
             encoding="utf-8",
+            newline="",
             dir=path.parent,
             delete=False,
         ) as handle:

--- a/reviewer/config/branches.py
+++ b/reviewer/config/branches.py
@@ -330,8 +330,9 @@ def _append_repository_candidate(
             sort_keys=False,
             width=10**9,
         ).strip()
-        separator = ", " if existing.data else ""
-        candidate = existing.text[:flow_end] + separator + flow[1:-1] + existing.text[flow_end:]
+        prefix = existing.text[:flow_end]
+        separator = " " if prefix.rstrip().endswith(",") else ", " if existing.data else ""
+        candidate = prefix + separator + flow[1:-1] + existing.text[flow_end:]
     else:
         document_end = next(
             (

--- a/reviewer/config/branches.py
+++ b/reviewer/config/branches.py
@@ -11,7 +11,7 @@ import stat
 from collections.abc import Mapping
 from dataclasses import dataclass
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Literal
 
 import yaml
 
@@ -30,6 +30,7 @@ if TYPE_CHECKING:
     from reviewer.config.settings import Settings
 
 BRANCHES_KEY = "repository"
+RepositoryBlockAction = Literal["create", "append", "noop"]
 
 
 @dataclass(frozen=True)
@@ -133,7 +134,12 @@ class BranchMigrationResult:
     noop: bool
 
 
-def _render_block(index: tuple[str, ...]) -> str:
+def render_repository_block(
+    primary: str,
+    index: tuple[str, ...],
+    *,
+    migrated: bool = False,
+) -> str:
     """Сформировать YAML-блок repository через safe_dump.
 
     Имена веток попадают в YAML как есть — легальное git-имя вроде
@@ -141,15 +147,48 @@ def _render_block(index: tuple[str, ...]) -> str:
     парсится как не-строка. ``safe_dump`` сам кавычит там, где нужно.
     """
     body = yaml.safe_dump(
-        {BRANCHES_KEY: {"index_branches": list(index)}},
+        {
+            BRANCHES_KEY: {
+                "primary_branch": primary,
+                "index_branches": list(index),
+            }
+        },
         allow_unicode=True,
         sort_keys=False,
     )
-    return (
-        "\n# Отслеживаемые ветки репозитория (перенесено из REVIEW_BRANCHES).\n"
-        "# Первая ветка списка — первичная, если primary_branch не задан явно.\n"
-        f"{body}"
-    )
+    if not migrated:
+        return body
+    return "# Отслеживаемые ветки репозитория (перенесено из REVIEW_BRANCHES).\n" + body
+
+
+def publish_repository_block(
+    path: Path,
+    source: str,
+    block: str,
+) -> RepositoryBlockAction:
+    """Создать или дописать repository-блок, не меняя существующий блок."""
+    try:
+        existing_text = path.read_text(encoding="utf-8")
+    except FileNotFoundError:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        try:
+            with open(path, "x", encoding="utf-8") as handle:
+                handle.write(block)
+        except FileExistsError:
+            # Параллельный процесс уже создал файл: не рискуем менять его вслепую.
+            return "noop"
+        return "create"
+
+    if BRANCHES_KEY in _read_mapping(existing_text, source):
+        return "noop"
+
+    if not existing_text:
+        updated = block
+    else:
+        separator = "\n" if existing_text.endswith("\n") else "\n\n"
+        updated = existing_text + separator + block
+    path.write_text(updated, encoding="utf-8")
+    return "append"
 
 
 def migrate_repo_branches(
@@ -175,23 +214,13 @@ def migrate_repo_branches(
     if effective.source.startswith("home:"):
         return BranchMigrationResult(destination, False, True)
     index = effective.index
-    block = _render_block(index)
-    try:
-        existing_text = destination.read_text(encoding="utf-8")
-    except FileNotFoundError:
-        destination.parent.mkdir(parents=True, exist_ok=True)
-        try:
-            with open(destination, "x", encoding="utf-8") as handle:
-                handle.write(block.lstrip("\n"))
-        except FileExistsError:
-            # Гонка: параллельный процесс успел создать файл между stat и open.
-            return BranchMigrationResult(destination, False, True)
-        return BranchMigrationResult(destination, True, False)
-    if BRANCHES_KEY in _read_mapping(existing_text, source):
-        return BranchMigrationResult(destination, False, True)
-    suffix = "" if existing_text.endswith("\n") else "\n"
-    destination.write_text(existing_text + suffix + block, encoding="utf-8")
-    return BranchMigrationResult(destination, False, False)
+    block = render_repository_block(index[0], index, migrated=True)
+    action = publish_repository_block(destination, source, block)
+    return BranchMigrationResult(
+        path=destination,
+        created=action == "create",
+        noop=action == "noop",
+    )
 
 
 def resolve_repo_branches(

--- a/reviewer/config/branches.py
+++ b/reviewer/config/branches.py
@@ -37,6 +37,7 @@ from reviewer.config.layers import (
     _prepare_destination_parent,
     _publish_new_config,
     _read_mapping,
+    _supports_secure_directory_walk,
     home_repo_path,
     reviewer_config_root,
 )
@@ -123,19 +124,18 @@ def _parse_block(block: object, source: str) -> tuple[str, tuple[str, ...]]:
     return primary, tuple(index)
 
 
-def _load_layer(path: Path, source: str) -> tuple[str, tuple[str, ...]] | None:
+def _load_layer(
+    path: Path,
+    source: str,
+    *,
+    root: Path,
+    parent_segments: tuple[str, ...],
+) -> tuple[str, tuple[str, ...]] | None:
     """Прочитать блок `repository` одного домашнего файла, либо None."""
-    try:
-        if not stat.S_ISREG(path.stat().st_mode):
-            return None
-        text = path.read_text(encoding="utf-8")
-    except FileNotFoundError:
+    existing = _read_home_file(path, source, root, parent_segments)
+    if existing is None:
         return None
-    except (OSError, UnicodeError) as exc:
-        raise HomeConfigError(
-            f"{source}: конфиг не прочитан: {type(exc).__name__}"
-        ) from None
-    data = _read_mapping(text, source)
+    data = existing.data
     if BRANCHES_KEY not in data:
         return None
     block = data[BRANCHES_KEY]
@@ -189,6 +189,114 @@ class _LockedDestination:
     data: dict[str, object]
     identity: tuple[int, int]
     mode: int
+
+
+@dataclass(frozen=True)
+class _ExistingParent:
+    exists: bool
+    descriptor: int | None
+
+
+@contextmanager
+def _open_existing_parent(
+    root: Path,
+    segments: tuple[str, ...],
+    source: str,
+):
+    """Открыть существующий parent без создания и symlink-переходов ниже root."""
+    if not _supports_secure_directory_walk():
+        try:
+            root_metadata = root.stat()
+        except FileNotFoundError:
+            yield _ExistingParent(False, None)
+            return
+        except OSError as exc:
+            raise HomeConfigError(
+                f"{source}: parent не проверен: {type(exc).__name__}"
+            ) from None
+        if not stat.S_ISDIR(root_metadata.st_mode):
+            raise HomeConfigError(f"{source}: config root не является directory")
+        current = root
+        for segment in segments:
+            current /= segment
+            try:
+                metadata = os.lstat(current)
+            except FileNotFoundError:
+                yield _ExistingParent(False, None)
+                return
+            except OSError as exc:
+                raise HomeConfigError(
+                    f"{source}: parent не проверен: {type(exc).__name__}"
+                ) from None
+            if stat.S_ISLNK(metadata.st_mode):
+                raise HomeConfigError(f"{source}: symlink в destination запрещён")
+            if not stat.S_ISDIR(metadata.st_mode):
+                raise HomeConfigError(f"{source}: parent destination не является directory")
+        yield _ExistingParent(True, None)
+        return
+
+    descriptor = -1
+    try:
+        try:
+            descriptor = os.open(
+                root,
+                os.O_RDONLY | os.O_DIRECTORY | getattr(os, "O_CLOEXEC", 0),
+            )
+        except FileNotFoundError:
+            yield _ExistingParent(False, None)
+            return
+        except OSError as exc:
+            raise HomeConfigError(
+                f"{source}: parent не проверен: {type(exc).__name__}"
+            ) from None
+        for segment in segments:
+            try:
+                child = os.open(
+                    segment,
+                    os.O_RDONLY
+                    | os.O_DIRECTORY
+                    | os.O_NOFOLLOW
+                    | getattr(os, "O_CLOEXEC", 0),
+                    dir_fd=descriptor,
+                )
+            except FileNotFoundError:
+                yield _ExistingParent(False, None)
+                return
+            except OSError:
+                raise HomeConfigError(
+                    f"{source}: symlink или non-directory parent запрещён"
+                ) from None
+            try:
+                metadata = os.fstat(child)
+                if not stat.S_ISDIR(metadata.st_mode):
+                    raise HomeConfigError(
+                        f"{source}: parent destination не является directory"
+                    )
+            except Exception:
+                try:
+                    os.close(child)
+                except OSError:
+                    pass
+                raise
+            try:
+                os.close(descriptor)
+            except OSError:
+                try:
+                    os.close(child)
+                except OSError:
+                    pass
+                raise HomeConfigError(f"{source}: parent descriptor не закрыт") from None
+            descriptor = child
+        yield _ExistingParent(True, descriptor)
+    finally:
+        if descriptor != -1:
+            try:
+                os.close(descriptor)
+            except OSError as exc:
+                if sys.exc_info()[0] is None:
+                    raise HomeConfigError(
+                        f"{source}: parent descriptor не закрыт: {type(exc).__name__}"
+                    ) from None
 
 
 def _destination_context(path: Path, source: str) -> tuple[Path, str]:
@@ -291,6 +399,35 @@ def _read_locked_destination(
                     raise HomeConfigError(
                         f"{source}: конфиг не закрыт: {type(exc).__name__}"
                     ) from None
+
+
+def _read_home_file(
+    path: Path,
+    source: str,
+    root: Path,
+    parent_segments: tuple[str, ...],
+) -> _LockedDestination | None:
+    with _open_existing_parent(root, parent_segments, source) as parent:
+        if not parent.exists:
+            return None
+        with _read_locked_destination(
+            path,
+            source,
+            parent_fd=parent.descriptor,
+        ) as existing:
+            return existing
+
+
+def read_repository_config_file(path: Path, source: str) -> str | None:
+    """Без записи и symlink-переходов прочитать домашний repo config."""
+    root, repo = _destination_context(path, source)
+    existing = _read_home_file(
+        path,
+        source,
+        root,
+        ("repos", *repo.split("/")[:-1]),
+    )
+    return None if existing is None else existing.text
 
 
 def _flow_mapping_end(tokens: list[object]) -> tuple[int, bool] | None:
@@ -540,11 +677,20 @@ def resolve_repo_branches(
     repo = normalize_repo(repo)
     root = config_root or reviewer_config_root()
     layers = (
-        (home_repo_path(repo, root), f"home:repos/{repo}.yml"),
-        (root / "review.yml", "home:review.yml"),
+        (
+            home_repo_path(repo, root),
+            f"home:repos/{repo}.yml",
+            ("repos", *repo.split("/")[:-1]),
+        ),
+        (root / "review.yml", "home:review.yml", ()),
     )
-    for path, source in layers:
-        parsed = _load_layer(path, source)
+    for path, source, parent_segments in layers:
+        parsed = _load_layer(
+            path,
+            source,
+            root=root,
+            parent_segments=parent_segments,
+        )
         if parsed is not None:
             primary, index = parsed
             return RepoBranches(primary=primary, index=index, source=source)

--- a/reviewer/config/branches.py
+++ b/reviewer/config/branches.py
@@ -22,6 +22,7 @@ import yaml
 from yaml.tokens import (
     BlockMappingStartToken,
     DocumentEndToken,
+    FlowEntryToken,
     FlowMappingEndToken,
     FlowMappingStartToken,
     FlowSequenceEndToken,
@@ -292,10 +293,10 @@ def _read_locked_destination(
                     ) from None
 
 
-def _flow_mapping_end(tokens: list[object]) -> int | None:
+def _flow_mapping_end(tokens: list[object]) -> tuple[int, bool] | None:
     flow_depth = 0
     root_flow = False
-    for token in tokens:
+    for position, token in enumerate(tokens):
         if isinstance(token, (FlowMappingStartToken, FlowSequenceStartToken)):
             if flow_depth == 0:
                 if not isinstance(token, FlowMappingStartToken):
@@ -305,7 +306,10 @@ def _flow_mapping_end(tokens: list[object]) -> int | None:
         elif isinstance(token, (FlowMappingEndToken, FlowSequenceEndToken)):
             flow_depth -= 1
             if root_flow and flow_depth == 0:
-                return token.start_mark.index
+                return (
+                    token.start_mark.index,
+                    isinstance(tokens[position - 1], FlowEntryToken),
+                )
         elif flow_depth == 0 and isinstance(token, BlockMappingStartToken):
             return None
     return None
@@ -321,8 +325,9 @@ def _append_repository_candidate(
         raise HomeConfigError(f"{source}: repository block отсутствует")
     repository = block_data[BRANCHES_KEY]
     tokens = list(yaml.scan(existing.text))
-    flow_end = _flow_mapping_end(tokens)
-    if flow_end is not None:
+    flow_mapping = _flow_mapping_end(tokens)
+    if flow_mapping is not None:
+        flow_end, has_trailing_comma = flow_mapping
         flow = yaml.safe_dump(
             {BRANCHES_KEY: repository},
             allow_unicode=True,
@@ -331,7 +336,7 @@ def _append_repository_candidate(
             width=10**9,
         ).strip()
         prefix = existing.text[:flow_end]
-        separator = " " if prefix.rstrip().endswith(",") else ", " if existing.data else ""
+        separator = " " if has_trailing_comma else ", " if existing.data else ""
         candidate = prefix + separator + flow[1:-1] + existing.text[flow_end:]
     else:
         document_end = next(

--- a/reviewer/config/branches.py
+++ b/reviewer/config/branches.py
@@ -7,19 +7,34 @@
 """
 from __future__ import annotations
 
+import os
+import secrets
 import stat
+import sys
+import tempfile
 from collections.abc import Mapping
+from contextlib import contextmanager
 from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING, Literal
 
 import yaml
+from yaml.tokens import (
+    BlockMappingStartToken,
+    DocumentEndToken,
+    FlowMappingEndToken,
+    FlowMappingStartToken,
+    FlowSequenceEndToken,
+    FlowSequenceStartToken,
+)
 
 from reviewer.config.layers import (
     HomeConfigError,
     HomeCredentialError,
     HomePolicyError,
     _credential_path,
+    _prepare_destination_parent,
+    _publish_new_config,
     _read_mapping,
     home_repo_path,
     reviewer_config_root,
@@ -31,6 +46,12 @@ if TYPE_CHECKING:
 
 BRANCHES_KEY = "repository"
 RepositoryBlockAction = Literal["create", "append", "noop"]
+_PUBLISH_ATTEMPTS = 3
+
+try:
+    import fcntl
+except ImportError:  # pragma: no cover - Windows fallback relies on identity checks.
+    fcntl = None
 
 
 @dataclass(frozen=True)
@@ -161,34 +182,307 @@ def render_repository_block(
     return "# Отслеживаемые ветки репозитория (перенесено из REVIEW_BRANCHES).\n" + body
 
 
+@dataclass(frozen=True)
+class _LockedDestination:
+    text: str
+    data: dict[str, object]
+    identity: tuple[int, int]
+    mode: int
+
+
+def _destination_context(path: Path, source: str) -> tuple[Path, str]:
+    prefix = "home:repos/"
+    suffix = ".yml"
+    if not source.startswith(prefix) or not source.endswith(suffix):
+        raise HomeConfigError("repository destination: source имеет недопустимый формат")
+    try:
+        repo = normalize_repo(source[len(prefix) : -len(suffix)])
+        root = path.parents[len(repo.split("/"))]
+    except (IndexError, ValueError):
+        raise HomeConfigError("repository destination: путь имеет недопустимый формат") from None
+    if home_repo_path(repo, root) != path:
+        raise HomeConfigError("repository destination: путь не соответствует source")
+    return root, repo
+
+
+@contextmanager
+def _read_locked_destination(
+    path: Path,
+    source: str,
+    *,
+    parent_fd: int | None,
+):
+    """Прочитать и удерживать regular destination без следования symlink."""
+    try:
+        before = (
+            os.stat(path.name, dir_fd=parent_fd, follow_symlinks=False)
+            if parent_fd is not None
+            else os.lstat(path)
+        )
+    except FileNotFoundError:
+        yield None
+        return
+    except OSError as exc:
+        raise HomeConfigError(
+            f"{source}: конфиг не прочитан: {type(exc).__name__}"
+        ) from None
+    if stat.S_ISLNK(before.st_mode):
+        raise HomeConfigError(f"{source}: symlink запрещён")
+    if not stat.S_ISREG(before.st_mode):
+        raise HomeConfigError(f"{source}: destination должен быть regular file")
+
+    descriptor = -1
+    flags = os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0)
+    try:
+        descriptor = (
+            os.open(path.name, flags, dir_fd=parent_fd)
+            if parent_fd is not None
+            else os.open(path, flags)
+        )
+        if fcntl is not None:
+            fcntl.flock(descriptor, fcntl.LOCK_EX)
+        opened = os.fstat(descriptor)
+        fresh = (
+            os.stat(path.name, dir_fd=parent_fd, follow_symlinks=False)
+            if parent_fd is not None
+            else os.lstat(path)
+        )
+        identities = {
+            (before.st_dev, before.st_ino),
+            (opened.st_dev, opened.st_ino),
+            (fresh.st_dev, fresh.st_ino),
+        }
+        if (
+            not stat.S_ISREG(opened.st_mode)
+            or stat.S_ISLNK(fresh.st_mode)
+            or len(identities) != 1
+        ):
+            raise HomeConfigError(f"{source}: race при чтении destination")
+        with os.fdopen(os.dup(descriptor), encoding="utf-8") as handle:
+            text = handle.read()
+        after = (
+            os.stat(path.name, dir_fd=parent_fd, follow_symlinks=False)
+            if parent_fd is not None
+            else os.lstat(path)
+        )
+        if (after.st_dev, after.st_ino) != (opened.st_dev, opened.st_ino):
+            raise HomeConfigError(f"{source}: race при чтении destination")
+        yield _LockedDestination(
+            text=text,
+            data=_read_mapping(text, source),
+            identity=(opened.st_dev, opened.st_ino),
+            mode=stat.S_IMODE(opened.st_mode),
+        )
+    except HomeConfigError:
+        raise
+    except (OSError, UnicodeError) as exc:
+        raise HomeConfigError(
+            f"{source}: конфиг не прочитан: {type(exc).__name__}"
+        ) from None
+    finally:
+        if descriptor != -1:
+            try:
+                if fcntl is not None:
+                    fcntl.flock(descriptor, fcntl.LOCK_UN)
+                os.close(descriptor)
+            except OSError as exc:
+                if sys.exc_info()[0] is None:
+                    raise HomeConfigError(
+                        f"{source}: конфиг не закрыт: {type(exc).__name__}"
+                    ) from None
+
+
+def _flow_mapping_end(tokens: list[object]) -> int | None:
+    flow_depth = 0
+    root_flow = False
+    for token in tokens:
+        if isinstance(token, (FlowMappingStartToken, FlowSequenceStartToken)):
+            if flow_depth == 0:
+                if not isinstance(token, FlowMappingStartToken):
+                    return None
+                root_flow = True
+            flow_depth += 1
+        elif isinstance(token, (FlowMappingEndToken, FlowSequenceEndToken)):
+            flow_depth -= 1
+            if root_flow and flow_depth == 0:
+                return token.start_mark.index
+        elif flow_depth == 0 and isinstance(token, BlockMappingStartToken):
+            return None
+    return None
+
+
+def _append_repository_candidate(
+    existing: _LockedDestination,
+    block: str,
+    source: str,
+) -> str:
+    block_data = _read_mapping(block, source)
+    if BRANCHES_KEY not in block_data:
+        raise HomeConfigError(f"{source}: repository block отсутствует")
+    repository = block_data[BRANCHES_KEY]
+    tokens = list(yaml.scan(existing.text))
+    flow_end = _flow_mapping_end(tokens)
+    if flow_end is not None:
+        flow = yaml.safe_dump(
+            {BRANCHES_KEY: repository},
+            allow_unicode=True,
+            default_flow_style=True,
+            sort_keys=False,
+            width=10**9,
+        ).strip()
+        separator = ", " if existing.data else ""
+        candidate = existing.text[:flow_end] + separator + flow[1:-1] + existing.text[flow_end:]
+    else:
+        document_end = next(
+            (
+                token.start_mark.index
+                for token in tokens
+                if isinstance(token, DocumentEndToken)
+            ),
+            None,
+        )
+        insertion = len(existing.text) if document_end is None else document_end
+        prefix = existing.text[:insertion]
+        suffix = existing.text[insertion:]
+        if not prefix:
+            separator = ""
+        elif prefix.endswith("\n"):
+            separator = "\n" if document_end is None else ""
+        else:
+            separator = "\n\n" if document_end is None else "\n"
+        candidate = prefix + separator + block + suffix
+
+    parsed = _read_mapping(candidate, source)
+    if BRANCHES_KEY not in parsed:
+        raise HomeConfigError(f"{source}: repository block не опубликован")
+    return candidate
+
+
+def _replace_destination(
+    path: Path,
+    content: str,
+    source: str,
+    existing: _LockedDestination,
+    *,
+    parent_fd: int | None,
+) -> None:
+    temp_name: str | None = None
+    temp_path: Path | None = None
+    descriptor = -1
+    try:
+        if parent_fd is not None:
+            temp_name = f".reviewer-repository-{secrets.token_hex(12)}"
+            descriptor = os.open(
+                temp_name,
+                os.O_WRONLY | os.O_CREAT | os.O_EXCL,
+                existing.mode,
+                dir_fd=parent_fd,
+            )
+            with os.fdopen(descriptor, "w", encoding="utf-8") as handle:
+                descriptor = -1
+                handle.write(content)
+                handle.flush()
+                os.fsync(handle.fileno())
+            fresh = os.stat(path.name, dir_fd=parent_fd, follow_symlinks=False)
+            if (fresh.st_dev, fresh.st_ino) != existing.identity:
+                raise HomeConfigError(f"{source}: race при публикации destination")
+            os.replace(
+                temp_name,
+                path.name,
+                src_dir_fd=parent_fd,
+                dst_dir_fd=parent_fd,
+            )
+            temp_name = None
+            return
+
+        with tempfile.NamedTemporaryFile(
+            "w",
+            encoding="utf-8",
+            dir=path.parent,
+            delete=False,
+        ) as handle:
+            handle.write(content)
+            handle.flush()
+            os.fsync(handle.fileno())
+            temp_path = Path(handle.name)
+        temp_path.chmod(existing.mode)
+        fresh = os.lstat(path)
+        if (fresh.st_dev, fresh.st_ino) != existing.identity:
+            raise HomeConfigError(f"{source}: race при публикации destination")
+        os.replace(temp_path, path)
+        temp_path = None
+    except HomeConfigError:
+        raise
+    except OSError as exc:
+        raise HomeConfigError(
+            f"{source}: публикация не выполнена: {type(exc).__name__}"
+        ) from None
+    finally:
+        if descriptor != -1:
+            try:
+                os.close(descriptor)
+            except OSError:
+                pass
+        if temp_name is not None and parent_fd is not None:
+            try:
+                os.unlink(temp_name, dir_fd=parent_fd)
+            except FileNotFoundError:
+                pass
+            except OSError as exc:
+                if sys.exc_info()[0] is None:
+                    raise HomeConfigError(
+                        f"{source}: очистка temporary file: {type(exc).__name__}"
+                    ) from None
+        if temp_path is not None:
+            try:
+                temp_path.unlink()
+            except FileNotFoundError:
+                pass
+            except OSError as exc:
+                if sys.exc_info()[0] is None:
+                    raise HomeConfigError(
+                        f"{source}: очистка temporary file: {type(exc).__name__}"
+                    ) from None
+
+
 def publish_repository_block(
     path: Path,
     source: str,
     block: str,
 ) -> RepositoryBlockAction:
     """Создать или дописать repository-блок, не меняя существующий блок."""
-    try:
-        existing_text = path.read_text(encoding="utf-8")
-    except FileNotFoundError:
-        path.parent.mkdir(parents=True, exist_ok=True)
-        try:
-            with open(path, "x", encoding="utf-8") as handle:
-                handle.write(block)
-        except FileExistsError:
-            # Параллельный процесс уже создал файл: не рискуем менять его вслепую.
-            return "noop"
-        return "create"
-
-    if BRANCHES_KEY in _read_mapping(existing_text, source):
-        return "noop"
-
-    if not existing_text:
-        updated = block
-    else:
-        separator = "\n" if existing_text.endswith("\n") else "\n\n"
-        updated = existing_text + separator + block
-    path.write_text(updated, encoding="utf-8")
-    return "append"
+    root, repo = _destination_context(path, source)
+    block_data = _read_mapping(block, source)
+    if BRANCHES_KEY not in block_data:
+        raise HomeConfigError(f"{source}: repository block отсутствует")
+    with _prepare_destination_parent(root, repo, source) as parent:
+        for _attempt in range(_PUBLISH_ATTEMPTS):
+            with _read_locked_destination(
+                path,
+                source,
+                parent_fd=parent.descriptor,
+            ) as existing:
+                if existing is None:
+                    if _publish_new_config(
+                        path,
+                        block,
+                        source,
+                        parent_fd=parent.descriptor,
+                    ):
+                        return "create"
+                    continue
+                if BRANCHES_KEY in existing.data:
+                    return "noop"
+                candidate = _append_repository_candidate(existing, block, source)
+                _replace_destination(
+                    path,
+                    candidate,
+                    source,
+                    existing,
+                    parent_fd=parent.descriptor,
+                )
+                return "append"
+    raise HomeConfigError(f"{source}: race при публикации destination")
 
 
 def migrate_repo_branches(

--- a/reviewer/config/onboarding.py
+++ b/reviewer/config/onboarding.py
@@ -1,16 +1,24 @@
 """Локальное обнаружение репозитория и чистый план домашнего repo-конфига."""
 from __future__ import annotations
 
+import os
+import stat
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Literal
 
 from reviewer.config.branches import (
+    _read_locked_destination,
     publish_repository_block,
     render_repository_block,
     resolve_repo_branches,
 )
-from reviewer.config.layers import _read_mapping, home_repo_path, reviewer_config_root
+from reviewer.config.layers import (
+    HomeConfigError,
+    _read_mapping,
+    home_repo_path,
+    reviewer_config_root,
+)
 from reviewer.config.settings import Settings
 from reviewer.gitutil import remote_default_branch, remote_url, repo_root
 from reviewer.services.repo_id import derive_repo_from_remote, normalize_repo
@@ -66,6 +74,33 @@ def parse_branch_csv(raw: str, primary: str) -> tuple[str, ...]:
     return _validate_branches(index, primary)
 
 
+def _read_plan_destination(
+    path: Path,
+    root: Path,
+    repo: str,
+    source: str,
+) -> str | None:
+    """Без записи прочитать regular destination, не следуя symlink ниже root."""
+    current = root
+    for segment in ("repos", *repo.split("/")[:-1]):
+        current /= segment
+        try:
+            metadata = os.lstat(current)
+        except FileNotFoundError:
+            return None
+        except OSError as exc:
+            raise HomeConfigError(
+                f"{source}: destination не проверен: {type(exc).__name__}"
+            ) from None
+        if stat.S_ISLNK(metadata.st_mode):
+            raise HomeConfigError(f"{source}: symlink в destination запрещён")
+        if not stat.S_ISDIR(metadata.st_mode):
+            raise HomeConfigError(f"{source}: parent destination не является directory")
+
+    with _read_locked_destination(path, source, parent_fd=None) as existing:
+        return None if existing is None else existing.text
+
+
 def detect_repository(
     path: str,
     repo_override: str | None,
@@ -110,6 +145,7 @@ def plan_repository_config(
     root = config_root if config_root is not None else reviewer_config_root()
     path = home_repo_path(repo, root)
     source = f"home:repos/{repo}.yml"
+    existing_text = _read_plan_destination(path, root, repo, source)
     effective = resolve_repo_branches(repo, settings=settings, config_root=root)
 
     if effective.source == source:
@@ -124,9 +160,7 @@ def plan_repository_config(
             effective.index if selected_primary in effective.index else (selected_primary,)
         )
         _validate_branches(selected_index, selected_primary)
-        try:
-            existing_text = path.read_text(encoding="utf-8")
-        except FileNotFoundError:
+        if existing_text is None:
             action = "create"
         else:
             action = "noop" if "repository" in _read_mapping(

--- a/reviewer/config/onboarding.py
+++ b/reviewer/config/onboarding.py
@@ -115,9 +115,11 @@ def plan_repository_config(
     if effective.source == source:
         selected_primary = effective.primary
         selected_index = effective.index
+        selected_primary_source = effective.source
         action: PlanAction = "noop"
     else:
         selected_primary = primary if primary is not None else detection.primary
+        selected_primary_source = "cli" if primary is not None else detection.primary_source
         selected_index = index if index is not None else (
             effective.index if selected_primary in effective.index else (selected_primary,)
         )
@@ -139,7 +141,7 @@ def plan_repository_config(
         primary=selected_primary,
         index=selected_index,
         repo_source=detection.repo_source,
-        primary_source=detection.primary_source,
+        primary_source=selected_primary_source,
         action=action,
         preview=preview,
     )
@@ -149,10 +151,8 @@ def apply_repository_config(plan: RepositoryConfigPlan) -> None:
     """Применить рассчитанный план; конкурентная запись может дать безопасный noop."""
     if plan.action == "noop":
         return
-    action = publish_repository_block(
+    publish_repository_block(
         plan.path,
         f"home:repos/{plan.repo}.yml",
         plan.preview,
     )
-    if action not in {plan.action, "noop"}:
-        raise RuntimeError(f"ожидалось действие {plan.action}, выполнено {action}")

--- a/reviewer/config/onboarding.py
+++ b/reviewer/config/onboarding.py
@@ -1,24 +1,17 @@
 """Локальное обнаружение репозитория и чистый план домашнего repo-конфига."""
 from __future__ import annotations
 
-import os
-import stat
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Literal
 
 from reviewer.config.branches import (
-    _read_locked_destination,
     publish_repository_block,
+    read_repository_config_file,
     render_repository_block,
     resolve_repo_branches,
 )
-from reviewer.config.layers import (
-    HomeConfigError,
-    _read_mapping,
-    home_repo_path,
-    reviewer_config_root,
-)
+from reviewer.config.layers import _read_mapping, home_repo_path, reviewer_config_root
 from reviewer.config.settings import Settings
 from reviewer.gitutil import remote_default_branch, remote_url, repo_root
 from reviewer.services.repo_id import derive_repo_from_remote, normalize_repo
@@ -74,33 +67,6 @@ def parse_branch_csv(raw: str, primary: str) -> tuple[str, ...]:
     return _validate_branches(index, primary)
 
 
-def _read_plan_destination(
-    path: Path,
-    root: Path,
-    repo: str,
-    source: str,
-) -> str | None:
-    """Без записи прочитать regular destination, не следуя symlink ниже root."""
-    current = root
-    for segment in ("repos", *repo.split("/")[:-1]):
-        current /= segment
-        try:
-            metadata = os.lstat(current)
-        except FileNotFoundError:
-            return None
-        except OSError as exc:
-            raise HomeConfigError(
-                f"{source}: destination не проверен: {type(exc).__name__}"
-            ) from None
-        if stat.S_ISLNK(metadata.st_mode):
-            raise HomeConfigError(f"{source}: symlink в destination запрещён")
-        if not stat.S_ISDIR(metadata.st_mode):
-            raise HomeConfigError(f"{source}: parent destination не является directory")
-
-    with _read_locked_destination(path, source, parent_fd=None) as existing:
-        return None if existing is None else existing.text
-
-
 def detect_repository(
     path: str,
     repo_override: str | None,
@@ -145,7 +111,7 @@ def plan_repository_config(
     root = config_root if config_root is not None else reviewer_config_root()
     path = home_repo_path(repo, root)
     source = f"home:repos/{repo}.yml"
-    existing_text = _read_plan_destination(path, root, repo, source)
+    existing_text = read_repository_config_file(path, source)
     effective = resolve_repo_branches(repo, settings=settings, config_root=root)
 
     if effective.source == source:

--- a/reviewer/config/onboarding.py
+++ b/reviewer/config/onboarding.py
@@ -1,0 +1,158 @@
+"""Локальное обнаружение репозитория и чистый план домашнего repo-конфига."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Literal
+
+from reviewer.config.branches import (
+    publish_repository_block,
+    render_repository_block,
+    resolve_repo_branches,
+)
+from reviewer.config.layers import _read_mapping, home_repo_path, reviewer_config_root
+from reviewer.config.settings import Settings
+from reviewer.gitutil import remote_default_branch, remote_url, repo_root
+from reviewer.services.repo_id import derive_repo_from_remote, normalize_repo
+
+PlanAction = Literal["create", "append", "noop"]
+
+
+@dataclass(frozen=True)
+class RepositoryDetection:
+    """Локально обнаруженные repo/primary и происхождение каждого значения."""
+
+    root: Path
+    repo: str
+    repo_source: str
+    primary: str
+    primary_source: str
+
+
+@dataclass(frozen=True)
+class RepositoryConfigPlan:
+    """Неизменяемый план записи repository-блока домашнего конфига."""
+
+    path: Path
+    repo: str
+    primary: str
+    index: tuple[str, ...]
+    repo_source: str
+    primary_source: str
+    action: PlanAction
+    preview: str
+
+
+def _validate_branches(index: tuple[str, ...], primary: str) -> tuple[str, ...]:
+    if not isinstance(primary, str) or not primary.strip():
+        raise ValueError("primary branch должна быть непустой строкой")
+    if not index:
+        raise ValueError("index branches должны быть непустым списком")
+    if any(
+        not isinstance(branch, str) or not branch.strip() or branch != branch.strip()
+        for branch in index
+    ):
+        raise ValueError("index branches содержат пустое или неочищенное имя")
+    if len(index) != len(set(index)):
+        raise ValueError("index branches содержат дубли")
+    if primary not in index:
+        raise ValueError(f"primary branch {primary!r} отсутствует в index branches")
+    return index
+
+
+def parse_branch_csv(raw: str, primary: str) -> tuple[str, ...]:
+    """Разобрать CSV отслеживаемых веток и проверить primary/index инварианты."""
+    index = tuple(part.strip() for part in raw.split(","))
+    return _validate_branches(index, primary)
+
+
+def detect_repository(
+    path: str,
+    repo_override: str | None,
+    *,
+    settings: Settings,
+) -> RepositoryDetection | None:
+    """Локально определить git root, repo id и primary без сетевых запросов."""
+    root_value = repo_root(path)
+    if root_value is None:
+        return None
+
+    if repo_override is not None:
+        repo = normalize_repo(repo_override)
+        repo_source = "cli"
+    else:
+        repo = derive_repo_from_remote(remote_url(root_value) or "")
+        if repo is None:
+            return None
+        repo_source = "git:origin"
+
+    effective = resolve_repo_branches(repo, settings=settings)
+    detected_primary = remote_default_branch(root_value)
+    return RepositoryDetection(
+        root=Path(root_value),
+        repo=repo,
+        repo_source=repo_source,
+        primary=detected_primary or effective.primary,
+        primary_source="git:origin/HEAD" if detected_primary else effective.source,
+    )
+
+
+def plan_repository_config(
+    detection: RepositoryDetection,
+    *,
+    settings: Settings,
+    primary: str | None = None,
+    index: tuple[str, ...] | None = None,
+    config_root: Path | None = None,
+) -> RepositoryConfigPlan:
+    """Вычислить create/append/noop и preview, ничего не записывая на диск."""
+    repo = normalize_repo(detection.repo)
+    root = config_root if config_root is not None else reviewer_config_root()
+    path = home_repo_path(repo, root)
+    source = f"home:repos/{repo}.yml"
+    effective = resolve_repo_branches(repo, settings=settings, config_root=root)
+
+    if effective.source == source:
+        selected_primary = effective.primary
+        selected_index = effective.index
+        action: PlanAction = "noop"
+    else:
+        selected_primary = primary if primary is not None else detection.primary
+        selected_index = index if index is not None else (
+            effective.index if selected_primary in effective.index else (selected_primary,)
+        )
+        _validate_branches(selected_index, selected_primary)
+        try:
+            existing_text = path.read_text(encoding="utf-8")
+        except FileNotFoundError:
+            action = "create"
+        else:
+            action = "noop" if "repository" in _read_mapping(
+                existing_text,
+                source,
+            ) else "append"
+
+    preview = render_repository_block(selected_primary, selected_index)
+    return RepositoryConfigPlan(
+        path=path,
+        repo=repo,
+        primary=selected_primary,
+        index=selected_index,
+        repo_source=detection.repo_source,
+        primary_source=detection.primary_source,
+        action=action,
+        preview=preview,
+    )
+
+
+def apply_repository_config(plan: RepositoryConfigPlan) -> None:
+    """Применить рассчитанный план; конкурентная запись может дать безопасный noop."""
+    if plan.action == "noop":
+        return
+    action = publish_repository_block(
+        plan.path,
+        f"home:repos/{plan.repo}.yml",
+        plan.preview,
+    )
+    if action not in {plan.action, "noop"}:
+        raise RuntimeError(f"ожидалось действие {plan.action}, выполнено {action}")

--- a/reviewer/entrypoints/cli.py
+++ b/reviewer/entrypoints/cli.py
@@ -5,6 +5,7 @@ from contextlib import contextmanager
 from dataclasses import dataclass
 import json
 import logging
+from pathlib import Path
 import platform as _platform
 import re
 import shutil as _shutil
@@ -17,6 +18,7 @@ import yaml
 
 from reviewer.config.settings import Settings
 from reviewer.app import build_components
+from reviewer.config import onboarding as repo_onboarding
 from reviewer.config.branches import migrate_repo_branches, resolve_repo_branches
 from reviewer.config.layers import (
     HomeConfigError,
@@ -24,7 +26,7 @@ from reviewer.config.layers import (
     migrate_repo_config,
     resolve_policy_data,
 )
-from reviewer.gitutil import file_at_ref, list_python_files, rev_parse, remote_url
+from reviewer.gitutil import file_at_ref, list_python_files, repo_root, rev_parse, remote_url
 from reviewer.graph.backend import build_code_graph
 from reviewer.graph.store import GraphStore
 from reviewer.index.freshness import update_base
@@ -94,6 +96,17 @@ def _config_error_message(exc: Exception) -> str:
     return "конфиг не прочитан: YAML"
 
 
+def _branches_report(branches) -> dict[str, object]:
+    """Общий payload effective branches для config show и repo onboarding."""
+    return {
+        "branches": {
+            "primary": branches.primary,
+            "index": list(branches.index),
+            "source": branches.source,
+        }
+    }
+
+
 def _render_config_report(report: Mapping[str, object]) -> None:
     branches = report.get("branches")
     if branches:
@@ -104,6 +117,8 @@ def _render_config_report(report: Mapping[str, object]) -> None:
     policy_error = report.get("policy_error")
     if policy_error is not None:
         click.echo(f"policy_error: {policy_error}")
+        return
+    if "effective" not in report:
         return
     effective = report["effective"]
     sources = report["sources"]
@@ -169,13 +184,7 @@ def config_show(repo: str, branch: str | None, as_json: bool) -> None:
     try:
         with _config_context(repo, branch) as ctx:
             settings, _components, vcs, repo_id, ref, branches, vcs_error = ctx
-            payload: dict[str, object] = {
-                "branches": {
-                    "primary": branches.primary,
-                    "index": list(branches.index),
-                    "source": branches.source,
-                }
-            }
+            payload = _branches_report(branches)
             try:
                 if vcs_error is not None:
                     raise vcs_error
@@ -1080,6 +1089,34 @@ def install(client: str | None, all_clients: bool, list_clients: bool,
         click.echo("Готово. Перезапустите клиент. Ключи: reviewer init && reviewer check.")
 
 
+@dataclass(frozen=True)
+class _GlobalInitPlan:
+    path: Path
+    content: str
+    preview: str
+    source: str
+    action: str
+
+
+def _render_init_preview(
+    global_plan: _GlobalInitPlan | None,
+    repo_plan: repo_onboarding.RepositoryConfigPlan | None,
+) -> None:
+    """Показать все target-планы до первой записи, не раскрывая env secrets."""
+    click.echo("# reviewer init preview")
+    if global_plan is not None:
+        click.echo(f"\nfile: {global_plan.path}")
+        click.echo(f"action: {global_plan.action}")
+        click.echo(f"source: {global_plan.source}")
+        click.echo(global_plan.preview)
+    if repo_plan is not None:
+        click.echo(f"\nfile: {repo_plan.path}")
+        click.echo(f"action: {repo_plan.action}")
+        click.echo(f"repo: {repo_plan.repo} ({repo_plan.repo_source})")
+        click.echo(f"primary: {repo_plan.primary} ({repo_plan.primary_source})")
+        click.echo(repo_plan.preview)
+
+
 @cli.command()
 @click.option("--path", "path_opt", default=None,
               help="куда писать .env (по умолчанию ~/.config/rag-reviewer/.env)")
@@ -1087,108 +1124,253 @@ def install(client: str | None, all_clients: bool, list_clients: bool,
               help="принять все дефолты без интерактива (CI-режим)")
 @click.option("--dry-run", "dry_run", is_flag=True,
               help="показать безопасный preview без prompt, сети и записи файла")
-def init(path_opt: str | None, yes: bool, dry_run: bool) -> None:
-    """Интерактивный мастер настройки .env для rag-reviewer."""
+@click.option(
+    "--scope",
+    type=click.Choice(("all", "global", "repo")),
+    default="all",
+    show_default=True,
+    help="этапы настройки: global .env, repo branch config или оба",
+)
+@click.option("--repo", "repo_opt", default=None, help="owner/name для repo stage")
+def init(
+    path_opt: str | None,
+    yes: bool,
+    dry_run: bool,
+    scope: str,
+    repo_opt: str | None,
+) -> None:
+    """Настроить global .env и per-repo ветки с preview до записи."""
     import subprocess
-    from pathlib import Path
     from reviewer import install as inst
     from reviewer.tasks.boards import setup as board_setup
     from reviewer.tasks.boards.errors import BoardProviderError
     from reviewer.tasks.boards.registry import default_board_registry
 
-    dest = Path(path_opt).expanduser() if path_opt else inst.default_env_path()
-    current = inst.read_env(dest)
-    wizard_keys = {f.key for g in inst.WIZARD_GROUPS for f in g.fields}
-
-    if dry_run:
-        values = inst.prompt_groups(inst.WIZARD_GROUPS, current=current, yes=True)
-        extra = {k: v for k, v in current.items() if k not in wizard_keys}
-        click.echo(f"# reviewer init preview: {dest}")
-        click.echo(inst.render_env_preview(values, extra))
-        return
-
-    dest.parent.mkdir(parents=True, exist_ok=True)
-
-    if not yes:
-        click.echo(f"Настройка rag-reviewer: {dest}")
-        click.echo("─" * 52)
-
+    run_global = scope in {"all", "global"}
+    run_repo = scope in {"all", "repo"}
+    interactive = not yes and not dry_run
+    if run_repo and repo_opt is not None:
+        try:
+            repo_opt = _resolve_config_repo(repo_opt)
+        except ValueError as exc:
+            raise click.ClickException(str(exc)) from exc
+    global_plan: _GlobalInitPlan | None = None
+    repo_plan: repo_onboarding.RepositoryConfigPlan | None = None
+    settings: Settings | None = None
     try:
-        groups = inst.WIZARD_GROUPS
-        if yes:
-            values = inst.prompt_groups(groups, current=current, yes=True)
-        else:
-            board_group = next(group for group in groups if group.title == "Доска задач")
-            common_fields = inst.common_board_env_fields(board_group)
-            values = inst.prompt_groups(
-                [
-                    (
-                        inst.EnvGroup(
-                            title=board_group.title,
-                            fields=common_fields,
-                            optional=True,
-                        )
-                        if group is board_group
-                        else group
-                    )
-                    for group in groups
-                ],
-                current=current,
-                yes=False,
-            )
-            for field in board_group.fields:
-                if field in common_fields:
-                    continue
-                values[field.key] = current.get(field.key, "") or field.default
+        if run_global:
+            dest = Path(path_opt).expanduser() if path_opt else inst.default_env_path()
+            current = inst.read_env(dest)
+            wizard_keys = {field.key for group in inst.WIZARD_GROUPS for field in group.fields}
+            groups = inst.WIZARD_GROUPS
 
-            if click.confirm("\nПодключить provider доски задач?", default=False):
-                registry = default_board_registry()
-                io = board_setup.ClickSetupIO()
-                board_type = io.choose(
-                    "Выберите provider доски",
+            if interactive:
+                click.echo(f"Настройка rag-reviewer: {dest}")
+                click.echo("─" * 52)
+                board_group = next(group for group in groups if group.title == "Доска задач")
+                common_fields = inst.common_board_env_fields(board_group)
+                values = inst.prompt_groups(
                     [
-                        board_setup.SetupChoice(
-                            value=registered_type,
-                            label=registry.get(registered_type).setup.label,
+                        (
+                            inst.EnvGroup(
+                                title=board_group.title,
+                                fields=common_fields,
+                                optional=True,
+                            )
+                            if group is board_group
+                            else group
                         )
-                        for registered_type in registry.registered_types()
+                        for group in groups
                     ],
+                    current=current,
+                    yes=False,
                 )
-                while True:
-                    try:
-                        values.update(
-                            board_setup.configure_board_provider(registry.get(board_type), io)
-                        )
-                        break
-                    except BoardProviderError as error:
-                        click.echo(f"✗ {board_type}: {error.message}")
-                        if error.hint:
-                            click.echo(f"  {error.hint}")
-                        if not click.confirm(
-                            "Исправить credentials и повторить?",
-                            default=True,
-                        ):
-                            click.echo(
-                                "Provider пропущен; непроверенные credentials не сохранены."
+                for field in board_group.fields:
+                    if field in common_fields:
+                        continue
+                    values[field.key] = current.get(field.key, "") or field.default
+
+                if click.confirm("\nПодключить provider доски задач?", default=False):
+                    registry = default_board_registry()
+                    io = board_setup.ClickSetupIO()
+                    board_type = io.choose(
+                        "Выберите provider доски",
+                        [
+                            board_setup.SetupChoice(
+                                value=registered_type,
+                                label=registry.get(registered_type).setup.label,
+                            )
+                            for registered_type in registry.registered_types()
+                        ],
+                    )
+                    while True:
+                        try:
+                            values.update(
+                                board_setup.configure_board_provider(registry.get(board_type), io)
                             )
                             break
+                        except BoardProviderError as error:
+                            click.echo(f"✗ {board_type}: {error.message}")
+                            if error.hint:
+                                click.echo(f"  {error.hint}")
+                            if not click.confirm(
+                                "Исправить credentials и повторить?",
+                                default=True,
+                            ):
+                                click.echo(
+                                    "Provider пропущен; непроверенные credentials не сохранены."
+                                )
+                                break
+            else:
+                values = inst.prompt_groups(groups, current=current, yes=True)
+
+            extra = {key: value for key, value in current.items() if key not in wizard_keys}
+            content = inst.render_env(values, extra)
+            if dest.is_file() and dest.read_text(encoding="utf-8") == content:
+                action = "noop"
+            else:
+                action = "update" if dest.is_file() else "create"
+            global_plan = _GlobalInitPlan(
+                path=dest,
+                content=content,
+                preview=inst.render_env_preview(values, extra),
+                source=f"existing:{dest}" if dest.is_file() else "wizard defaults/input",
+                action=action,
+            )
+
+        if run_repo:
+            settings = Settings(_env_file=None) if scope == "repo" else Settings()
+            detection = repo_onboarding.detect_repository(
+                ".",
+                repo_opt,
+                settings=settings,
+            )
+            if (
+                detection is None
+                and interactive
+                and repo_opt is None
+                and repo_root(".") is not None
+            ):
+                entered_repo = click.prompt(
+                    "Repository (owner/name)",
+                    default="",
+                    show_default=False,
+                ).strip()
+                if entered_repo:
+                    detection = repo_onboarding.detect_repository(
+                        ".",
+                        entered_repo,
+                        settings=settings,
+                    )
+
+            if detection is None:
+                message = (
+                    "repo не определён: запустите из git repository с распознаваемым origin "
+                    "или передайте --repo owner/name"
+                )
+                if scope == "repo":
+                    raise click.ClickException(message)
+                click.echo(f"repo stage пропущен: {message}")
+            else:
+                initial_plan = repo_onboarding.plan_repository_config(
+                    detection,
+                    settings=settings,
+                )
+                if initial_plan.action == "noop" or not interactive:
+                    repo_plan = initial_plan
+                else:
+                    click.echo(
+                        f"\nОбнаружен repo {detection.repo} ({detection.repo_source})"
+                    )
+                    click.echo(
+                        f"Primary candidate: {detection.primary} "
+                        f"({detection.primary_source})"
+                    )
+                    primary = click.prompt(
+                        "Primary branch",
+                        default=initial_plan.primary,
+                    ).strip()
+                    default_index = (
+                        initial_plan.index
+                        if primary == initial_plan.primary
+                        else (primary,)
+                    )
+                    while True:
+                        raw_index = click.prompt(
+                            "Index branches (CSV)",
+                            default=",".join(default_index),
+                        )
+                        try:
+                            index = repo_onboarding.parse_branch_csv(raw_index, primary)
+                        except ValueError as exc:
+                            click.echo(f"Некорректные ветки: {exc}")
+                            continue
+                        break
+                    repo_plan = repo_onboarding.plan_repository_config(
+                        detection,
+                        settings=settings,
+                        primary=(primary if primary != initial_plan.primary else None),
+                        index=index,
+                    )
+
+        _render_init_preview(global_plan, repo_plan)
+        if dry_run:
+            return
+        if interactive and not click.confirm(
+            "\nЗаписать показанные изменения?",
+            default=True,
+        ):
+            click.echo("Отменено — файлы не изменены.")
+            return
     except click.Abort:
-        click.echo("\nОтменено — файл не изменён.")
+        click.echo("\nОтменено — файлы не изменены.")
         return
+    except (HomeConfigError, yaml.YAMLError) as exc:
+        raise click.ClickException(_config_error_message(exc)) from exc
+    except ValueError as exc:
+        raise click.ClickException(str(exc)) from exc
 
-    extra = {k: v for k, v in current.items() if k not in wizard_keys}
-    content = inst.render_env(values, extra)
-    dest.write_text(content, encoding="utf-8")
-    click.echo(f"\n✓ Записан {dest}")
+    if global_plan is not None:
+        try:
+            if global_plan.action != "noop":
+                global_plan.path.parent.mkdir(parents=True, exist_ok=True)
+                global_plan.path.write_text(global_plan.content, encoding="utf-8")
+        except Exception as exc:  # noqa: BLE001 — error не должен раскрыть env content
+            raise click.ClickException(
+                f"Не удалось записать {global_plan.path}: {type(exc).__name__}"
+            ) from None
+        if global_plan.action == "noop":
+            click.echo(f"\n✓ Global config: noop → {global_plan.path}")
+        else:
+            click.echo(f"\n✓ Записан {global_plan.path} ({global_plan.action})")
 
-    if not yes and click.confirm("\nЗапустить reviewer check сейчас?", default=True):
+    if repo_plan is not None:
+        try:
+            repo_onboarding.apply_repository_config(repo_plan)
+        except Exception as exc:  # noqa: BLE001 — не эхоить потенциальный payload исключения
+            raise click.ClickException(
+                f"Не удалось записать {repo_plan.path}: {type(exc).__name__}"
+            ) from None
+        click.echo(f"✓ Repo config: {repo_plan.action} → {repo_plan.path}")
+        assert settings is not None
+        try:
+            effective = resolve_repo_branches(repo_plan.repo, settings=settings)
+        except (HomeConfigError, yaml.YAMLError) as exc:
+            raise click.ClickException(_config_error_message(exc)) from exc
+        _render_config_report(_branches_report(effective))
+        click.echo(f"Полный отчёт: reviewer config show --repo {repo_plan.repo}")
+
+    if run_global and interactive and click.confirm(
+        "\nЗапустить reviewer check сейчас?",
+        default=True,
+    ):
         subprocess.run(["reviewer", "check"], check=False)
-    elif not yes:
+    elif run_global and interactive:
         click.echo("Запустите: reviewer check")
-    else:
+    elif run_global:
         click.echo("Готово. Запустите: reviewer check")
 
-    if not yes and _shutil.which("codex") and click.confirm(
+    if run_global and interactive and _shutil.which("codex") and click.confirm(
         "\nУстановить или обновить rag-reviewer для Codex?", default=True
     ):
         result = _run_codex_target(include_mcp=True, dry_run=False)

--- a/reviewer/entrypoints/cli.py
+++ b/reviewer/entrypoints/cli.py
@@ -18,13 +18,19 @@ import yaml
 
 from reviewer.config.settings import Settings
 from reviewer.app import build_components
-from reviewer.config import onboarding as repo_onboarding
 from reviewer.config.branches import migrate_repo_branches, resolve_repo_branches
 from reviewer.config.layers import (
     HomeConfigError,
     build_config_report,
     migrate_repo_config,
     resolve_policy_data,
+)
+from reviewer.config.onboarding import (
+    RepositoryConfigPlan,
+    apply_repository_config,
+    detect_repository,
+    parse_branch_csv,
+    plan_repository_config,
 )
 from reviewer.gitutil import file_at_ref, list_python_files, repo_root, rev_parse, remote_url
 from reviewer.graph.backend import build_code_graph
@@ -1100,7 +1106,7 @@ class _GlobalInitPlan:
 
 def _render_init_preview(
     global_plan: _GlobalInitPlan | None,
-    repo_plan: repo_onboarding.RepositoryConfigPlan | None,
+    repo_plan: RepositoryConfigPlan | None,
 ) -> None:
     """Показать все target-планы до первой записи, не раскрывая env secrets."""
     click.echo("# reviewer init preview")
@@ -1155,7 +1161,7 @@ def init(
         except ValueError as exc:
             raise click.ClickException(str(exc)) from exc
     global_plan: _GlobalInitPlan | None = None
-    repo_plan: repo_onboarding.RepositoryConfigPlan | None = None
+    repo_plan: RepositoryConfigPlan | None = None
     settings: Settings | None = None
     try:
         if run_global:
@@ -1240,7 +1246,7 @@ def init(
 
         if run_repo:
             settings = Settings(_env_file=None) if scope == "repo" else Settings()
-            detection = repo_onboarding.detect_repository(
+            detection = detect_repository(
                 ".",
                 repo_opt,
                 settings=settings,
@@ -1257,7 +1263,7 @@ def init(
                     show_default=False,
                 ).strip()
                 if entered_repo:
-                    detection = repo_onboarding.detect_repository(
+                    detection = detect_repository(
                         ".",
                         entered_repo,
                         settings=settings,
@@ -1272,7 +1278,7 @@ def init(
                     raise click.ClickException(message)
                 click.echo(f"repo stage пропущен: {message}")
             else:
-                initial_plan = repo_onboarding.plan_repository_config(
+                initial_plan = plan_repository_config(
                     detection,
                     settings=settings,
                 )
@@ -1301,12 +1307,12 @@ def init(
                             default=",".join(default_index),
                         )
                         try:
-                            index = repo_onboarding.parse_branch_csv(raw_index, primary)
+                            index = parse_branch_csv(raw_index, primary)
                         except ValueError as exc:
                             click.echo(f"Некорректные ветки: {exc}")
                             continue
                         break
-                    repo_plan = repo_onboarding.plan_repository_config(
+                    repo_plan = plan_repository_config(
                         detection,
                         settings=settings,
                         primary=(primary if primary != initial_plan.primary else None),
@@ -1346,7 +1352,7 @@ def init(
 
     if repo_plan is not None:
         try:
-            repo_onboarding.apply_repository_config(repo_plan)
+            apply_repository_config(repo_plan)
         except Exception as exc:  # noqa: BLE001 — не эхоить потенциальный payload исключения
             raise click.ClickException(
                 f"Не удалось записать {repo_plan.path}: {type(exc).__name__}"

--- a/reviewer/gitutil.py
+++ b/reviewer/gitutil.py
@@ -8,6 +8,31 @@ def _git(repo: str, *args: str) -> str:
     return subprocess.run(["git", "-C", repo, *args],
                           check=True, capture_output=True, text=True).stdout
 
+
+def repo_root(path: str = ".") -> str | None:
+    try:
+        root = _git(path, "rev-parse", "--show-toplevel").strip()
+    except (OSError, subprocess.CalledProcessError):
+        return None
+    return os.path.abspath(root) if root else None
+
+
+def remote_default_branch(repo: str) -> str | None:
+    try:
+        ref = _git(
+            repo,
+            "symbolic-ref",
+            "--quiet",
+            "refs/remotes/origin/HEAD",
+        ).strip()
+    except (OSError, subprocess.CalledProcessError):
+        return None
+
+    prefix = "refs/remotes/origin/"
+    branch = ref.removeprefix(prefix)
+    return branch if ref.startswith(prefix) and branch else None
+
+
 def changed_files(repo: str, base: str, head: str) -> list[str]:
     out = _git(repo, "diff", "--name-only", f"{base}..{head}")
     return [line for line in out.splitlines() if line]

--- a/reviewer/install.py
+++ b/reviewer/install.py
@@ -28,7 +28,6 @@ PACKAGE = "rag-reviewer"
 SERVER_NAME = "reviewer"
 COMMON_BOARD_ENV_KEYS = frozenset(
     {
-        "TASK_BOARD_MCP",
         "TASK_BOARD_KEY_PATTERN",
         "TASK_BOARD_URL_TEMPLATE",
     }
@@ -137,10 +136,6 @@ def board_env_group(registry) -> EnvGroup:
     """
     fields = [
         EnvField(
-            key="TASK_BOARD_MCP",
-            prompt_text="TASK_BOARD_MCP (имя MCP-сервера доски)",
-        ),
-        EnvField(
             key="TASK_BOARD_KEY_PATTERN",
             prompt_text=r"TASK_BOARD_KEY_PATTERN (напр. [A-Z]+-\d+)",
         ),
@@ -165,7 +160,7 @@ def board_env_group(registry) -> EnvGroup:
 
 
 def common_board_env_fields(group: EnvGroup) -> list[EnvField]:
-    """Только три non-secret поля общей связки; prefix matching запрещён."""
+    """Только два non-secret поля общей связки; prefix matching запрещён."""
     return [field for field in group.fields if field.key in COMMON_BOARD_ENV_KEYS]
 
 
@@ -217,22 +212,6 @@ WIZARD_GROUPS: list[EnvGroup] = [
         ],
     ),
     EnvGroup(
-        title="Мульти-репо / ветки",
-        optional=True,
-        fields=[
-            EnvField(
-                key="DEFAULT_REPO",
-                prompt_text="DEFAULT_REPO (owner/name или пусто)",
-                default="",
-            ),
-            EnvField(
-                key="REVIEW_BRANCHES",
-                prompt_text="REVIEW_BRANCHES (CSV, первая — первичная)",
-                default="main,master",
-            ),
-        ],
-    ),
-    EnvGroup(
         title="GitLab VCS",
         optional=True,
         fields=[
@@ -255,23 +234,6 @@ WIZARD_GROUPS: list[EnvGroup] = [
         ],
     ),
     board_env_group(_default_board_registry()),
-    EnvGroup(
-        title="Веб-админка",
-        optional=True,
-        fields=[
-            EnvField(
-                key="WEB_ADMIN_USER",
-                prompt_text="WEB_ADMIN_USER (basic-auth логин)",
-                default="",
-            ),
-            EnvField(
-                key="WEB_ADMIN_PASSWORD",
-                prompt_text="WEB_ADMIN_PASSWORD (basic-auth пароль)",
-                default="",
-                secret=True,
-            ),
-        ],
-    ),
 ]
 
 ENV_TEMPLATE = _env_template_with_board_fields(
@@ -298,7 +260,6 @@ def read_env(path: Path) -> dict[str, str]:
 _GROUP_HEADERS: dict[str, str] = {
     "Обязательные": "# --- Voyage / GitHub ---",
     "Хранилища (Postgres / Neo4j)": "# --- Postgres (ParadeDB :5433) / Neo4j (:7687) ---",
-    "Мульти-репо / ветки": "# --- Мульти-репо / ветки (опционально) ---",
     "GitLab VCS": (
         "# --- GitLab VCS (опционально; multi-platform: ревью GitLab MR) ---\n"
         "# VCS_PROVIDER — фолбэк, когда репо не индексирован. Тип VCS\n"
@@ -312,7 +273,6 @@ _GROUP_HEADERS: dict[str, str] = {
         "# YouGile key можно получить автоматически через reviewer init; password не пишется.\n"
         "# TASK_BOARD_API_KEY/BASE — только read-only compatibility aliases для YouGile."
     ),
-    "Веб-админка": "# --- Веб-админка наблюдаемости (опционально; пусто = без аутентификации) ---",
 }
 
 

--- a/reviewer/launcher/metadata.py
+++ b/reviewer/launcher/metadata.py
@@ -54,10 +54,13 @@ COMMAND_PRESENTATION = {
     ),
     ("init",): CommandPresentation(
         summary="Настроить reviewer",
-        details="Создаёт или обновляет user-scope .env через существующий setup wizard.",
+        details=(
+            "Планирует и настраивает global .env и per-repo branch config "
+            "с preview до записи."
+        ),
         effects=(Effect.WRITE,),
-        scenarios=("Первичная настройка", "Смена credentials"),
-        keywords=("config", "env", "wizard"),
+        scenarios=("Первичная настройка", "Добавление репозитория", "Смена credentials"),
+        keywords=("config", "env", "repository", "wizard"),
     ),
     ("install",): CommandPresentation(
         summary="Подключить reviewer к AI-клиенту",

--- a/tests/config/test_branches.py
+++ b/tests/config/test_branches.py
@@ -1,7 +1,10 @@
+import os
+from pathlib import Path
+
 import pytest
 
 from reviewer.config.branches import RepoBranches, resolve_repo_branches
-from reviewer.config.layers import HomePolicyError
+from reviewer.config.layers import HomeConfigError, HomePolicyError
 from reviewer.config.settings import Settings
 
 
@@ -164,3 +167,98 @@ def test_credential_key_inside_repository_block_is_rejected(tmp_path, monkeypatc
             "o/r", settings=_settings(monkeypatch), config_root=tmp_path
         )
     assert "ghp_secret" not in str(exc.value)
+
+
+@pytest.mark.parametrize("relative", ["repos/o/r.yml", "review.yml"])
+def test_symlinked_branch_layer_is_rejected_without_reading_external_content(
+    tmp_path,
+    monkeypatch,
+    relative,
+):
+    external = tmp_path / "external.yml"
+    marker = "external-only-branch"
+    external.write_text(
+        f"repository:\n  index_branches: [{marker}]\n",
+        encoding="utf-8",
+    )
+    path = tmp_path / relative
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.symlink_to(external)
+    original_read_text = Path.read_text
+
+    def reject_symlink_read(candidate, *args, **kwargs):
+        if candidate == path:
+            raise AssertionError("branch resolver followed symlink")
+        return original_read_text(candidate, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "read_text", reject_symlink_read)
+
+    with pytest.raises(HomeConfigError, match="symlink") as captured:
+        resolve_repo_branches(
+            "o/r",
+            settings=_settings(monkeypatch, "main"),
+            config_root=tmp_path,
+        )
+
+    assert marker not in repr(captured.value)
+    assert external.read_text(encoding="utf-8").endswith(f"[{marker}]\n")
+
+
+def test_symlinked_branch_parent_is_rejected_without_external_provenance(
+    tmp_path,
+    monkeypatch,
+):
+    marker = "external-parent-branch"
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    external = outside / "r.yml"
+    external.write_text(
+        f"repository:\n  index_branches: [{marker}]\n",
+        encoding="utf-8",
+    )
+    repos = tmp_path / "repos"
+    repos.mkdir()
+    (repos / "o").symlink_to(outside, target_is_directory=True)
+
+    with pytest.raises(HomeConfigError, match="symlink") as captured:
+        resolve_repo_branches(
+            "o/r",
+            settings=_settings(monkeypatch, "main"),
+            config_root=tmp_path,
+        )
+
+    assert marker not in repr(captured.value)
+    assert external.read_text(encoding="utf-8").endswith(f"[{marker}]\n")
+
+
+def test_directory_branch_layer_is_config_error(tmp_path, monkeypatch):
+    (tmp_path / "repos/o/r.yml").mkdir(parents=True)
+
+    with pytest.raises(HomeConfigError, match="regular"):
+        resolve_repo_branches(
+            "o/r",
+            settings=_settings(monkeypatch, "main"),
+            config_root=tmp_path,
+        )
+
+
+@pytest.mark.skipif(not hasattr(os, "mkfifo"), reason="FIFO недоступен на платформе")
+def test_fifo_branch_layer_is_rejected_without_reading(tmp_path, monkeypatch):
+    path = tmp_path / "repos/o/r.yml"
+    path.parent.mkdir(parents=True)
+    os.mkfifo(path)
+    original_read_text = Path.read_text
+
+    def reject_fifo_read(candidate, *args, **kwargs):
+        if candidate == path:
+            raise AssertionError("branch resolver attempted to read FIFO")
+        return original_read_text(candidate, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "read_text", reject_fifo_read)
+
+    with pytest.raises(HomeConfigError, match="regular"):
+        resolve_repo_branches(
+            "o/r",
+            settings=_settings(monkeypatch, "main"),
+            config_root=tmp_path,
+        )

--- a/tests/config/test_branches_migrate.py
+++ b/tests/config/test_branches_migrate.py
@@ -1,7 +1,6 @@
-import builtins
-
 import yaml
 
+import reviewer.config.layers as layers
 from reviewer.config.branches import (
     migrate_repo_branches,
     publish_repository_block,
@@ -107,20 +106,19 @@ def test_env_file_is_not_touched(tmp_path, monkeypatch):
     assert env.read_text(encoding="utf-8") == "REVIEW_BRANCHES=dev,main\n"
 
 
-def test_shared_publisher_create_race_degrades_to_noop(tmp_path, monkeypatch):
+def test_shared_publisher_create_race_reloads_and_appends(tmp_path, monkeypatch):
     path = tmp_path / "repos/o/r.yml"
     block = render_repository_block("main", ("main",))
-    real_open = builtins.open
 
-    def racing_open(file, mode="r", *args, **kwargs):
-        if file == path and mode == "x":
-            path.write_text("# created by another process\n", encoding="utf-8")
-            raise FileExistsError
-        return real_open(file, mode, *args, **kwargs)
+    def racing_link(*args, **kwargs):
+        path.write_text("# created by another process\nmax_comments: 5\n", encoding="utf-8")
+        raise FileExistsError
 
-    monkeypatch.setattr(builtins, "open", racing_open)
+    monkeypatch.setattr(layers.os, "link", racing_link)
 
     action = publish_repository_block(path, "home:repos/o/r.yml", block)
+    text = path.read_text(encoding="utf-8")
 
-    assert action == "noop"
-    assert path.read_text(encoding="utf-8") == "# created by another process\n"
+    assert action == "append"
+    assert "# created by another process" in text
+    assert yaml.safe_load(text)["repository"]["primary_branch"] == "main"

--- a/tests/config/test_branches_migrate.py
+++ b/tests/config/test_branches_migrate.py
@@ -1,6 +1,13 @@
+import builtins
+
 import yaml
 
-from reviewer.config.branches import migrate_repo_branches, resolve_repo_branches
+from reviewer.config.branches import (
+    migrate_repo_branches,
+    publish_repository_block,
+    render_repository_block,
+    resolve_repo_branches,
+)
 from reviewer.config.settings import Settings
 
 
@@ -14,7 +21,10 @@ def test_migration_creates_file_with_env_branches(tmp_path, monkeypatch):
     result = migrate_repo_branches("o/r", settings=settings, config_root=tmp_path)
     assert result.created is True
     data = yaml.safe_load(result.path.read_text(encoding="utf-8"))
-    assert data["repository"]["index_branches"] == ["dev", "main"]
+    assert data["repository"] == {
+        "primary_branch": "dev",
+        "index_branches": ["dev", "main"],
+    }
 
 
 def test_effective_branches_unchanged_by_migration(tmp_path, monkeypatch):
@@ -27,10 +37,12 @@ def test_effective_branches_unchanged_by_migration(tmp_path, monkeypatch):
 
 def test_second_call_is_noop(tmp_path, monkeypatch):
     settings = _settings(monkeypatch)
-    migrate_repo_branches("o/r", settings=settings, config_root=tmp_path)
+    first = migrate_repo_branches("o/r", settings=settings, config_root=tmp_path)
+    original = first.path.read_bytes()
     second = migrate_repo_branches("o/r", settings=settings, config_root=tmp_path)
     assert second.noop is True
     assert second.created is False
+    assert second.path.read_bytes() == original
 
 
 def test_existing_repository_block_is_not_overwritten(tmp_path, monkeypatch):
@@ -82,6 +94,7 @@ def test_migration_quotes_yaml_ambiguous_branch_names(tmp_path, monkeypatch):
     text = result.path.read_text(encoding="utf-8")
     data = yaml.safe_load(text)
     assert data["repository"]["index_branches"] == ["2.0", "on", "no", "feature{x}"]
+    assert data["repository"]["primary_branch"] == "2.0"
     resolved = resolve_repo_branches("o/r", settings=settings, config_root=tmp_path)
     assert resolved.index == ("2.0", "on", "no", "feature{x}")
     assert resolved.primary == "2.0"
@@ -92,3 +105,22 @@ def test_env_file_is_not_touched(tmp_path, monkeypatch):
     env.write_text("REVIEW_BRANCHES=dev,main\n", encoding="utf-8")
     migrate_repo_branches("o/r", settings=_settings(monkeypatch), config_root=tmp_path)
     assert env.read_text(encoding="utf-8") == "REVIEW_BRANCHES=dev,main\n"
+
+
+def test_shared_publisher_create_race_degrades_to_noop(tmp_path, monkeypatch):
+    path = tmp_path / "repos/o/r.yml"
+    block = render_repository_block("main", ("main",))
+    real_open = builtins.open
+
+    def racing_open(file, mode="r", *args, **kwargs):
+        if file == path and mode == "x":
+            path.write_text("# created by another process\n", encoding="utf-8")
+            raise FileExistsError
+        return real_open(file, mode, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "open", racing_open)
+
+    action = publish_repository_block(path, "home:repos/o/r.yml", block)
+
+    assert action == "noop"
+    assert path.read_text(encoding="utf-8") == "# created by another process\n"

--- a/tests/config/test_onboarding.py
+++ b/tests/config/test_onboarding.py
@@ -365,6 +365,7 @@ def test_apply_appends_without_losing_comments_and_quotes_ambiguous_names(
     "original",
     [
         "{}\n",
+        "{   }\n",
         "{max_comments: 5} # keep flow comment\n",
     ],
 )
@@ -386,6 +387,33 @@ def test_apply_extends_flow_mapping_as_one_valid_document(monkeypatch, tmp_path,
     if "max_comments" in original:
         assert data["max_comments"] == 5
         assert "# keep flow comment" in text
+
+
+@pytest.mark.parametrize(
+    "original",
+    [
+        "{max_comments: 5,}\n",
+        "{ max_comments: 5,   } # keep trailing-comma comment\n",
+    ],
+)
+def test_apply_extends_flow_mapping_with_trailing_comma(monkeypatch, tmp_path, original):
+    path = tmp_path / "repos/o/r.yml"
+    path.parent.mkdir(parents=True)
+    path.write_text(original, encoding="utf-8")
+    plan = plan_repository_config(
+        _detection(tmp_path),
+        settings=_settings(monkeypatch),
+        config_root=tmp_path,
+    )
+
+    apply_repository_config(plan)
+    text = path.read_text(encoding="utf-8")
+    data = yaml.safe_load(text)
+
+    assert data["max_comments"] == 5
+    assert data["repository"]["primary_branch"] == "dev"
+    if "#" in original:
+        assert "# keep trailing-comma comment" in text
 
 
 def test_apply_inserts_before_document_terminator(monkeypatch, tmp_path):

--- a/tests/config/test_onboarding.py
+++ b/tests/config/test_onboarding.py
@@ -185,6 +185,45 @@ def test_detect_repository_uses_effective_home_primary_source(monkeypatch, tmp_p
     assert result.primary_source == "home:review.yml"
 
 
+def test_detect_repository_rejects_symlinked_repo_layer_without_false_provenance(
+    monkeypatch,
+    tmp_path,
+):
+    config_root = tmp_path / "rag-reviewer"
+    path = config_root / "repos/o/r.yml"
+    path.parent.mkdir(parents=True)
+    external = tmp_path / "external.yml"
+    marker = "external-detected-branch"
+    external.write_text(
+        f"repository:\n  index_branches: [{marker}]\n",
+        encoding="utf-8",
+    )
+    path.symlink_to(external)
+    original_read_text = Path.read_text
+
+    def reject_symlink_read(candidate, *args, **kwargs):
+        if candidate == path:
+            raise AssertionError("detect_repository followed branch config symlink")
+        return original_read_text(candidate, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "read_text", reject_symlink_read)
+    monkeypatch.setattr("reviewer.config.onboarding.repo_root", lambda _path: str(tmp_path))
+    monkeypatch.setattr(
+        "reviewer.config.onboarding.remote_url",
+        lambda _path: "https://github.com/o/r.git",
+    )
+
+    with pytest.raises(HomeConfigError, match="symlink") as captured:
+        detect_repository(
+            ".",
+            None,
+            settings=_settings(monkeypatch, "main", config_home=tmp_path),
+        )
+
+    assert marker not in repr(captured.value)
+    assert external.read_text(encoding="utf-8").endswith(f"[{marker}]\n")
+
+
 def test_parse_branch_csv_strips_items():
     assert parse_branch_csv(" dev, main ", "dev") == ("dev", "main")
 

--- a/tests/config/test_onboarding.py
+++ b/tests/config/test_onboarding.py
@@ -1,0 +1,362 @@
+from dataclasses import FrozenInstanceError
+from pathlib import Path
+
+import pytest
+import yaml
+
+from reviewer.config.onboarding import (
+    RepositoryConfigPlan,
+    RepositoryDetection,
+    apply_repository_config,
+    detect_repository,
+    parse_branch_csv,
+    plan_repository_config,
+)
+from reviewer.config.settings import Settings
+
+
+def _settings(monkeypatch, branches="main", *, config_home=None):
+    monkeypatch.setenv("REVIEW_BRANCHES", branches)
+    if config_home is not None:
+        monkeypatch.setenv("XDG_CONFIG_HOME", str(config_home))
+    return Settings(_env_file=None)
+
+
+def _detection(
+    root: Path,
+    *,
+    repo: str = "o/r",
+    primary: str = "dev",
+) -> RepositoryDetection:
+    return RepositoryDetection(
+        root=root,
+        repo=repo,
+        repo_source="git:origin",
+        primary=primary,
+        primary_source="git:origin/HEAD",
+    )
+
+
+def test_repository_contracts_are_immutable(tmp_path):
+    detection = _detection(tmp_path)
+    plan = RepositoryConfigPlan(
+        path=tmp_path / "r.yml",
+        repo="o/r",
+        primary="dev",
+        index=("dev",),
+        repo_source="git:origin",
+        primary_source="git:origin/HEAD",
+        action="create",
+        preview="repository: {}\n",
+    )
+
+    with pytest.raises(FrozenInstanceError):
+        detection.repo = "other/repo"
+    with pytest.raises(FrozenInstanceError):
+        plan.action = "noop"
+
+
+def test_detect_repository_returns_none_outside_git(monkeypatch):
+    monkeypatch.setattr("reviewer.config.onboarding.repo_root", lambda _path: None)
+    monkeypatch.setattr(
+        "reviewer.config.onboarding.remote_url",
+        lambda _path: pytest.fail("remote must not be inspected outside git"),
+    )
+
+    assert detect_repository(".", "o/r", settings=_settings(monkeypatch)) is None
+
+
+def test_detect_repository_prefers_normalized_cli_repo(monkeypatch, tmp_path):
+    monkeypatch.setattr("reviewer.config.onboarding.repo_root", lambda _path: str(tmp_path))
+    monkeypatch.setattr(
+        "reviewer.config.onboarding.remote_url",
+        lambda _path: pytest.fail("explicit repo must win before origin"),
+    )
+    monkeypatch.setattr("reviewer.config.onboarding.remote_default_branch", lambda _path: "dev")
+
+    result = detect_repository(
+        ".",
+        " CLI/Repo ",
+        settings=_settings(monkeypatch, config_home=tmp_path),
+    )
+
+    assert result == RepositoryDetection(
+        root=tmp_path,
+        repo="cli/repo",
+        repo_source="cli",
+        primary="dev",
+        primary_source="git:origin/HEAD",
+    )
+
+
+def test_detect_repository_falls_back_to_origin_repo(monkeypatch, tmp_path):
+    monkeypatch.setattr("reviewer.config.onboarding.repo_root", lambda _path: str(tmp_path))
+    monkeypatch.setattr(
+        "reviewer.config.onboarding.remote_url",
+        lambda _path: "https://github.com/Remote/Name.git",
+    )
+    monkeypatch.setattr("reviewer.config.onboarding.remote_default_branch", lambda _path: "main")
+
+    result = detect_repository(
+        ".",
+        None,
+        settings=_settings(monkeypatch, config_home=tmp_path),
+    )
+
+    assert result is not None
+    assert result.repo == "remote/name"
+    assert result.repo_source == "git:origin"
+
+
+def test_detect_repository_returns_none_without_repo_source(monkeypatch, tmp_path):
+    monkeypatch.setattr("reviewer.config.onboarding.repo_root", lambda _path: str(tmp_path))
+    monkeypatch.setattr("reviewer.config.onboarding.remote_url", lambda _path: None)
+
+    assert (
+        detect_repository(
+            ".",
+            None,
+            settings=_settings(monkeypatch, config_home=tmp_path),
+        )
+        is None
+    )
+
+
+@pytest.mark.parametrize(
+    ("origin_head", "expected_primary", "expected_source"),
+    [
+        ("dev", "dev", "git:origin/HEAD"),
+        (None, "release", "env"),
+    ],
+)
+def test_detect_repository_primary_precedence(
+    monkeypatch,
+    tmp_path,
+    origin_head,
+    expected_primary,
+    expected_source,
+):
+    monkeypatch.setattr("reviewer.config.onboarding.repo_root", lambda _path: str(tmp_path))
+    monkeypatch.setattr(
+        "reviewer.config.onboarding.remote_url",
+        lambda _path: "git@github.com:o/r.git",
+    )
+    monkeypatch.setattr(
+        "reviewer.config.onboarding.remote_default_branch",
+        lambda _path: origin_head,
+    )
+
+    result = detect_repository(
+        ".",
+        None,
+        settings=_settings(monkeypatch, "release,main", config_home=tmp_path),
+    )
+
+    assert result is not None
+    assert result.primary == expected_primary
+    assert result.primary_source == expected_source
+
+
+def test_detect_repository_uses_effective_home_primary_source(monkeypatch, tmp_path):
+    config_root = tmp_path / "rag-reviewer"
+    config_root.mkdir()
+    (config_root / "review.yml").write_text(
+        "repository:\n  index_branches: [trunk]\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr("reviewer.config.onboarding.repo_root", lambda _path: str(tmp_path))
+    monkeypatch.setattr(
+        "reviewer.config.onboarding.remote_url",
+        lambda _path: "https://github.com/o/r.git",
+    )
+    monkeypatch.setattr("reviewer.config.onboarding.remote_default_branch", lambda _path: None)
+
+    result = detect_repository(
+        ".",
+        None,
+        settings=_settings(monkeypatch, "main", config_home=tmp_path),
+    )
+
+    assert result is not None
+    assert result.primary == "trunk"
+    assert result.primary_source == "home:review.yml"
+
+
+def test_parse_branch_csv_strips_items():
+    assert parse_branch_csv(" dev, main ", "dev") == ("dev", "main")
+
+
+@pytest.mark.parametrize(
+    "raw",
+    ["", "   ", "dev,,main", ",dev", "dev,", "dev,dev", "dev, dev"],
+)
+def test_parse_branch_csv_rejects_empty_items_and_duplicates(raw):
+    with pytest.raises(ValueError):
+        parse_branch_csv(raw, "dev")
+
+
+def test_parse_branch_csv_requires_primary_in_index():
+    with pytest.raises(ValueError, match="primary"):
+        parse_branch_csv("main,release", "dev")
+
+
+def test_plan_preserves_compatible_effective_index(monkeypatch, tmp_path):
+    plan = plan_repository_config(
+        _detection(tmp_path),
+        settings=_settings(monkeypatch, "dev,main"),
+        config_root=tmp_path,
+    )
+
+    assert plan.path == tmp_path / "repos/o/r.yml"
+    assert plan.primary == "dev"
+    assert plan.index == ("dev", "main")
+    assert plan.action == "create"
+    assert not plan.path.exists()
+
+
+def test_plan_replaces_incompatible_effective_index(monkeypatch, tmp_path):
+    plan = plan_repository_config(
+        _detection(tmp_path),
+        settings=_settings(monkeypatch, "main,master"),
+        config_root=tmp_path,
+    )
+
+    assert plan.primary == "dev"
+    assert plan.index == ("dev",)
+    assert plan.action == "create"
+
+
+@pytest.mark.parametrize("index", [(), ("dev", ""), ("dev", "dev"), ("main",)])
+def test_plan_validates_explicit_index(monkeypatch, tmp_path, index):
+    with pytest.raises(ValueError):
+        plan_repository_config(
+            _detection(tmp_path),
+            settings=_settings(monkeypatch),
+            index=index,
+            config_root=tmp_path,
+        )
+
+
+def test_plan_uses_authoritative_repo_file_without_rewriting(monkeypatch, tmp_path):
+    path = tmp_path / "repos/o/r.yml"
+    path.parent.mkdir(parents=True)
+    original = (
+        "# authoritative\n"
+        "repository:\n"
+        "  primary_branch: trunk\n"
+        "  index_branches: [trunk, release]\n"
+        "  future: keep\n"
+    )
+    path.write_text(original, encoding="utf-8")
+
+    plan = plan_repository_config(
+        _detection(tmp_path),
+        settings=_settings(monkeypatch),
+        primary="other",
+        index=("other",),
+        config_root=tmp_path,
+    )
+    apply_repository_config(plan)
+
+    assert plan.action == "noop"
+    assert plan.primary == "trunk"
+    assert plan.index == ("trunk", "release")
+    assert yaml.safe_load(plan.preview)["repository"] == {
+        "primary_branch": "trunk",
+        "index_branches": ["trunk", "release"],
+    }
+    assert path.read_text(encoding="utf-8") == original
+
+
+def test_apply_creates_and_repeat_is_byte_for_byte_noop(monkeypatch, tmp_path):
+    detection = _detection(tmp_path)
+    plan = plan_repository_config(
+        detection,
+        settings=_settings(monkeypatch),
+        index=("dev", "main"),
+        config_root=tmp_path,
+    )
+
+    assert plan.action == "create"
+    assert not plan.path.exists()
+    apply_repository_config(plan)
+    first = plan.path.read_bytes()
+    repeated = plan_repository_config(
+        detection,
+        settings=_settings(monkeypatch),
+        config_root=tmp_path,
+    )
+    apply_repository_config(repeated)
+
+    assert repeated.action == "noop"
+    assert plan.path.read_bytes() == first
+    assert yaml.safe_load(first)["repository"] == {
+        "primary_branch": "dev",
+        "index_branches": ["dev", "main"],
+    }
+
+
+def test_apply_appends_without_losing_comments_and_quotes_ambiguous_names(
+    monkeypatch,
+    tmp_path,
+):
+    path = tmp_path / "repos/o/r.yml"
+    path.parent.mkdir(parents=True)
+    original = "# keep me\nmax_comments: 7\n"
+    path.write_text(original, encoding="utf-8")
+    plan = plan_repository_config(
+        _detection(tmp_path, primary="2.0"),
+        settings=_settings(monkeypatch),
+        index=("2.0", "on", "no", "feature{x}"),
+        config_root=tmp_path,
+    )
+
+    assert plan.action == "append"
+    assert path.read_text(encoding="utf-8") == original
+    apply_repository_config(plan)
+    text = path.read_text(encoding="utf-8")
+
+    assert text.startswith(original)
+    assert "# keep me" in text
+    assert yaml.safe_load(text)["repository"] == {
+        "primary_branch": "2.0",
+        "index_branches": ["2.0", "on", "no", "feature{x}"],
+    }
+
+
+def test_plan_rejects_malformed_existing_yaml(monkeypatch, tmp_path):
+    path = tmp_path / "repos/o/r.yml"
+    path.parent.mkdir(parents=True)
+    path.write_text("repository: [unclosed\n", encoding="utf-8")
+
+    with pytest.raises(ValueError, match="YAML"):
+        plan_repository_config(
+            _detection(tmp_path),
+            settings=_settings(monkeypatch),
+            config_root=tmp_path,
+        )
+
+
+def test_repository_paths_are_isolated(monkeypatch, tmp_path):
+    first = plan_repository_config(
+        _detection(tmp_path, repo="one/service", primary="main"),
+        settings=_settings(monkeypatch),
+        config_root=tmp_path,
+    )
+    second = plan_repository_config(
+        _detection(tmp_path, repo="two/service", primary="release"),
+        settings=_settings(monkeypatch),
+        config_root=tmp_path,
+    )
+
+    apply_repository_config(first)
+    apply_repository_config(second)
+
+    assert first.path == tmp_path / "repos/one/service.yml"
+    assert second.path == tmp_path / "repos/two/service.yml"
+    assert yaml.safe_load(first.path.read_text(encoding="utf-8"))["repository"][
+        "primary_branch"
+    ] == "main"
+    assert yaml.safe_load(second.path.read_text(encoding="utf-8"))["repository"][
+        "primary_branch"
+    ] == "release"

--- a/tests/config/test_onboarding.py
+++ b/tests/config/test_onboarding.py
@@ -4,6 +4,8 @@ from pathlib import Path
 import pytest
 import yaml
 
+import reviewer.config.layers as layers
+from reviewer.config.layers import HomeConfigError
 from reviewer.config.onboarding import (
     RepositoryConfigPlan,
     RepositoryDetection,
@@ -210,6 +212,7 @@ def test_plan_preserves_compatible_effective_index(monkeypatch, tmp_path):
     assert plan.path == tmp_path / "repos/o/r.yml"
     assert plan.primary == "dev"
     assert plan.index == ("dev", "main")
+    assert plan.primary_source == "git:origin/HEAD"
     assert plan.action == "create"
     assert not plan.path.exists()
 
@@ -261,11 +264,25 @@ def test_plan_uses_authoritative_repo_file_without_rewriting(monkeypatch, tmp_pa
     assert plan.action == "noop"
     assert plan.primary == "trunk"
     assert plan.index == ("trunk", "release")
+    assert plan.primary_source == "home:repos/o/r.yml"
     assert yaml.safe_load(plan.preview)["repository"] == {
         "primary_branch": "trunk",
         "index_branches": ["trunk", "release"],
     }
     assert path.read_text(encoding="utf-8") == original
+
+
+def test_plan_marks_explicit_primary_as_cli(monkeypatch, tmp_path):
+    plan = plan_repository_config(
+        _detection(tmp_path),
+        settings=_settings(monkeypatch),
+        primary="release",
+        index=("release", "main"),
+        config_root=tmp_path,
+    )
+
+    assert plan.primary == "release"
+    assert plan.primary_source == "cli"
 
 
 def test_apply_creates_and_repeat_is_byte_for_byte_noop(monkeypatch, tmp_path):
@@ -296,6 +313,26 @@ def test_apply_creates_and_repeat_is_byte_for_byte_noop(monkeypatch, tmp_path):
     }
 
 
+def test_apply_accepts_create_race_that_requires_append(monkeypatch, tmp_path):
+    plan = plan_repository_config(
+        _detection(tmp_path),
+        settings=_settings(monkeypatch),
+        config_root=tmp_path,
+    )
+
+    def racing_link(*args, **kwargs):
+        plan.path.write_text("max_comments: 5\n", encoding="utf-8")
+        raise FileExistsError
+
+    monkeypatch.setattr(layers.os, "link", racing_link)
+
+    apply_repository_config(plan)
+
+    data = yaml.safe_load(plan.path.read_text(encoding="utf-8"))
+    assert data["max_comments"] == 5
+    assert data["repository"]["primary_branch"] == "dev"
+
+
 def test_apply_appends_without_losing_comments_and_quotes_ambiguous_names(
     monkeypatch,
     tmp_path,
@@ -322,6 +359,92 @@ def test_apply_appends_without_losing_comments_and_quotes_ambiguous_names(
         "primary_branch": "2.0",
         "index_branches": ["2.0", "on", "no", "feature{x}"],
     }
+
+
+@pytest.mark.parametrize(
+    "original",
+    [
+        "{}\n",
+        "{max_comments: 5} # keep flow comment\n",
+    ],
+)
+def test_apply_extends_flow_mapping_as_one_valid_document(monkeypatch, tmp_path, original):
+    path = tmp_path / "repos/o/r.yml"
+    path.parent.mkdir(parents=True)
+    path.write_text(original, encoding="utf-8")
+    plan = plan_repository_config(
+        _detection(tmp_path),
+        settings=_settings(monkeypatch),
+        config_root=tmp_path,
+    )
+
+    apply_repository_config(plan)
+    text = path.read_text(encoding="utf-8")
+    data = yaml.safe_load(text)
+
+    assert data["repository"]["primary_branch"] == "dev"
+    if "max_comments" in original:
+        assert data["max_comments"] == 5
+        assert "# keep flow comment" in text
+
+
+def test_apply_inserts_before_document_terminator(monkeypatch, tmp_path):
+    path = tmp_path / "repos/o/r.yml"
+    path.parent.mkdir(parents=True)
+    original = "# keep head\nmax_comments: 5\n...\n# keep tail\n"
+    path.write_text(original, encoding="utf-8")
+    plan = plan_repository_config(
+        _detection(tmp_path),
+        settings=_settings(monkeypatch),
+        config_root=tmp_path,
+    )
+
+    apply_repository_config(plan)
+    text = path.read_text(encoding="utf-8")
+    data = yaml.safe_load(text)
+
+    assert data["max_comments"] == 5
+    assert data["repository"]["primary_branch"] == "dev"
+    assert text.index("repository:") < text.index("...")
+    assert "# keep head" in text
+    assert "# keep tail" in text
+
+
+def test_apply_rejects_symlink_destination_without_modifying_target(monkeypatch, tmp_path):
+    path = tmp_path / "repos/o/r.yml"
+    path.parent.mkdir(parents=True)
+    target = tmp_path / "outside.yml"
+    original = "max_comments: 5\n"
+    target.write_text(original, encoding="utf-8")
+    path.symlink_to(target)
+    plan = plan_repository_config(
+        _detection(tmp_path),
+        settings=_settings(monkeypatch),
+        config_root=tmp_path,
+    )
+
+    with pytest.raises(HomeConfigError, match="symlink"):
+        apply_repository_config(plan)
+
+    assert target.read_text(encoding="utf-8") == original
+
+
+def test_apply_rejects_symlink_parent_without_external_write(monkeypatch, tmp_path):
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    repos = tmp_path / "repos"
+    repos.mkdir()
+    (repos / "o").symlink_to(outside, target_is_directory=True)
+    plan = plan_repository_config(
+        _detection(tmp_path),
+        settings=_settings(monkeypatch),
+        config_root=tmp_path,
+    )
+
+    with pytest.raises(HomeConfigError, match="symlink"):
+        apply_repository_config(plan)
+
+    assert not (outside / "r.yml").exists()
 
 
 def test_plan_rejects_malformed_existing_yaml(monkeypatch, tmp_path):

--- a/tests/config/test_onboarding.py
+++ b/tests/config/test_onboarding.py
@@ -404,6 +404,30 @@ def test_apply_appends_without_losing_comments_and_quotes_ambiguous_names(
 @pytest.mark.parametrize(
     "original",
     [
+        b"# keep me\r\nmax_comments: 7\r\n",
+        b"# keep me\r\nmax_comments: 7\n",
+    ],
+)
+def test_apply_append_preserves_existing_line_endings(monkeypatch, tmp_path, original):
+    path = tmp_path / "repos/o/r.yml"
+    path.parent.mkdir(parents=True)
+    path.write_bytes(original)
+    plan = plan_repository_config(
+        _detection(tmp_path),
+        settings=_settings(monkeypatch),
+        config_root=tmp_path,
+    )
+
+    apply_repository_config(plan)
+
+    content = path.read_bytes()
+    assert content.startswith(original)
+    assert yaml.safe_load(content)["repository"]["primary_branch"] == "dev"
+
+
+@pytest.mark.parametrize(
+    "original",
+    [
         "{}\n",
         "{   }\n",
         "{max_comments: 5} # keep flow comment\n",

--- a/tests/config/test_onboarding.py
+++ b/tests/config/test_onboarding.py
@@ -416,6 +416,25 @@ def test_apply_extends_flow_mapping_with_trailing_comma(monkeypatch, tmp_path, o
         assert "# keep trailing-comma comment" in text
 
 
+def test_apply_extends_flow_mapping_with_comment_after_trailing_comma(monkeypatch, tmp_path):
+    path = tmp_path / "repos/o/r.yml"
+    path.parent.mkdir(parents=True)
+    path.write_text("{max_comments: 5, # keep\n}\n", encoding="utf-8")
+    plan = plan_repository_config(
+        _detection(tmp_path),
+        settings=_settings(monkeypatch),
+        config_root=tmp_path,
+    )
+
+    apply_repository_config(plan)
+    text = path.read_text(encoding="utf-8")
+    data = yaml.safe_load(text)
+
+    assert data["max_comments"] == 5
+    assert data["repository"]["primary_branch"] == "dev"
+    assert "# keep" in text
+
+
 def test_apply_inserts_before_document_terminator(monkeypatch, tmp_path):
     path = tmp_path / "repos/o/r.yml"
     path.parent.mkdir(parents=True)

--- a/tests/config/test_onboarding.py
+++ b/tests/config/test_onboarding.py
@@ -1,4 +1,5 @@
 from dataclasses import FrozenInstanceError
+import os
 from pathlib import Path
 
 import pytest
@@ -457,41 +458,76 @@ def test_apply_inserts_before_document_terminator(monkeypatch, tmp_path):
     assert "# keep tail" in text
 
 
-def test_apply_rejects_symlink_destination_without_modifying_target(monkeypatch, tmp_path):
+def test_plan_rejects_symlink_destination_without_modifying_target(monkeypatch, tmp_path):
     path = tmp_path / "repos/o/r.yml"
     path.parent.mkdir(parents=True)
     target = tmp_path / "outside.yml"
     original = "max_comments: 5\n"
     target.write_text(original, encoding="utf-8")
     path.symlink_to(target)
-    plan = plan_repository_config(
-        _detection(tmp_path),
-        settings=_settings(monkeypatch),
-        config_root=tmp_path,
-    )
 
     with pytest.raises(HomeConfigError, match="symlink"):
-        apply_repository_config(plan)
+        plan_repository_config(
+            _detection(tmp_path),
+            settings=_settings(monkeypatch),
+            config_root=tmp_path,
+        )
 
     assert target.read_text(encoding="utf-8") == original
 
 
-def test_apply_rejects_symlink_parent_without_external_write(monkeypatch, tmp_path):
+def test_plan_rejects_directory_destination(monkeypatch, tmp_path):
+    path = tmp_path / "repos/o/r.yml"
+    path.mkdir(parents=True)
+
+    with pytest.raises(HomeConfigError, match="regular"):
+        plan_repository_config(
+            _detection(tmp_path),
+            settings=_settings(monkeypatch),
+            config_root=tmp_path,
+        )
+
+
+@pytest.mark.skipif(not hasattr(os, "mkfifo"), reason="FIFO недоступен на платформе")
+def test_plan_rejects_fifo_without_reading(monkeypatch, tmp_path):
+    path = tmp_path / "repos/o/r.yml"
+    path.parent.mkdir(parents=True)
+    os.mkfifo(path)
+    original_read_text = Path.read_text
+
+    def reject_fifo_read(candidate, *args, **kwargs):
+        if candidate == path:
+            raise AssertionError("planner attempted to read FIFO")
+        return original_read_text(candidate, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "read_text", reject_fifo_read)
+
+    with pytest.raises(HomeConfigError, match="regular"):
+        plan_repository_config(
+            _detection(tmp_path),
+            settings=_settings(monkeypatch),
+            config_root=tmp_path,
+        )
+
+
+def test_plan_rejects_symlink_parent_without_external_read(monkeypatch, tmp_path):
     outside = tmp_path / "outside"
     outside.mkdir()
+    external = outside / "r.yml"
+    original = "max_comments: 5\n"
+    external.write_text(original, encoding="utf-8")
     repos = tmp_path / "repos"
     repos.mkdir()
     (repos / "o").symlink_to(outside, target_is_directory=True)
-    plan = plan_repository_config(
-        _detection(tmp_path),
-        settings=_settings(monkeypatch),
-        config_root=tmp_path,
-    )
 
     with pytest.raises(HomeConfigError, match="symlink"):
-        apply_repository_config(plan)
+        plan_repository_config(
+            _detection(tmp_path),
+            settings=_settings(monkeypatch),
+            config_root=tmp_path,
+        )
 
-    assert not (outside / "r.yml").exists()
+    assert external.read_text(encoding="utf-8") == original
 
 
 def test_plan_rejects_malformed_existing_yaml(monkeypatch, tmp_path):

--- a/tests/entrypoints/test_cli_init_onboarding.py
+++ b/tests/entrypoints/test_cli_init_onboarding.py
@@ -62,7 +62,7 @@ def _forbid_noninteractive_side_effects(monkeypatch) -> None:
 def test_init_scope_global_never_detects_or_reads_repo(monkeypatch, tmp_path):
     env, config_root = _isolate(monkeypatch, tmp_path)
     monkeypatch.setattr(
-        "reviewer.config.onboarding.detect_repository",
+        "reviewer.entrypoints.cli.detect_repository",
         lambda *_args, **_kwargs: pytest.fail("repo detection called"),
     )
     monkeypatch.setattr(
@@ -87,7 +87,7 @@ def test_init_scope_repo_does_not_read_or_rewrite_global_env(monkeypatch, tmp_pa
         lambda _path: pytest.fail("global env read"),
     )
     monkeypatch.setattr(
-        "reviewer.config.onboarding.detect_repository",
+        "reviewer.entrypoints.cli.detect_repository",
         lambda *_args, **_kwargs: _detection(tmp_path),
     )
     real_settings = cli_module.Settings
@@ -122,7 +122,7 @@ def test_init_scope_repo_keeps_second_repository_isolated(monkeypatch, tmp_path)
             repo_source="cli",
         )
 
-    monkeypatch.setattr("reviewer.config.onboarding.detect_repository", detect)
+    monkeypatch.setattr("reviewer.entrypoints.cli.detect_repository", detect)
     runner = CliRunner()
 
     first = runner.invoke(
@@ -146,7 +146,7 @@ def test_init_scope_repo_keeps_second_repository_isolated(monkeypatch, tmp_path)
 def test_init_default_all_previews_global_and_repo_targets(monkeypatch, tmp_path):
     env, config_root = _isolate(monkeypatch, tmp_path)
     monkeypatch.setattr(
-        "reviewer.config.onboarding.detect_repository",
+        "reviewer.entrypoints.cli.detect_repository",
         lambda path, *_args, **_kwargs: _detection(tmp_path)
         if path == "."
         else pytest.fail("--path leaked into repo stage"),
@@ -171,11 +171,11 @@ def test_init_dry_run_previews_both_targets_without_prompt_write_or_network(
 ):
     env, config_root = _isolate(monkeypatch, tmp_path)
     monkeypatch.setattr(
-        "reviewer.config.onboarding.detect_repository",
+        "reviewer.entrypoints.cli.detect_repository",
         lambda *_args, **_kwargs: _detection(tmp_path),
     )
     monkeypatch.setattr(
-        "reviewer.config.onboarding.apply_repository_config",
+        "reviewer.entrypoints.cli.apply_repository_config",
         lambda _plan: pytest.fail("repo write called"),
     )
     _forbid_noninteractive_side_effects(monkeypatch)
@@ -197,7 +197,7 @@ def test_init_yes_writes_after_preview_without_prompt_provider_check_or_network(
 ):
     env, config_root = _isolate(monkeypatch, tmp_path)
     monkeypatch.setattr(
-        "reviewer.config.onboarding.detect_repository",
+        "reviewer.entrypoints.cli.detect_repository",
         lambda *_args, **_kwargs: _detection(tmp_path),
     )
     _forbid_noninteractive_side_effects(monkeypatch)
@@ -247,7 +247,7 @@ def test_init_interactive_retries_owner_name_for_unrecognized_remote(monkeypatch
         return _detection(tmp_path, repo_override, repo_source="cli")
 
     answers = iter(["o/r", "dev", "dev"])
-    monkeypatch.setattr("reviewer.config.onboarding.detect_repository", detect)
+    monkeypatch.setattr("reviewer.entrypoints.cli.detect_repository", detect)
     monkeypatch.setattr(click, "prompt", lambda *_args, **_kwargs: next(answers))
     monkeypatch.setattr(click, "confirm", lambda *_args, **_kwargs: True)
 
@@ -264,7 +264,7 @@ def test_init_interactive_can_correct_detected_branches(monkeypatch, tmp_path):
     answers = iter(["release", "release,main"])
     confirms: list[str] = []
     monkeypatch.setattr(
-        "reviewer.config.onboarding.detect_repository",
+        "reviewer.entrypoints.cli.detect_repository",
         lambda *_args, **_kwargs: _detection(tmp_path),
     )
     monkeypatch.setattr(click, "prompt", lambda *_args, **_kwargs: next(answers))
@@ -290,7 +290,7 @@ def test_init_interactive_retries_invalid_branch_csv(monkeypatch, tmp_path):
     _env, config_root = _isolate(monkeypatch, tmp_path)
     answers = iter(["dev", "dev,dev", "main", "dev,main"])
     monkeypatch.setattr(
-        "reviewer.config.onboarding.detect_repository",
+        "reviewer.entrypoints.cli.detect_repository",
         lambda *_args, **_kwargs: _detection(tmp_path),
     )
     monkeypatch.setattr(click, "prompt", lambda *_args, **_kwargs: next(answers))
@@ -311,7 +311,7 @@ def test_init_existing_repo_block_is_noop_and_skips_branch_prompts(monkeypatch, 
     original = "repository:\n  primary_branch: trunk\n  index_branches: [trunk, main]\n"
     path.write_text(original, encoding="utf-8")
     monkeypatch.setattr(
-        "reviewer.config.onboarding.detect_repository",
+        "reviewer.entrypoints.cli.detect_repository",
         lambda *_args, **_kwargs: _detection(tmp_path),
     )
     monkeypatch.setattr(click, "prompt", lambda *_args, **_kwargs: pytest.fail("branch prompt"))
@@ -338,7 +338,7 @@ def test_init_final_rejection_or_abort_happens_before_first_write(
 ):
     env, config_root = _isolate(monkeypatch, tmp_path)
     monkeypatch.setattr(
-        "reviewer.config.onboarding.detect_repository",
+        "reviewer.entrypoints.cli.detect_repository",
         lambda *_args, **_kwargs: _detection(tmp_path),
     )
     monkeypatch.setattr(
@@ -351,7 +351,7 @@ def test_init_final_rejection_or_abort_happens_before_first_write(
     )
     monkeypatch.setattr(click, "prompt", lambda _text, default, **_kwargs: default)
     monkeypatch.setattr(
-        "reviewer.config.onboarding.apply_repository_config",
+        "reviewer.entrypoints.cli.apply_repository_config",
         lambda _plan: pytest.fail("repo write called"),
     )
     confirmations = iter([False, "final"])
@@ -386,7 +386,7 @@ def test_init_missing_detection_all_skips_but_repo_fails_with_guidance(
 ):
     env, config_root = _isolate(monkeypatch, tmp_path)
     monkeypatch.setattr(
-        "reviewer.config.onboarding.detect_repository",
+        "reviewer.entrypoints.cli.detect_repository",
         lambda *_args, **_kwargs: None,
     )
 
@@ -416,7 +416,7 @@ def test_init_invalid_repo_fails_before_prompt_preview_or_write(monkeypatch, tmp
 def test_init_repo_prints_effective_branch_source_and_exact_follow_up(monkeypatch, tmp_path):
     _env, _config_root = _isolate(monkeypatch, tmp_path)
     monkeypatch.setattr(
-        "reviewer.config.onboarding.detect_repository",
+        "reviewer.entrypoints.cli.detect_repository",
         lambda *_args, **_kwargs: _detection(tmp_path),
     )
     monkeypatch.setattr(
@@ -436,11 +436,11 @@ def test_init_repo_prints_effective_branch_source_and_exact_follow_up(monkeypatc
 def test_init_repo_write_failure_is_explicit_and_nonzero(monkeypatch, tmp_path):
     _env, _config_root = _isolate(monkeypatch, tmp_path)
     monkeypatch.setattr(
-        "reviewer.config.onboarding.detect_repository",
+        "reviewer.entrypoints.cli.detect_repository",
         lambda *_args, **_kwargs: _detection(tmp_path),
     )
     monkeypatch.setattr(
-        "reviewer.config.onboarding.apply_repository_config",
+        "reviewer.entrypoints.cli.apply_repository_config",
         lambda _plan: (_ for _ in ()).throw(OSError("secret detail")),
     )
 

--- a/tests/entrypoints/test_cli_init_onboarding.py
+++ b/tests/entrypoints/test_cli_init_onboarding.py
@@ -1,0 +1,452 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import click
+from click.testing import CliRunner
+import pytest
+import yaml
+
+import reviewer.entrypoints.cli as cli_module
+from reviewer.config.onboarding import RepositoryDetection
+from reviewer.entrypoints.cli import cli
+
+
+def _isolate(monkeypatch, tmp_path: Path) -> tuple[Path, Path]:
+    env = tmp_path / "global" / ".env"
+    config_home = tmp_path / "xdg"
+    monkeypatch.setattr("reviewer.install.default_env_path", lambda: env)
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(config_home))
+    monkeypatch.setenv("REVIEW_BRANCHES", "main")
+    monkeypatch.delenv("REVIEWER_ENV_FILE", raising=False)
+    return env, config_home / "rag-reviewer"
+
+
+def _detection(
+    tmp_path: Path,
+    repo: str = "o/r",
+    *,
+    primary: str = "dev",
+    repo_source: str = "git:origin",
+) -> RepositoryDetection:
+    return RepositoryDetection(
+        root=tmp_path,
+        repo=repo,
+        repo_source=repo_source,
+        primary=primary,
+        primary_source="git:origin/HEAD",
+    )
+
+
+def _repo_path(config_root: Path, repo: str = "o/r") -> Path:
+    owner, name = repo.split("/", 1)
+    return config_root / "repos" / owner / f"{name}.yml"
+
+
+def _forbid_noninteractive_side_effects(monkeypatch) -> None:
+    def fail(name):
+        return lambda *_args, **_kwargs: pytest.fail(f"{name} called")
+
+    monkeypatch.setattr(click, "prompt", fail("prompt"))
+    monkeypatch.setattr(click, "confirm", fail("confirm"))
+    monkeypatch.setattr(click, "launch", fail("browser"))
+    monkeypatch.setattr(
+        "reviewer.tasks.boards.setup.configure_board_provider",
+        fail("provider setup"),
+    )
+    monkeypatch.setattr(cli_module, "_run_codex_target", fail("Codex install"))
+    monkeypatch.setattr("subprocess.run", fail("reviewer check"))
+    monkeypatch.setattr(cli_module, "_config_context", fail("full config show"))
+
+
+def test_init_scope_global_never_detects_or_reads_repo(monkeypatch, tmp_path):
+    env, config_root = _isolate(monkeypatch, tmp_path)
+    monkeypatch.setattr(
+        "reviewer.config.onboarding.detect_repository",
+        lambda *_args, **_kwargs: pytest.fail("repo detection called"),
+    )
+    monkeypatch.setattr(
+        cli_module,
+        "Settings",
+        lambda *_args, **_kwargs: pytest.fail("repo settings constructed"),
+    )
+
+    result = CliRunner().invoke(cli, ["init", "--scope", "global", "--yes"])
+
+    assert result.exit_code == 0, result.output
+    assert env.is_file()
+    assert not config_root.exists()
+
+
+def test_init_scope_repo_does_not_read_or_rewrite_global_env(monkeypatch, tmp_path):
+    env, config_root = _isolate(monkeypatch, tmp_path)
+    env.parent.mkdir(parents=True)
+    env.write_text("SENTINEL=unchanged\n", encoding="utf-8")
+    monkeypatch.setattr(
+        "reviewer.install.read_env",
+        lambda _path: pytest.fail("global env read"),
+    )
+    monkeypatch.setattr(
+        "reviewer.config.onboarding.detect_repository",
+        lambda *_args, **_kwargs: _detection(tmp_path),
+    )
+    real_settings = cli_module.Settings
+    settings_calls: list[dict[str, object]] = []
+
+    def settings_factory(**kwargs):
+        settings_calls.append(kwargs)
+        return real_settings(**kwargs)
+
+    monkeypatch.setattr(cli_module, "Settings", settings_factory)
+
+    result = CliRunner().invoke(cli, ["init", "--scope", "repo", "--yes"])
+
+    assert result.exit_code == 0, result.output
+    assert settings_calls == [{"_env_file": None}]
+    assert env.read_text(encoding="utf-8") == "SENTINEL=unchanged\n"
+    assert _repo_path(config_root).is_file()
+
+
+def test_init_scope_repo_keeps_second_repository_isolated(monkeypatch, tmp_path):
+    env, config_root = _isolate(monkeypatch, tmp_path)
+    env.parent.mkdir(parents=True)
+    env.write_text("SENTINEL=unchanged\n", encoding="utf-8")
+
+    def detect(_path, repo_override, *, settings):
+        del settings
+        primary = "main" if repo_override == "one/service" else "release"
+        return _detection(
+            tmp_path,
+            repo_override,
+            primary=primary,
+            repo_source="cli",
+        )
+
+    monkeypatch.setattr("reviewer.config.onboarding.detect_repository", detect)
+    runner = CliRunner()
+
+    first = runner.invoke(
+        cli,
+        ["init", "--scope", "repo", "--repo", "one/service", "--yes"],
+    )
+    first_path = _repo_path(config_root, "one/service")
+    first_bytes = first_path.read_bytes() if first_path.exists() else b""
+    second = runner.invoke(
+        cli,
+        ["init", "--scope", "repo", "--repo", "two/service", "--yes"],
+    )
+
+    assert first.exit_code == 0, first.output
+    assert second.exit_code == 0, second.output
+    assert first_path.read_bytes() == first_bytes
+    assert _repo_path(config_root, "two/service").is_file()
+    assert env.read_text(encoding="utf-8") == "SENTINEL=unchanged\n"
+
+
+def test_init_default_all_previews_global_and_repo_targets(monkeypatch, tmp_path):
+    env, config_root = _isolate(monkeypatch, tmp_path)
+    monkeypatch.setattr(
+        "reviewer.config.onboarding.detect_repository",
+        lambda path, *_args, **_kwargs: _detection(tmp_path)
+        if path == "."
+        else pytest.fail("--path leaked into repo stage"),
+    )
+
+    result = CliRunner().invoke(
+        cli,
+        ["init", "--path", str(env), "--yes"],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert "# reviewer init preview" in result.output
+    assert f"file: {env}" in result.output
+    assert f"file: {_repo_path(config_root)}" in result.output
+    assert "repo: o/r (git:origin)" in result.output
+    assert "primary: dev (git:origin/HEAD)" in result.output
+
+
+def test_init_dry_run_previews_both_targets_without_prompt_write_or_network(
+    monkeypatch,
+    tmp_path,
+):
+    env, config_root = _isolate(monkeypatch, tmp_path)
+    monkeypatch.setattr(
+        "reviewer.config.onboarding.detect_repository",
+        lambda *_args, **_kwargs: _detection(tmp_path),
+    )
+    monkeypatch.setattr(
+        "reviewer.config.onboarding.apply_repository_config",
+        lambda _plan: pytest.fail("repo write called"),
+    )
+    _forbid_noninteractive_side_effects(monkeypatch)
+
+    result = CliRunner().invoke(cli, ["init", "--dry-run"])
+
+    assert result.exit_code == 0, result.output
+    assert f"file: {env}" in result.output
+    assert f"file: {_repo_path(config_root)}" in result.output
+    assert "action: create" in result.output
+    assert not env.exists()
+    assert not env.parent.exists()
+    assert not config_root.parent.exists()
+
+
+def test_init_yes_writes_after_preview_without_prompt_provider_check_or_network(
+    monkeypatch,
+    tmp_path,
+):
+    env, config_root = _isolate(monkeypatch, tmp_path)
+    monkeypatch.setattr(
+        "reviewer.config.onboarding.detect_repository",
+        lambda *_args, **_kwargs: _detection(tmp_path),
+    )
+    _forbid_noninteractive_side_effects(monkeypatch)
+
+    result = CliRunner().invoke(cli, ["init", "--yes"])
+
+    assert result.exit_code == 0, result.output
+    assert result.output.index("# reviewer init preview") < result.output.index("Записан")
+    assert env.is_file()
+    assert _repo_path(config_root).is_file()
+
+
+def test_init_preview_redacts_removed_and_unknown_secrets(monkeypatch, tmp_path):
+    env, _config_root = _isolate(monkeypatch, tmp_path)
+    env.parent.mkdir(parents=True)
+    env.write_text(
+        "WEB_ADMIN_PASSWORD=legacy-admin-secret\n"
+        "TASK_BOARD_MCP=legacy-board-name\n"
+        "CUSTOM_TOKEN=unknown-token-secret\n"
+        "DATABASE_URL=postgresql://user:url-secret@db.example/reviewer\n",
+        encoding="utf-8",
+    )
+
+    result = CliRunner().invoke(
+        cli,
+        ["init", "--scope", "global", "--dry-run"],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert "WEB_ADMIN_PASSWORD=" in result.output
+    assert "TASK_BOARD_MCP=legacy-board-name" in result.output
+    assert "CUSTOM_TOKEN=" in result.output
+    assert "DATABASE_URL=" in result.output
+    for secret in ("legacy-admin-secret", "unknown-token-secret", "url-secret"):
+        assert secret not in result.output
+
+
+def test_init_interactive_retries_owner_name_for_unrecognized_remote(monkeypatch, tmp_path):
+    _env, config_root = _isolate(monkeypatch, tmp_path)
+    calls: list[str | None] = []
+
+    def detect(_path, repo_override, *, settings):
+        del settings
+        calls.append(repo_override)
+        if repo_override is None:
+            return None
+        return _detection(tmp_path, repo_override, repo_source="cli")
+
+    answers = iter(["o/r", "dev", "dev"])
+    monkeypatch.setattr("reviewer.config.onboarding.detect_repository", detect)
+    monkeypatch.setattr(click, "prompt", lambda *_args, **_kwargs: next(answers))
+    monkeypatch.setattr(click, "confirm", lambda *_args, **_kwargs: True)
+
+    result = CliRunner().invoke(cli, ["init", "--scope", "repo"])
+
+    assert result.exit_code == 0, result.output
+    assert calls == [None, "o/r"]
+    assert "repo: o/r (cli)" in result.output
+    assert _repo_path(config_root).is_file()
+
+
+def test_init_interactive_can_correct_detected_branches(monkeypatch, tmp_path):
+    _env, config_root = _isolate(monkeypatch, tmp_path)
+    answers = iter(["release", "release,main"])
+    confirms: list[str] = []
+    monkeypatch.setattr(
+        "reviewer.config.onboarding.detect_repository",
+        lambda *_args, **_kwargs: _detection(tmp_path),
+    )
+    monkeypatch.setattr(click, "prompt", lambda *_args, **_kwargs: next(answers))
+    monkeypatch.setattr(
+        click,
+        "confirm",
+        lambda prompt, **_kwargs: confirms.append(prompt) or True,
+    )
+
+    result = CliRunner().invoke(cli, ["init", "--scope", "repo"])
+
+    assert result.exit_code == 0, result.output
+    assert len(confirms) == 1
+    assert "Обнаружен repo o/r (git:origin)" in result.output
+    data = yaml.safe_load(_repo_path(config_root).read_text(encoding="utf-8"))
+    assert data["repository"] == {
+        "primary_branch": "release",
+        "index_branches": ["release", "main"],
+    }
+
+
+def test_init_interactive_retries_invalid_branch_csv(monkeypatch, tmp_path):
+    _env, config_root = _isolate(monkeypatch, tmp_path)
+    answers = iter(["dev", "dev,dev", "main", "dev,main"])
+    monkeypatch.setattr(
+        "reviewer.config.onboarding.detect_repository",
+        lambda *_args, **_kwargs: _detection(tmp_path),
+    )
+    monkeypatch.setattr(click, "prompt", lambda *_args, **_kwargs: next(answers))
+    monkeypatch.setattr(click, "confirm", lambda *_args, **_kwargs: True)
+
+    result = CliRunner().invoke(cli, ["init", "--scope", "repo"])
+
+    assert result.exit_code == 0, result.output
+    assert result.output.count("Некорректные ветки:") == 2
+    data = yaml.safe_load(_repo_path(config_root).read_text(encoding="utf-8"))
+    assert data["repository"]["index_branches"] == ["dev", "main"]
+
+
+def test_init_existing_repo_block_is_noop_and_skips_branch_prompts(monkeypatch, tmp_path):
+    _env, config_root = _isolate(monkeypatch, tmp_path)
+    path = _repo_path(config_root)
+    path.parent.mkdir(parents=True)
+    original = "repository:\n  primary_branch: trunk\n  index_branches: [trunk, main]\n"
+    path.write_text(original, encoding="utf-8")
+    monkeypatch.setattr(
+        "reviewer.config.onboarding.detect_repository",
+        lambda *_args, **_kwargs: _detection(tmp_path),
+    )
+    monkeypatch.setattr(click, "prompt", lambda *_args, **_kwargs: pytest.fail("branch prompt"))
+    confirmations: list[str] = []
+    monkeypatch.setattr(
+        click,
+        "confirm",
+        lambda prompt, **_kwargs: confirmations.append(prompt) or True,
+    )
+
+    result = CliRunner().invoke(cli, ["init", "--scope", "repo"])
+
+    assert result.exit_code == 0, result.output
+    assert len(confirmations) == 1
+    assert "action: noop" in result.output
+    assert path.read_text(encoding="utf-8") == original
+
+
+@pytest.mark.parametrize("abort", [False, True])
+def test_init_final_rejection_or_abort_happens_before_first_write(
+    monkeypatch,
+    tmp_path,
+    abort,
+):
+    env, config_root = _isolate(monkeypatch, tmp_path)
+    monkeypatch.setattr(
+        "reviewer.config.onboarding.detect_repository",
+        lambda *_args, **_kwargs: _detection(tmp_path),
+    )
+    monkeypatch.setattr(
+        "reviewer.install.prompt_groups",
+        lambda groups, current, yes: {
+            field.key: current.get(field.key, "") or field.default
+            for group in groups
+            for field in group.fields
+        },
+    )
+    monkeypatch.setattr(click, "prompt", lambda _text, default, **_kwargs: default)
+    monkeypatch.setattr(
+        "reviewer.config.onboarding.apply_repository_config",
+        lambda _plan: pytest.fail("repo write called"),
+    )
+    confirmations = iter([False, "final"])
+
+    def confirm(*_args, **_kwargs):
+        answer = next(confirmations)
+        if answer == "final" and abort:
+            raise click.Abort()
+        return False if answer == "final" else answer
+
+    monkeypatch.setattr(click, "confirm", confirm)
+
+    result = CliRunner().invoke(cli, ["init"])
+
+    assert result.exit_code == 0, result.output
+    assert "Отменено" in result.output
+    assert not env.exists()
+    assert not env.parent.exists()
+    assert not config_root.parent.exists()
+
+
+@pytest.mark.parametrize(
+    ("scope", "expected_code", "global_written"),
+    [("all", 0, True), ("repo", 1, False)],
+)
+def test_init_missing_detection_all_skips_but_repo_fails_with_guidance(
+    monkeypatch,
+    tmp_path,
+    scope,
+    expected_code,
+    global_written,
+):
+    env, config_root = _isolate(monkeypatch, tmp_path)
+    monkeypatch.setattr(
+        "reviewer.config.onboarding.detect_repository",
+        lambda *_args, **_kwargs: None,
+    )
+
+    result = CliRunner().invoke(cli, ["init", "--scope", scope, "--yes"])
+
+    assert result.exit_code == expected_code, result.output
+    assert "--repo owner/name" in result.output
+    assert env.exists() is global_written
+    assert not config_root.exists()
+
+
+def test_init_invalid_repo_fails_before_prompt_preview_or_write(monkeypatch, tmp_path):
+    env, config_root = _isolate(monkeypatch, tmp_path)
+    monkeypatch.setattr(click, "prompt", lambda *_args, **_kwargs: pytest.fail("prompt called"))
+    monkeypatch.setattr(click, "confirm", lambda *_args, **_kwargs: pytest.fail("confirm called"))
+
+    result = CliRunner().invoke(cli, ["init", "--repo", "invalid", "--yes"])
+
+    assert result.exit_code != 0
+    assert "owner/name" in result.output
+    assert "# reviewer init preview" not in result.output
+    assert not env.exists()
+    assert not env.parent.exists()
+    assert not config_root.exists()
+
+
+def test_init_repo_prints_effective_branch_source_and_exact_follow_up(monkeypatch, tmp_path):
+    _env, _config_root = _isolate(monkeypatch, tmp_path)
+    monkeypatch.setattr(
+        "reviewer.config.onboarding.detect_repository",
+        lambda *_args, **_kwargs: _detection(tmp_path),
+    )
+    monkeypatch.setattr(
+        cli_module,
+        "_config_context",
+        lambda *_args, **_kwargs: pytest.fail("full config show called"),
+    )
+
+    result = CliRunner().invoke(cli, ["init", "--scope", "repo", "--yes"])
+
+    assert result.exit_code == 0, result.output
+    assert "branches:" in result.output
+    assert "home:repos/o/r.yml" in result.output
+    assert "reviewer config show --repo o/r" in result.output
+
+
+def test_init_repo_write_failure_is_explicit_and_nonzero(monkeypatch, tmp_path):
+    _env, _config_root = _isolate(monkeypatch, tmp_path)
+    monkeypatch.setattr(
+        "reviewer.config.onboarding.detect_repository",
+        lambda *_args, **_kwargs: _detection(tmp_path),
+    )
+    monkeypatch.setattr(
+        "reviewer.config.onboarding.apply_repository_config",
+        lambda _plan: (_ for _ in ()).throw(OSError("secret detail")),
+    )
+
+    result = CliRunner().invoke(cli, ["init", "--scope", "repo", "--yes"])
+
+    assert result.exit_code != 0
+    assert "repos/o/r.yml" in result.output
+    assert "OSError" in result.output
+    assert "secret detail" not in result.output

--- a/tests/install/test_codex_cli.py
+++ b/tests/install/test_codex_cli.py
@@ -85,7 +85,7 @@ def test_init_yes_never_invokes_codex(monkeypatch, tmp_path):
         "reviewer.install_codex.run_codex_install",
         lambda options, **kwargs: (_ for _ in ()).throw(AssertionError("Codex invoked")),
     )
-    result = CliRunner().invoke(cli, ["init", "--yes"])
+    result = CliRunner().invoke(cli, ["init", "--scope", "global", "--yes"])
     assert result.exit_code == 0, result.output
 
 
@@ -97,15 +97,18 @@ def test_interactive_init_uses_the_canonical_codex_flow(monkeypatch, tmp_path):
             field.key: field.default for group in groups for field in group.fields
         },
     )
-    # board setup = no, reviewer check = no, Codex install = yes
-    answers = iter([False, False, True])
+    # board setup = no, write = yes, reviewer check = no, Codex install = yes
+    answers = iter([False, True, False, True])
     monkeypatch.setattr("click.confirm", lambda prompt, default=True: next(answers))
     monkeypatch.setattr("reviewer.entrypoints.cli._shutil.which", lambda name: "/opt/codex")
     monkeypatch.setattr(
         "reviewer.install_codex.run_codex_install",
         lambda options, **kwargs: captured.append(options) or fake_result(tmp_path, options),
     )
-    result = CliRunner().invoke(cli, ["init", "--path", str(tmp_path / ".env")])
+    result = CliRunner().invoke(
+        cli,
+        ["init", "--scope", "global", "--path", str(tmp_path / ".env")],
+    )
     assert result.exit_code == 0, result.output
     assert captured and captured[0].include_mcp is True
 

--- a/tests/install/test_install_wizard.py
+++ b/tests/install/test_install_wizard.py
@@ -164,7 +164,7 @@ def test_init_yes_creates_env_file(tmp_path, monkeypatch):
     dest = tmp_path / ".env"
     monkeypatch.setattr("reviewer.install.default_env_path", lambda: dest)
     runner = CliRunner()
-    result = runner.invoke(cli, ["init", "--yes"])
+    result = runner.invoke(cli, ["init", "--scope", "global", "--yes"])
     assert result.exit_code == 0, result.output
     assert dest.exists()
     content = dest.read_text(encoding="utf-8")
@@ -173,6 +173,7 @@ def test_init_yes_creates_env_file(tmp_path, monkeypatch):
     assert "YOUGILE_API_KEY=" in content
     assert "YOUTRACK_TOKEN=" in content
     assert "JIRA_API_TOKEN=" in content
+    assert all(f"{key}=" not in content for key in REMOVED_STANDARD_KEYS)
 
 
 def test_init_dry_run_is_safe_preview_only(tmp_path, monkeypatch):
@@ -187,7 +188,7 @@ def test_init_dry_run_is_safe_preview_only(tmp_path, monkeypatch):
         "click.prompt",
         lambda *_args, **_kwargs: (_ for _ in ()).throw(AssertionError("prompt called")),
     )
-    result = CliRunner().invoke(cli, ["init", "--dry-run"])
+    result = CliRunner().invoke(cli, ["init", "--scope", "global", "--dry-run"])
 
     assert result.exit_code == 0, result.output
     assert "JIRA_API_TOKEN=" in result.output
@@ -209,7 +210,7 @@ def test_init_dry_run_redacts_legacy_and_unknown_extra_secrets(tmp_path, monkeyp
     )
     monkeypatch.setattr("reviewer.install.default_env_path", lambda: dest)
 
-    result = CliRunner().invoke(cli, ["init", "--dry-run"])
+    result = CliRunner().invoke(cli, ["init", "--scope", "global", "--dry-run"])
 
     assert result.exit_code == 0, result.output
     assert "TASK_BOARD_API_KEY=" in result.output
@@ -293,7 +294,7 @@ def test_init_noninteractive_modes_never_touch_provider_setup_stages(
         lambda *_args, **_kwargs: calls.append("http-construction") or SentinelClient(),
     )
 
-    result = CliRunner().invoke(cli, ["init", mode])
+    result = CliRunner().invoke(cli, ["init", "--scope", "global", mode])
 
     assert result.exit_code == 0, result.output
     assert calls == []
@@ -326,11 +327,11 @@ def test_init_interactive_configures_selected_registry_provider(tmp_path, monkey
             "JIRA_API_TOKEN": "jira-secret",
         },
     )
-    answers = iter([True, False])
+    answers = iter([True, True, False])
     monkeypatch.setattr("click.confirm", lambda *_args, **_kwargs: next(answers))
     monkeypatch.setattr("reviewer.entrypoints.cli._shutil.which", lambda _name: None)
 
-    result = CliRunner().invoke(cli, ["init"])
+    result = CliRunner().invoke(cli, ["init", "--scope", "global"])
 
     assert result.exit_code == 0, result.output
     assert configured == ["jira"]
@@ -358,11 +359,11 @@ def test_init_interactive_common_board_fields_do_not_require_rest_provider(
         return values
 
     monkeypatch.setattr("reviewer.install.prompt_groups", prompt_groups)
-    answers = iter([False, False])
+    answers = iter([False, True, False])
     monkeypatch.setattr("click.confirm", lambda *_args, **_kwargs: next(answers))
     monkeypatch.setattr("reviewer.entrypoints.cli._shutil.which", lambda _name: None)
 
-    result = CliRunner().invoke(cli, ["init"])
+    result = CliRunner().invoke(cli, ["init", "--scope", "global"])
 
     assert result.exit_code == 0, result.output
     assert seen_board_group == [
@@ -377,7 +378,7 @@ def test_init_yes_preserves_existing_secret(tmp_path, monkeypatch):
     dest.write_text("VOYAGE_API_KEY=sk-existing\n", encoding="utf-8")
     monkeypatch.setattr("reviewer.install.default_env_path", lambda: dest)
     runner = CliRunner()
-    result = runner.invoke(cli, ["init", "--yes"])
+    result = runner.invoke(cli, ["init", "--scope", "global", "--yes"])
     assert result.exit_code == 0, result.output
     content = dest.read_text(encoding="utf-8")
     assert "VOYAGE_API_KEY=sk-existing" in content
@@ -397,13 +398,23 @@ def test_render_env_includes_gitlab_fields():
 
 def test_init_yes_preserves_extra_keys(tmp_path, monkeypatch):
     dest = tmp_path / ".env"
-    dest.write_text("VOYAGE_API_KEY=sk-x\nREVIEW_MAX_COMMENTS=42\n", encoding="utf-8")
+    dest.write_text(
+        "VOYAGE_API_KEY=sk-x\n"
+        "REVIEW_MAX_COMMENTS=42\n"
+        "DEFAULT_REPO=owner/legacy\n"
+        "WEB_ADMIN_USER=legacy-admin\n"
+        "TASK_BOARD_MCP=legacy-board\n",
+        encoding="utf-8",
+    )
     monkeypatch.setattr("reviewer.install.default_env_path", lambda: dest)
     runner = CliRunner()
-    result = runner.invoke(cli, ["init", "--yes"])
+    result = runner.invoke(cli, ["init", "--scope", "global", "--yes"])
     assert result.exit_code == 0, result.output
     content = dest.read_text(encoding="utf-8")
     assert "REVIEW_MAX_COMMENTS=42" in content
+    assert "DEFAULT_REPO=owner/legacy" in content
+    assert "WEB_ADMIN_USER=legacy-admin" in content
+    assert "TASK_BOARD_MCP=legacy-board" in content
 
 
 def test_env_template_mirrors_env_example():

--- a/tests/install/test_install_wizard.py
+++ b/tests/install/test_install_wizard.py
@@ -11,6 +11,15 @@ from reviewer.tasks.boards.registry import (
 )
 
 
+REMOVED_STANDARD_KEYS = {
+    "DEFAULT_REPO",
+    "REVIEW_BRANCHES",
+    "WEB_ADMIN_USER",
+    "WEB_ADMIN_PASSWORD",
+    "TASK_BOARD_MCP",
+}
+
+
 def _keys_from_text(text: str) -> set[str]:
     """Имена KEY из текста .env-вида: пропускаем комментарии и пустые строки."""
     keys = set()
@@ -58,9 +67,6 @@ def test_render_env_contains_wizard_keys():
         "NEO4J_URI": "neo4j://localhost:7687",
         "NEO4J_USER": "neo4j",
         "NEO4J_PASSWORD": "reviewerpass",
-        "DEFAULT_REPO": "",
-        "REVIEW_BRANCHES": "main,master",
-        "TASK_BOARD_MCP": "",
         "TASK_BOARD_KEY_PATTERN": "",
         "TASK_BOARD_URL_TEMPLATE": "",
     }
@@ -77,9 +83,6 @@ def test_render_env_extra_keys_preserved():
         "NEO4J_URI": "neo4j://localhost:7687",
         "NEO4J_USER": "neo4j",
         "NEO4J_PASSWORD": "reviewerpass",
-        "DEFAULT_REPO": "",
-        "REVIEW_BRANCHES": "main,master",
-        "TASK_BOARD_MCP": "",
         "TASK_BOARD_KEY_PATTERN": "",
         "TASK_BOARD_URL_TEMPLATE": "",
     }
@@ -106,17 +109,40 @@ def test_prompt_groups_yes_uses_current_values():
 def test_prompt_groups_yes_uses_field_default_when_no_current():
     result = inst.prompt_groups(inst.WIZARD_GROUPS, current={}, yes=True)
     assert result["PG_DSN"] == "postgresql://reviewer:reviewer@localhost:5433/reviewer"
-    assert result["REVIEW_BRANCHES"] == "main,master"
     assert result["VOYAGE_API_KEY"] == ""
+    assert result.keys().isdisjoint(REMOVED_STANDARD_KEYS)
 
 
 def test_prompt_groups_yes_skips_optional_groups():
     # При yes=True опциональные группы сохраняют current или default — не вызывают confirm
-    current = {"TASK_BOARD_MCP": "yougile"}
+    current = {"TASK_BOARD_KEY_PATTERN": "PRI-\\d+"}
     result = inst.prompt_groups(inst.WIZARD_GROUPS, current=current, yes=True)
-    assert result["TASK_BOARD_MCP"] == "yougile"
-    # Остальные поля доски — пустые (default)
-    assert result["TASK_BOARD_KEY_PATTERN"] == ""
+    assert result["TASK_BOARD_KEY_PATTERN"] == "PRI-\\d+"
+    assert result["TASK_BOARD_URL_TEMPLATE"] == ""
+
+
+def test_fresh_wizard_omits_repo_web_and_legacy_board_mcp():
+    keys = {field.key for group in inst.WIZARD_GROUPS for field in group.fields}
+
+    assert keys.isdisjoint(REMOVED_STANDARD_KEYS)
+
+
+def test_runtime_template_keeps_compatibility_keys():
+    assert REMOVED_STANDARD_KEYS <= _keys_from_text(inst.ENV_TEMPLATE)
+
+
+def test_render_env_preserves_removed_existing_keys_as_extra():
+    values = {
+        field.key: field.default
+        for group in inst.WIZARD_GROUPS
+        for field in group.fields
+    }
+    extra = {key: f"existing-{key.lower()}" for key in REMOVED_STANDARD_KEYS}
+
+    rendered = inst.render_env(values, extra)
+
+    for key, value in extra.items():
+        assert f"{key}={value}" in rendered
 
 
 def test_render_env_includes_board_api_key_and_hint():
@@ -328,9 +354,7 @@ def test_init_interactive_common_board_fields_do_not_require_rest_provider(
             if group.title == "Доска задач":
                 seen_board_group.extend(field.key for field in group.fields)
             for field in group.fields:
-                values[field.key] = (
-                    "board-mcp" if field.key == "TASK_BOARD_MCP" else field.default
-                )
+                values[field.key] = field.default
         return values
 
     monkeypatch.setattr("reviewer.install.prompt_groups", prompt_groups)
@@ -342,11 +366,10 @@ def test_init_interactive_common_board_fields_do_not_require_rest_provider(
 
     assert result.exit_code == 0, result.output
     assert seen_board_group == [
-        "TASK_BOARD_MCP",
         "TASK_BOARD_KEY_PATTERN",
         "TASK_BOARD_URL_TEMPLATE",
     ]
-    assert "TASK_BOARD_MCP=board-mcp" in dest.read_text(encoding="utf-8")
+    assert "TASK_BOARD_MCP=" not in dest.read_text(encoding="utf-8")
 
 
 def test_init_yes_preserves_existing_secret(tmp_path, monkeypatch):
@@ -360,18 +383,15 @@ def test_init_yes_preserves_existing_secret(tmp_path, monkeypatch):
     assert "VOYAGE_API_KEY=sk-existing" in content
 
 
-def test_render_env_includes_gitlab_and_web_admin():
+def test_render_env_includes_gitlab_fields():
     values = {f.key: f.default for g in inst.WIZARD_GROUPS for f in g.fields}
     values["GITLAB_TOKEN"] = "glpat-secret"
-    values["WEB_ADMIN_PASSWORD"] = "admin-secret"
     result = inst.render_env(values, extra={})
     # отличительный текст многострочного заголовка GitLab VCS (нет в дефолтном):
     assert "автоопределяется из git remote" in result
     assert "GITLAB_TOKEN=glpat-secret" in result
     assert "GITLAB_URL=https://gitlab.com" in result
     assert "VCS_PROVIDER=github" in result
-    assert "WEB_ADMIN_USER=" in result
-    assert "WEB_ADMIN_PASSWORD=admin-secret" in result
     assert "YOUGILE_API_BASE=" in result
 
 

--- a/tests/launcher/test_catalog.py
+++ b/tests/launcher/test_catalog.py
@@ -42,6 +42,24 @@ def test_status_schema_comes_from_click():
     assert by_name["as_json"].is_flag is True
 
 
+def test_init_schema_exposes_scope_choices_and_repo_option():
+    init = next(item for item in build_catalog(cli) if item.path == ("init",))
+    by_name = {parameter.name: parameter for parameter in init.params}
+
+    assert by_name["scope"].choices == ("all", "global", "repo")
+    assert by_name["scope"].default == "all"
+    assert by_name["repo_opt"].option_strings == ("--repo",)
+
+
+def test_init_metadata_mentions_both_targets_preview_and_repo_scenario():
+    init = next(item for item in build_catalog(cli) if item.path == ("init",))
+
+    assert "global .env" in init.details
+    assert "per-repo branch config" in init.details
+    assert "preview" in init.details
+    assert "Добавление репозитория" in init.scenarios
+
+
 def test_catalog_uses_public_click_labels_and_help_for_options():
     """Форма получает публичные имена и справку, а не Python destination."""
     status = next(item for item in build_catalog(cli) if item.path == ("status",))

--- a/tests/test_gitutil.py
+++ b/tests/test_gitutil.py
@@ -1,6 +1,12 @@
 import subprocess
 
-from reviewer.gitutil import changed_files, commits_behind, file_at_ref, remote_url
+import reviewer.gitutil as gitutil
+from reviewer.gitutil import (
+    changed_files,
+    commits_behind,
+    file_at_ref,
+    remote_url,
+)
 
 
 def _run(*a, cwd): subprocess.run(a, cwd=cwd, check=True, capture_output=True)
@@ -55,3 +61,82 @@ def test_remote_url_returns_origin(tmp_path):
     subprocess.run(["git", "-C", str(repo), "remote", "add", "origin",
                     "https://github.com/owner/name.git"], check=True, capture_output=True)
     assert "github.com" in (remote_url(str(repo)) or "")
+
+
+def test_repo_root_returns_top_level_from_nested_path(tmp_path):
+    repo = tmp_path / "repo"
+    nested = repo / "one" / "two"
+    nested.mkdir(parents=True)
+    _run("git", "init", "-q", cwd=repo)
+
+    assert gitutil.repo_root(str(nested)) == str(repo.resolve())
+
+
+def test_repo_root_returns_none_for_missing_and_non_git_paths(tmp_path):
+    non_git = tmp_path / "non-git"
+    non_git.mkdir()
+
+    assert gitutil.repo_root(str(non_git)) is None
+    assert gitutil.repo_root(str(tmp_path / "missing")) is None
+
+
+def test_repo_root_returns_none_on_os_error(monkeypatch):
+    def raise_os_error(*args):
+        raise OSError("git unavailable")
+
+    monkeypatch.setattr(gitutil, "_git", raise_os_error)
+
+    assert gitutil.repo_root(".") is None
+
+
+def test_remote_default_branch_returns_local_origin_head(tmp_path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _run("git", "init", "-q", cwd=repo)
+    _run(
+        "git",
+        "symbolic-ref",
+        "refs/remotes/origin/HEAD",
+        "refs/remotes/origin/dev",
+        cwd=repo,
+    )
+
+    assert gitutil.remote_default_branch(str(repo)) == "dev"
+
+
+def test_remote_default_branch_returns_none_without_origin_head(tmp_path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _run("git", "init", "-q", cwd=repo)
+
+    assert gitutil.remote_default_branch(str(repo)) is None
+
+
+def test_remote_default_branch_uses_only_local_symbolic_ref(monkeypatch):
+    calls = []
+
+    def fake_git(repo, *args):
+        calls.append((repo, args))
+        return "refs/remotes/origin/dev\n"
+
+    monkeypatch.setattr(gitutil, "_git", fake_git)
+
+    assert gitutil.remote_default_branch("/repo") == "dev"
+    assert calls == [
+        ("/repo", ("symbolic-ref", "--quiet", "refs/remotes/origin/HEAD"))
+    ]
+
+
+def test_remote_default_branch_returns_none_for_invalid_ref(monkeypatch):
+    monkeypatch.setattr(gitutil, "_git", lambda *args: "refs/heads/dev\n")
+
+    assert gitutil.remote_default_branch("/repo") is None
+
+
+def test_remote_default_branch_returns_none_on_os_error(monkeypatch):
+    def raise_os_error(*args):
+        raise OSError("git unavailable")
+
+    monkeypatch.setattr(gitutil, "_git", raise_os_error)
+
+    assert gitutil.remote_default_branch("/repo") is None

--- a/tests/test_install_wizard.py
+++ b/tests/test_install_wizard.py
@@ -8,6 +8,15 @@ from reviewer.tasks.boards.registry import (
 )
 
 
+REMOVED_STANDARD_KEYS = {
+    "DEFAULT_REPO",
+    "REVIEW_BRANCHES",
+    "WEB_ADMIN_USER",
+    "WEB_ADMIN_PASSWORD",
+    "TASK_BOARD_MCP",
+}
+
+
 def _keys():
     return {f.key for g in WIZARD_GROUPS for f in g.fields}
 
@@ -22,11 +31,11 @@ def test_wizard_has_per_type_board_creds():
     assert "JIRA_API_TOKEN" in keys
 
 
-def test_wizard_keeps_board_selectors():
+def test_wizard_keeps_current_board_selectors_only():
     keys = _keys()
     # TASK_BOARD_TYPE устарел и удалён из wizard; TYPE задаётся в .review.yml через task_board.type
-    assert "TASK_BOARD_MCP" in keys
-    assert "TASK_BOARD_KEY_PATTERN" in keys
+    assert {"TASK_BOARD_KEY_PATTERN", "TASK_BOARD_URL_TEMPLATE"} <= keys
+    assert keys.isdisjoint(REMOVED_STANDARD_KEYS)
 
 
 def test_wizard_has_gitlab_vcs_fields():
@@ -34,12 +43,6 @@ def test_wizard_has_gitlab_vcs_fields():
     assert "GITLAB_TOKEN" in keys
     assert "GITLAB_URL" in keys
     assert "VCS_PROVIDER" in keys
-
-
-def test_wizard_has_web_admin_fields():
-    keys = _keys()
-    assert "WEB_ADMIN_USER" in keys
-    assert "WEB_ADMIN_PASSWORD" in keys
 
 
 def test_wizard_has_yougile_api_base():
@@ -83,13 +86,13 @@ def test_board_group_uses_registry_metadata_without_legacy_aliases():
     group = board_env_group(registry)
     fields = {field.key: field for field in group.fields}
 
-    assert {"TASK_BOARD_MCP", "TASK_BOARD_KEY_PATTERN", "TASK_BOARD_URL_TEMPLATE"} <= fields.keys()
+    assert {"TASK_BOARD_KEY_PATTERN", "TASK_BOARD_URL_TEMPLATE"} <= fields.keys()
+    assert "TASK_BOARD_MCP" not in fields
     assert fields["FUTURE_TOKEN"].secret is True
     assert fields["FUTURE_URL"].default == "https://future.example"
     assert fields["TASK_BOARD_SERVICE_TOKEN"].secret is True
     assert "OLD_FUTURE_TOKEN" not in fields
     assert {field.key for field in common_board_env_fields(group)} == {
-        "TASK_BOARD_MCP",
         "TASK_BOARD_KEY_PATTERN",
         "TASK_BOARD_URL_TEMPLATE",
     }
@@ -107,5 +110,5 @@ def test_wizard_field_count_tracks_registry_credentials():
     )
 
     assert sum(len(group.fields) for group in WIZARD_GROUPS) == (
-        non_board_fields + 3 + registry_fields
+        non_board_fields + 2 + registry_fields
     )


### PR DESCRIPTION
## Summary
- разделить `reviewer init` на global/repo/all scopes с offline autodetect repo и primary branch
- добавить единый redacted preview до записи и безопасный per-repo YAML create/append/noop
- убрать repo/web/legacy board MCP поля из стандартного wizard, сохранив runtime compatibility

## Test Plan
- [x] `.venv/bin/pytest -q` (`3550 passed, 117 deselected`)
- [x] `.venv/bin/ruff check .`
- [x] `git diff --check dev...HEAD`

Task: PRI-223, часть B.