### PR TITLE
feat(config): credentials и branch-настройка PRI-223

### DIFF
--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "rag-reviewer",
-  "version": "0.4.2+codex.402aaefd5ade",
+  "version": "0.4.2+codex.c065a9277f74",
   "description": "Agentic PR review: hybrid RAG + code graph via MCP, review skills for Codex",
   "repository": "https://github.com/mimfort/rag_for_git",
   "license": "MIT",

--- a/README.md
+++ b/README.md
@@ -63,9 +63,9 @@ stores run locally; embedding and reranking requests go to Voyage.
    ```
 
    Indexing initializes the `chunks` schema that `reviewer check` queries, so a fresh installation
-   must index before checking. The check currently requires `GITHUB_TOKEN`, even for a GitLab-only
-   setup; validate `GITLAB_TOKEN` with a dry-run `/rag-reviewer:review-pr` against a GitLab MR until
-   that limitation is removed. The status payload should show an indexed SHA and `drift == 0`.
+   must index before checking. The check validates every configured VCS provider; its successful
+   identity check does not prove repository-specific permissions. The status payload should show an
+   indexed SHA and `drift == 0`.
    Full indexing sends code chunks to Voyage and can be slow on its free tier. Without a base
    index, PR review has only the diff and its temporary changed-file index (overlay), and therefore
    thinner repository context.
@@ -307,6 +307,44 @@ Important groups:
 
 Credentials stay server-side. **Credentials are not returned** by board metadata or discovery
 tools and must not be placed in `.review.yml`.
+
+### Configuration ownership
+
+| Location | Owner | Stores | Must not store |
+|---|---|---|---|
+| global `.env` | deployment/operator | secrets, credentials, DSNs, runtime infrastructure and compatibility fallbacks | repository policy |
+| home global YAML | OS account running reviewer | shared non-secret defaults | credentials |
+| home per-repo YAML | OS account running reviewer | `repository.primary_branch`, `repository.index_branches`, operator-owned repo policy | credentials |
+| committed `.review.yml` | repository team | team-visible review policy and non-secret task-board metadata | credentials or `repository` |
+| git remote / CLI | repository/operator | canonical `owner/name` identity and explicit command overrides | persisted secrets |
+| Postgres / Neo4j | reviewer runtime | derived indexes, task/review state and code graph | source-of-truth configuration |
+
+#### Single repository
+
+Run `reviewer init` from the clone, inspect the global `.env` and home per-repo previews, then run
+`reviewer check` and `reviewer config show --repo owner/name`.
+
+#### Second repository
+
+Run `reviewer init --scope repo` from the second clone. It creates or previews only that repository's
+home per-repo YAML and does not rewrite global `.env` or the first repository's config.
+
+#### CI / server
+
+Inject secrets into global `.env` or the process from a secret manager. Use noninteractive init only
+for deterministic preview/write, mount home YAML for the service account, and keep team-owned policy
+in committed `.review.yml`. Pass `--repo owner/name` when no usable git remote is present.
+
+### VCS credentials
+
+| Provider | Environment | Minimum access | Reviewer reads | Reviewer writes | `reviewer check` |
+|---|---|---|---|---|---|
+| GitHub | `GITHUB_TOKEN` | fine-grained PAT: Pull requests: Read and write; Contents: Read | PR metadata, files, comments, contents, compare | review comments/summary and PR body backlink | authenticates `/user` identity |
+| GitLab | `GITLAB_URL`, `GITLAB_TOKEN` | PAT/project token with `api` scope | MR metadata, changes, notes, repository files, compare | discussions/notes and MR description backlink | authenticates `/api/v4/user` identity |
+
+The health check proves URL/token authentication, not every granular repository permission. The
+selected repository permissions are exercised by an actual review. `reviewer init` shows the same
+contract before prompting only for the selected provider's credentials.
 
 ### Repositories and branches
 
@@ -596,13 +634,15 @@ summary и same-generation fragment coverage до удаления сирот и
 backfill пишет вектор только по exact CAS `source_hash + title + summary`, поэтому конкурентная
 перезапись текста не получает устаревший вектор и не увеличивает `embedded`.
 
-### `configure-review` — update `.review.yml`
+### `configure-review` — update layered policy and branches
 
-- **When:** tune ignored paths, retrieval limits, summary clustering, or board metadata.
+- **When:** tune tracked branches, ignored paths, retrieval limits, summary clustering, or board
+  metadata.
 - **Invoke:** `/rag-reviewer:configure-review`.
 - **Needs:** a git repository; MCP and databases are not required for baseline analysis.
 - **Reads/writes:** reads tracked Python structure/history and changes approved YAML fields in either
-  `home:repos/<owner>/<name>.yml` or committed `.review.yml`.
+  `home:repos/<owner>/<name>.yml` or committed `.review.yml`; branch values always go to the home
+  per-repo YAML.
 - **Result:** preserved foreign keys/comments plus exact rebuild guidance.
 
 ## Operations, troubleshooting, and limitations
@@ -679,8 +719,6 @@ errors are reported without preventing the process from starting where fail-soft
 - The base index is branch-scoped and blind to uncommitted working-tree changes.
 - OAuth loopback flows are not supported in headless/SSH integrations; use documented PAT/API-key
   credentials.
-- `reviewer check` currently validates `GITHUB_TOKEN` and the GitHub API even in a GitLab-only
-  deployment; validate `GITLAB_TOKEN` with a dry-run `/rag-reviewer:review-pr` against a GitLab MR.
 - Board work is optional. Missing provider configuration keeps task-aware skills board-less rather
   than blocking code retrieval.
 

--- a/README.ru.md
+++ b/README.ru.md
@@ -63,9 +63,9 @@ inline-комментарии, привязанные к изменённым с
    ```
 
    Индексация создаёт схему `chunks`, которую запрашивает `reviewer check`, поэтому в свежей
-   установке сначала нужен index. Сейчас check требует `GITHUB_TOKEN` даже для GitLab-only
-   конфигурации; до снятия этого ограничения проверяйте `GITLAB_TOKEN` через dry-run
-   `/rag-reviewer:review-pr` для GitLab MR. Status payload должен показать indexed SHA и `drift == 0`.
+   установке сначала нужен index. Check проверяет каждый настроенный VCS provider; успешная проверка
+   identity не подтверждает repository-specific permissions. Status payload должен показать indexed
+   SHA и `drift == 0`.
    Полная индексация отправляет чанки кода в Voyage и может быть медленной на free tier. Без base
    index ревью видит только дифф и временный индекс изменённых файлов (overlay), поэтому получает
    более узкий контекст репозитория.
@@ -310,6 +310,45 @@ New Chat или новую CLI-сессию. В IDE также выполнит�
 
 Credentials остаются на сервере. **Credentials are not returned** board metadata/discovery tools
 и не должны попадать в `.review.yml`.
+
+### Владение конфигурацией
+
+| Location | Owner | Stores | Must not store |
+|---|---|---|---|
+| global `.env` | deployment/operator | secrets, credentials, DSNs, runtime infrastructure и compatibility fallbacks | repository policy |
+| home global YAML | OS account, запускающий reviewer | общие non-secret defaults | credentials |
+| home per-repo YAML | OS account, запускающий reviewer | `repository.primary_branch`, `repository.index_branches`, operator-owned repo policy | credentials |
+| committed `.review.yml` | команда репозитория | team-visible review policy и non-secret task-board metadata | credentials или `repository` |
+| git remote / CLI | репозиторий/operator | canonical `owner/name` identity и явные command overrides | persisted secrets |
+| Postgres / Neo4j | reviewer runtime | derived indexes, task/review state и code graph | source-of-truth configuration |
+
+#### Один репозиторий
+
+Запустите `reviewer init` из клона, проверьте previews для global `.env` и home per-repo, затем
+выполните `reviewer check` и `reviewer config show --repo owner/name`.
+
+#### Второй репозиторий
+
+Запустите `reviewer init --scope repo` из второго клона. Команда создаёт или показывает preview
+только home per-repo YAML этого репозитория и не перезаписывает global `.env` или конфиг первого
+репозитория.
+
+#### CI / server
+
+Передавайте secrets в global `.env` или process из secret manager. Используйте noninteractive init
+только для deterministic preview/write, монтируйте home YAML для service account, а team-owned policy
+храните в committed `.review.yml`. Если подходящего git remote нет, передайте `--repo owner/name`.
+
+### VCS credentials
+
+| Provider | Environment | Minimum access | Reviewer reads | Reviewer writes | `reviewer check` |
+|---|---|---|---|---|---|
+| GitHub | `GITHUB_TOKEN` | fine-grained PAT: Pull requests: Read and write; Contents: Read | PR metadata, files, comments, contents, compare | review comments/summary и PR body backlink | authenticates `/user` identity |
+| GitLab | `GITLAB_URL`, `GITLAB_TOKEN` | PAT/project token with `api` scope | MR metadata, changes, notes, repository files, compare | discussions/notes и MR description backlink | authenticates `/api/v4/user` identity |
+
+Health check подтверждает URL/token authentication, но не каждое granular repository permission.
+Выбранные repository permissions проверяются реальным review. `reviewer init` показывает тот же
+contract перед запросом credentials только выбранного provider.
 
 ### Репозитории и ветки
 
@@ -583,13 +622,15 @@ threshold, graph backend и retrieval ceilings меняют cost/recall; сна�
 - **Чтение/запись:** читает symbols кластеров и пишет grounded summaries в summary store.
 - **Результат:** fresh/pruned summaries с отчётом deferred и orphans.
 
-### `configure-review` — обновить `.review.yml`
+### `configure-review` — обновить layered policy и ветки
 
-- **Когда:** настроить ignored paths, retrieval limits, summary clustering или board metadata.
+- **Когда:** настроить tracked branches, ignored paths, retrieval limits, summary clustering или
+  board metadata.
 - **Вызов:** `/rag-reviewer:configure-review`.
 - **Нужно:** git repo; MCP и databases не нужны для baseline analysis.
 - **Чтение/запись:** читает tracked Python structure/history и меняет одобренные YAML fields либо в
-  `home:repos/<owner>/<name>.yml`, либо в committed `.review.yml`.
+  `home:repos/<owner>/<name>.yml`, либо в committed `.review.yml`; значения веток всегда пишет в home
+  per-repo YAML.
 - **Результат:** сохранённые посторонние keys/comments и точная rebuild guidance.
 
 ## Эксплуатация, диагностика и ограничения
@@ -666,8 +707,6 @@ reviewer serve
 - Base index branch-scoped и не видит незакоммиченные working-tree changes.
 - OAuth loopback не поддерживается в headless/SSH integrations; используйте документированные
   PAT/API-key credentials.
-- Сейчас `reviewer check` проверяет `GITHUB_TOKEN` и GitHub API даже в GitLab-only deployment;
-  проверяйте `GITLAB_TOKEN` через dry-run `/rag-reviewer:review-pr` для GitLab MR.
 - Board опционален. Без provider config task-aware skills продолжают board-less, а code retrieval
   не блокируется.
 

--- a/docs/board-providers.md
+++ b/docs/board-providers.md
@@ -166,7 +166,13 @@ Credentials are server-side environment variables, never values in `.review.yml`
 safe identity, project, permission, and configuration metadata. Pass a non-secret project for
 project-scoped validation, for example `reviewer check --board-project jira=PRI`; repeat
 `--board-project TYPE=PROJECT` for a multi-provider deployment. Without a Jira project, identity
-is still checked, but create/transition permissions are reported as unknown.
+is still checked, but create/edit/transition permissions are reported as unknown.
+
+`reviewer init` asks for credentials only after a selected provider is known. Registry setup
+metadata is complete and structured: every registered provider declares minimum permissions,
+read operations, write operations, validation semantics, and an official setup URL. The installer
+shows that contract before the first secret prompt. `reviewer check` repeats provider validation
+without returning credentials.
 
 ## YouGile
 
@@ -180,6 +186,10 @@ OpenID Connect in self-hosted YouGile is for user sign-in, not an authorization 
 `allowOnlyOpenId` is enabled, provide an API key created by a separate
 API-capable account with the minimum required permissions; the acquisition flow must not try to
 exchange an OIDC session for a REST credential.
+
+An admin role is not required by reviewer itself. The API-capable account must be able to access the
+selected company and perform the listed task operations. With `allowOnlyOpenId`, use a ready key from
+such an account because the password acquisition endpoint is disabled.
 
 ## YouTrack
 

--- a/docs/superpowers/briefs/2026-08-07-PRI-223-redesign-reviewer-init.md
+++ b/docs/superpowers/briefs/2026-08-07-PRI-223-redesign-reviewer-init.md
@@ -1,56 +1,56 @@
-# Brief — PRI-223 Часть B: передел мастера reviewer init
+# Brief — PRI-223 Части C и D: credentials и configure-review
 https://ru.yougile.com/team/686c049c8af8/#PRI-223
 
 ## Task
 - Данные получены из reviewer store после sync; нормализованный ключ `ID-277`, алиас `PRI-223`.
-- Реализовать только часть B: разделить `reviewer init` на глобальный runtime/credentials шаг и repo-onboarding с autodetect remote/primary branch.
-- Убрать из стандартного мастера вопросы multirepo, `DEFAULT_REPO`, `REVIEW_BRANCHES`, `WEB_ADMIN_*` и legacy `TASK_BOARD_MCP`, сохранив runtime-поддержку старых env.
-- Перед записью показать файлы, несекретные значения и provenance; после записи показать effective config.
-- Критерии: fresh init без лишних вопросов; owner/name и primary branch видны до записи; второй repo изолирован; `--yes`/`--dry-run` без prompt/network; повторный init сохраняет advanced-настройки.
+- Реализовать только C: после выбора VCS/board provider спрашивать только его credentials и показывать получение токена, минимальные права, read/write-операции и проверку.
+- Не дублировать готовый YouGile `companies → API key` flow; довести его UX про manual fallback, `allowOnlyOpenId` и отсутствие обязательных admin-прав.
+- Реализовать D: `configure-review` определяет repo, спрашивает primary/index branches и безопасно обновляет home per-repo YAML, сохраняя остальные ключи и комментарии.
+- Зафиксировать модель владения настройками и сценарии single-repo/multi-repo/CI в синхронных README; добавить focused tests C/D.
 
 ## Related work
-- PRI-223 / PR #159 — часть A уже ввела effective per-repo branch config; часть B должна потреблять её публичные API, не реализовывать ветки заново.
-- PRI-221 / PR #150 — переиспользовать `home_repo_path`, строгую проверку home YAML и provenance вместо отдельного формата repo-конфига.
-- PRI-122 / PR #21 — исходный мастер onboarding задаёт baseline поведения, которое теперь разделяется на global и repo шаги.
-- PRI-169 — предыдущая правка полей `reviewer init`; её тестовые паттерны подходят для удаления полей без потери существующих advanced env.
-- (dropped 4: launcher, GitLab provider, Codex install и status используют иные механизмы и не задают реализацию части B.)
+- PRI-215 / PR #127 — переиспользовать generic registry, credential schema, setup metadata и существующий YouGile acquisition flow; не добавлять provider-specific ветвления в CLI.
+- PRI-221 / PR #150 — переиспользовать home per-repo path, credential rejection, provenance и двуязычный шаблон документации layered config.
+- PRI-205 / PR #92 — следовать server-side discovery/pick-list паттерну `configure-review`, сохраняя fail-open fallback и отсутствие credentials в YAML.
+- PRI-133 — сохранить VCS-контракт: GitHub/GitLab credentials принадлежат env, а provider определяется repo/remote или явным выбором.
+- PRI-169 — текущие init/provider tests являются регрессионным baseline при сужении VCS credential prompts.
+- (dropped 3: task sync scoping, retention filter и сама PRI-223 не добавляют отдельного механизма для C/D.)
 
 ## Subsystems
-- `reviewer/entrypoints` — команда `init`, orchestration prompt/preview/write/check и финальный effective-config output.
-- `reviewer` — `install.py` описывает env-поля, группы, prompting и безопасный render.
-- `reviewer/config` — home per-repo path, branch resolution и provenance, уже созданные частями PRI-221/A.
-- `tests/install` — контракт интерактивного, `--yes` и `--dry-run` режимов.
-- `tests/config` — изоляция per-repo YAML и проверка источников effective config.
+- `reviewer` — `install.py` задаёт стандартные env-группы, credential prompts и redacted preview.
+- `reviewer/entrypoints` — `reviewer init` выбирает provider, собирает global/repo plans и оркестрирует проверку.
+- `reviewer/tasks` — registry-driven board credential/setup metadata и YouGile acquisition/validation.
+- `reviewer/config` — effective branches, provenance и безопасная публикация home per-repo YAML.
+- `reviewer/vcs` — GitHub/GitLab операции, по которым формулируются минимальные scopes.
+- `tests/config` — изоляция repo, validation и сохранение home YAML.
+- `tests/entrypoints` — интерактивный/noninteractive контракт init и redaction.
+- `tests/docs` — паритет README и целостность документированных команд/skills.
 
 ## Relevant code
-- `reviewer/entrypoints/cli.py:828` — `init` сейчас смешивает env prompt, board setup, preview, запись и post-check; здесь разделить global и repo stages.
-- `reviewer/entrypoints/cli.py:844` — текущий поток читает один `.env`, а `--dry-run` рендерит только его; preview должен охватить оба назначения без записи и сети.
-- `reviewer/entrypoints/cli.py:924` — unknown/advanced env сохраняются через `extra`; этот инвариант нужен повторному init.
-- `reviewer/install.py:319` — `prompt_groups(..., yes)` уже гарантирует current-or-default без prompt в CI; repo stage должен иметь такой же явный noninteractive контракт.
-- `reviewer/install.py:105` — `EnvField`/`EnvGroup` моделируют только `.env`; repo YAML не следует встраивать в эти типы как псевдо-env.
-- `reviewer/gitutil.py:42` — `remote_url` уже fail-soft читает `origin`; использовать его для autodetect, не дублировать subprocess parsing.
-- `reviewer/services/repo_id.py:24` — `derive_repo_from_remote` уже нормализует remote в repo id; отсутствие/неподдерживаемый remote должно давать управляемый fallback.
-- `reviewer/services/branch.py:28` — `current_git_branch` даёт локальную ветку fail-soft; primary branch выбирать через effective API части A с autodetect fallback, не через committed `.review.yml` bootstrap.
-- `reviewer/config/layers.py:69` — `home_repo_path(repo)` задаёт канонический per-repo destination.
-- `reviewer/config/layers.py:257` — `resolve_policy_data` и `ResolutionMeta` задают существующий паттерн sources/shadowing для effective preview.
-- `reviewer/entrypoints/cli.py:136` — `config show` уже выводит effective config/provenance; переиспользовать после onboarding вместо второго отчётного формата.
-- (dropped 10: runtime consumers веток, MCP, board provider internals и launcher не меняются в части B.)
+- `reviewer/entrypoints/cli.py:1126` — расширить текущий `init`, сохранив scope/preview/no-network контракты части B.
+- `reviewer/entrypoints/cli.py:1173` — board credentials уже prompt-ятся только после выбора provider; использовать этот registry-driven паттерн для VCS, не регрессить board flow.
+- `reviewer/tasks/boards/registry.py:104` — `BoardProviderRegistry` централизует credential fields и проверяет полноту setup metadata; это эталон provider-scoped модели.
+- `reviewer/tasks/boards/yougile.py:90` — YouGile spec уже связывает credential fields, help text и acquisition hook; изменения должны быть уточнением метаданных/UX.
+- `reviewer/tasks/boards/setup.py:154` — готовый `companies → /auth/keys` flow с manual fallback и очисткой password; не переписывать.
+- `reviewer/config/settings.py:82` — GitHub/GitLab credentials и runtime fallbacks остаются env-only и обратно совместимыми.
+- `reviewer/config/onboarding.py:101` — текущий repo plan намеренно делает noop для существующего `repository`; `configure-review` нужен отдельный безопасный update существующего блока.
+- `reviewer/config/branches.py:159` — `render_repository_block` задаёт canonical YAML представление веток; переиспользовать validation/format без полной перезаписи файла.
+- `reviewer/config/branches.py:664` — `resolve_repo_branches` возвращает effective primary/index/source для показа выбранного слоя до записи.
+- (dropped 20: runtime board consumers, task ETL, MCP review path и общие Settings-поля не меняют C/D.)
 
 ## Test exemplars
-- `tests/install/test_install_wizard.py:152` — `--dry-run` не создаёт каталог/файл, не prompt-ит и скрывает секреты.
-- `tests/install/test_install_wizard.py:173` — preview редактирует legacy и неизвестные secret-like extras без утечки значений.
-- `tests/install/test_install_wizard.py:200` — `--dry-run` и `--yes` не запускают provider acquisition, validation, browser или network setup.
-- `tests/install/test_install_wizard.py:164` — `--yes` сохраняет unknown advanced env keys.
-- `tests/config/test_layers.py:135` — существующий home-файл остаётся неизменным при конфликте; repo-onboarding нужен неразрушающий update с отдельными тестами двух repo.
-- (dropped 5: provider-specific setup и integration migration tests относятся к частям C/A.)
+- `tests/install/test_install_wizard.py:303` — существующий тест доказывает выбор одного board provider и запись только его credentials; расширить аналогичным VCS-контрактом.
+- (dropped 14: broad test retrieval вернул production/нерелевантные chunks; два focused graph/test запроса завершились timeout.)
 
 ## Constraints / open questions
-- [existing_artifacts] `docs/superpowers/specs/2026-08-07-PRI-223-per-repo-branch-config-design.md` и `docs/superpowers/plans/2026-08-07-PRI-223-per-repo-branch-config.md` описывают часть A, не дизайн части B.
-- Граница части B жёсткая: provider-scoped credentials/minimal permissions остаются частью C; configure-review и двуязычная документация остаются частью D.
-- `criteria=[]` в store, но описание содержит полный раздел «Критерии приёмки»; для B применяются критерии 1, 2, 3, 10 и 11.
-- Branch bootstrap не должен читать committed `.review.yml` до выбора branch; источник только git/CLI/home per-repo/global/env fallback части A.
-- `--yes` и `--dry-run` не должны выполнять интерактивные или сетевые операции; preview никогда не показывает секреты.
-- PR #159 проверен через GitHub и присутствует в обновлённом `dev` (`4978334`); часть B создаётся поверх него.
-- Сводки подсистем уже были прогреты; в этом запуске они не обновлялись по прямому указанию пользователя.
+- Жёсткий scope: только C и D; A уже смержена PR #159, B уже присутствует на текущем `dev` и имеет отдельные spec/plan.
+- C частично существует: board provider credentials и YouGile acquisition уже scoped; реализация должна закрыть остаток, а не создавать второй setup framework.
+- `criteria=[]` в store, но описание содержит критерии; для C/D применяются 5, 8, 9, 14, 15 и общие security/noninteractive ограничения 7/10.
+- `[existing_artifacts]` brief C/D перезаписывает прежний brief B; specs/plans частей A и B остаются отдельными историческими артефактами.
+- `[existing_artifacts]` `docs/superpowers/specs/2026-08-07-PRI-223-per-repo-branch-config-design.md`, `docs/superpowers/specs/2026-08-08-PRI-223-reviewer-init-onboarding-design.md`.
+- `[existing_artifacts]` `docs/superpowers/plans/2026-08-07-PRI-223-per-repo-branch-config.md`, `docs/superpowers/plans/2026-08-08-PRI-223-reviewer-init-onboarding.md`.
+- Markdown skill/README не индексируются как Python snippets; перед дизайном их нужно прочитать локально, сохранив паритет plugin source и установленных projections.
+- Graph/test expansion reviewer завершился timeout; это не блокирует, но blast radius уточнить локальным search перед реализацией.
+- Сводки подсистем уже были построены; в этом запуске они не обновлялись по прямому указанию пользователя.
 
 Собран на: mid tier (session model gpt-5.6-sol), режим: inline

--- a/docs/superpowers/plans/2026-08-08-PRI-223-configure-review-docs.md
+++ b/docs/superpowers/plans/2026-08-08-PRI-223-configure-review-docs.md
@@ -1,0 +1,473 @@
+# PRI-223 Configure Review and Documentation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Teach `configure-review` to edit per-repository branch configuration without clobbering YAML and document the complete configuration ownership model and deployment scenarios in both READMEs.
+
+**Architecture:** The skill resolves the current repository and effective branch source with existing offline/runtime commands, then applies a line-oriented patch only to the home per-repo `repository` block after one combined preview/confirmation. Documentation pairs the ownership model, VCS token contract, and single/multi-repo/CI workflows in English and Russian.
+
+**Tech Stack:** Markdown skill prompts, Git CLI, reviewer CLI, pytest guard tests, Ruff for Python tests.
+
+---
+
+## File Map
+
+- Modify `plugin/skills/configure-review/SKILL.md`: branch resolution/edit/verification workflow.
+- Modify `tests/skills/test_configure_review_skill.py`: deterministic branch safety guards.
+- Modify `README.md` and `README.ru.md`: storage ownership table, VCS matrix, and three scenarios.
+- Modify `docs/board-providers.md`: align board setup wording with structured access metadata.
+- Modify `tests/docs/test_readme_onboarding.py` and `tests/docs/test_board_provider_docs.py`: paired documentation contracts.
+
+## Global Constraints
+
+- `repository` may be written only to home per-repo YAML, never committed `.review.yml`.
+- Preserve top-level keys, unknown repository subkeys, comments, line endings, and surrounding YAML style.
+- Never parse and rewrite the entire target through `yaml.safe_dump`.
+- No credential values may be read, displayed, copied, or written by the skill.
+- No network git command and no automatic index/summary/task rebuild.
+- Keep English/Russian README section order paired.
+
+---
+
+### Task 1: Guard the Branch Configuration Contract
+
+**Files:**
+- Modify: `tests/skills/test_configure_review_skill.py`
+
+- [ ] **Step 1: Add failing branch workflow guards**
+
+```python
+# tests/skills/test_configure_review_skill.py
+def _branch_section() -> str:
+    text = SKILL.read_text(encoding="utf-8")
+    match = re.search(r"## Repository branches.*?(?=\n## )", text, re.DOTALL)
+    assert match
+    return match.group()
+
+
+def test_skill_manages_primary_and_index_branches():
+    section = _branch_section()
+    assert "repository.primary_branch" in section
+    assert "repository.index_branches" in section
+    assert "primary" in section
+    assert "ordered unique" in section
+    assert "must be present in" in section
+
+
+def test_skill_resolves_repo_offline_and_shows_effective_source():
+    section = _branch_section()
+    assert "git rev-parse --show-toplevel" in section
+    assert "git remote get-url origin" in section
+    assert "reviewer config show --repo <owner/name> --json" in section
+    for forbidden in ("git fetch", "git ls-remote", "git remote show"):
+        assert forbidden not in section
+    assert "source" in section
+
+
+def test_skill_writes_branches_only_to_home_per_repo():
+    section = _branch_section()
+    assert "$XDG_CONFIG_HOME/rag-reviewer/repos/<owner>/<name>.yml" in section
+    assert "never write `repository` to committed `.review.yml`" in section
+    assert "even when committed policy is selected" in section
+
+
+def test_skill_preserves_yaml_and_forbids_whole_file_dump():
+    section = _branch_section()
+    for marker in (
+        "line-oriented patch",
+        "top-level keys",
+        "unknown repository subkeys",
+        "comments",
+        "line endings",
+        "surrounding YAML style",
+    ):
+        assert marker in section
+    assert "never serialize the complete file with `yaml.safe_dump`" in section
+
+
+def test_skill_previews_confirms_and_verifies_branch_change():
+    section = _branch_section()
+    assert "old and new" in section
+    assert "final confirmation" in section
+    assert section.count("reviewer config show --repo <owner/name> --json") >= 2
+    assert "exact primary/index/source" in section
+
+
+def test_skill_never_runs_branch_followups():
+    section = _branch_section()
+    assert "rag-reviewer:sync-codebase" in section
+    assert "do not run" in section.lower()
+    assert "rag-reviewer:summarize-subsystems" not in section
+```
+
+- [ ] **Step 2: Run guards and verify RED**
+
+Run: `.venv/bin/pytest tests/skills/test_configure_review_skill.py -q -k "branch or branches or yaml"`
+
+Expected: FAIL because `## Repository branches` does not exist.
+
+---
+
+### Task 2: Implement the `configure-review` Branch Workflow
+
+**Files:**
+- Modify: `plugin/skills/configure-review/SKILL.md:1-58,171-176`
+- Test: `tests/skills/test_configure_review_skill.py`
+
+- [ ] **Step 1: Expand frontmatter and Scope**
+
+Use this frontmatter description:
+
+```yaml
+description: Use when configuring or changing a repository's tracked branches, layered review policy, ignored tracked paths, retrieval limits, summary depth, or non-secret task-board metadata.
+```
+
+Add to Scope, after the policy key list:
+
+```markdown
+Tracked branches are separate from review policy. Manage `repository.primary_branch` and
+`repository.index_branches` only in the home per-repo target. The committed `.review.yml` cannot
+own `repository`, because branch selection must be available before a committed ref can be read.
+```
+
+- [ ] **Step 2: Add the complete branch section before Rebuild guidance**
+
+Insert this exact section:
+
+```markdown
+## Repository branches
+
+Handle branches before policy analysis whenever the user asks to inspect or change tracked
+branches.
+
+1. Resolve the local repository without network calls:
+   - `git rev-parse --show-toplevel` gives the git root;
+   - `git remote get-url origin` gives the canonical SSH/HTTPS remote candidate;
+   - normalize it to lowercase `<owner/name>` with the same SSH/HTTPS forms accepted by reviewer;
+   - if origin is absent or unrecognized, ask for `<owner/name>` explicitly.
+   Never run `git fetch`, `git ls-remote`, or `git remote show`.
+2. Run `reviewer config show --repo <owner/name> --json` and show the effective primary branch,
+   ordered index branches, and source. A policy/VCS diagnostic error does not erase the returned
+   branch section; a malformed home config is a blocking error and must not fall back silently.
+3. Ask for `repository.primary_branch`, then ask for the complete ordered unique
+   `repository.index_branches`. The primary must be present in the index list. Reject empty names,
+   duplicates, and a primary outside the list.
+4. The destination is always
+   `$XDG_CONFIG_HOME/rag-reviewer/repos/<owner>/<name>.yml` (or the equivalent
+   `~/.config/rag-reviewer/...` path when XDG is unset). Never write `repository` to committed
+   `.review.yml`, even when committed policy is selected for other keys. If policy and branches
+   change together, treat them as two targets in one preview.
+5. Read the destination without following symlinks. Stop on malformed, non-regular, symlinked, or
+   credential-like YAML. Build a line-oriented patch: if `repository` is absent, append the
+   canonical block; if it exists, replace only `primary_branch` and `index_branches`. Preserve all
+   top-level keys, unknown repository subkeys, comments, line endings, and surrounding YAML style.
+   Never serialize the complete file with `yaml.safe_dump`.
+6. Show the destination, source, old and new branch values, and the exact patch. Request one final
+   confirmation before any branch or policy write. A rejection leaves every target unchanged.
+7. After writing, run `reviewer config show --repo <owner/name> --json` again and require the exact
+   primary/index/source expected from the home per-repo layer. Report a mismatch as an error.
+
+If newly added index branches are not indexed, suggest `rag-reviewer:sync-codebase` once per new
+branch, but do not run it. A primary change to an already indexed branch needs no rebuild. Removing
+a branch stops reviewer from selecting it but does not delete its old base index automatically.
+Branch changes never trigger subsystem-summary work.
+```
+
+- [ ] **Step 3: Integrate combined preview/completion wording**
+
+Change Pipeline step 5 and Completion so they explicitly say:
+
+```markdown
+When branch and policy changes share a run, assemble both drafts first, show both paths and diffs,
+and request one final confirmation before either write.
+```
+
+Completion must report old/new branches, selected branch source, changed policy keys, generic board targets/options, and suggested follow-ups.
+
+- [ ] **Step 4: Run all skill guards**
+
+Run: `.venv/bin/pytest tests/skills/test_configure_review_skill.py -q`
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit the skill contract**
+
+```bash
+git add plugin/skills/configure-review/SKILL.md tests/skills/test_configure_review_skill.py
+git commit -m "feat(skill): configure-review настраивает ветки репозитория"
+```
+
+---
+
+### Task 3: Documentation Ownership and Scenario Guards
+
+**Files:**
+- Modify: `tests/docs/test_readme_onboarding.py`
+
+- [ ] **Step 1: Replace the obsolete GitLab limitation test**
+
+Delete `test_gitlab_only_check_limitation_is_explicit` and add:
+
+```python
+def test_readmes_document_configuration_ownership_and_scenarios():
+    cases = (
+        ("README.md", "### Configuration ownership", ("Single repository", "Second repository", "CI / server")),
+        ("README.ru.md", "### Владение конфигурацией", ("Один репозиторий", "Второй репозиторий", "CI / server")),
+    )
+    for filename, heading, scenarios in cases:
+        section = _section(_read(filename), heading)
+        for marker in (
+            "global `.env`",
+            "home global YAML",
+            "home per-repo YAML",
+            "committed `.review.yml`",
+            "git remote / CLI",
+            "Postgres / Neo4j",
+            "reviewer init --scope repo",
+            "reviewer config show --repo",
+        ):
+            assert marker in section, (filename, marker)
+        for scenario in scenarios:
+            assert scenario in section, (filename, scenario)
+
+
+def test_readmes_document_vcs_token_matrix_and_check_semantics():
+    for filename, heading in (
+        ("README.md", "### VCS credentials"),
+        ("README.ru.md", "### VCS credentials"),
+    ):
+        section = _section(_read(filename), heading)
+        for marker in (
+            "`GITHUB_TOKEN`",
+            "Pull requests: Read and write",
+            "Contents: Read",
+            "`GITLAB_TOKEN`",
+            "`api` scope",
+            "`/user`",
+            "`/api/v4/user`",
+            "identity",
+            "repository permissions",
+        ):
+            assert marker in section, (filename, marker)
+        assert "GitLab-only" not in _read(filename)
+        assert "dry-run `/rag-reviewer:review-pr`" not in _read(filename)
+```
+
+- [ ] **Step 2: Run docs guards and verify RED**
+
+Run: `.venv/bin/pytest tests/docs/test_readme_onboarding.py -q -k "ownership or vcs_token"`
+
+Expected: FAIL because the new sections do not exist and the old workaround remains.
+
+---
+
+### Task 4: Write Paired README Sections
+
+**Files:**
+- Modify: `README.md:294-390,599-606,662-683`
+- Modify: `README.ru.md:297-393,586-593,649-670`
+- Test: `tests/docs/test_readme_onboarding.py`
+
+- [ ] **Step 1: Add `### Configuration ownership` to README.md**
+
+Insert after `### Required services and credentials`:
+
+```markdown
+### Configuration ownership
+
+| Location | Owner | Stores | Must not store |
+|---|---|---|---|
+| global `.env` | deployment/operator | secrets, credentials, DSNs, runtime infrastructure and compatibility fallbacks | repository policy |
+| home global YAML | OS account running reviewer | shared non-secret defaults | credentials |
+| home per-repo YAML | OS account running reviewer | `repository.primary_branch`, `repository.index_branches`, operator-owned repo policy | credentials |
+| committed `.review.yml` | repository team | team-visible review policy and non-secret task-board metadata | credentials or `repository` |
+| git remote / CLI | repository/operator | canonical `owner/name` identity and explicit command overrides | persisted secrets |
+| Postgres / Neo4j | reviewer runtime | derived indexes, task/review state and code graph | source-of-truth configuration |
+
+#### Single repository
+
+Run `reviewer init` from the clone, inspect the global `.env` and home per-repo previews, then run
+`reviewer check` and `reviewer config show --repo owner/name`.
+
+#### Second repository
+
+Run `reviewer init --scope repo` from the second clone. It creates or previews only that repository's
+home per-repo YAML and does not rewrite global `.env` or the first repository's config.
+
+#### CI / server
+
+Inject secrets into global `.env` or the process from a secret manager. Use noninteractive init only
+for deterministic preview/write, mount home YAML for the service account, and keep team-owned policy
+in committed `.review.yml`. Pass `--repo owner/name` when no usable git remote is present.
+```
+
+- [ ] **Step 2: Add the Russian paired section**
+
+Use the same table row order and commands under `### Владение конфигурацией`, with scenario headings
+`#### Один репозиторий`, `#### Второй репозиторий`, and `#### CI / server`. Translate prose, but keep
+the literal storage labels tested above (`global `.env``, `home global YAML`, `home per-repo YAML`,
+`committed `.review.yml``, `git remote / CLI`, `Postgres / Neo4j`).
+
+- [ ] **Step 3: Add paired `### VCS credentials` sections**
+
+Use this exact matrix in both READMEs (translate prose around it, not env/scope/API literals):
+
+```markdown
+### VCS credentials
+
+| Provider | Environment | Minimum access | Reviewer reads | Reviewer writes | `reviewer check` |
+|---|---|---|---|---|---|
+| GitHub | `GITHUB_TOKEN` | fine-grained PAT: Pull requests: Read and write; Contents: Read | PR metadata, files, comments, contents, compare | review comments/summary and PR body backlink | authenticates `/user` identity |
+| GitLab | `GITLAB_URL`, `GITLAB_TOKEN` | PAT/project token with `api` scope | MR metadata, changes, notes, repository files, compare | discussions/notes and MR description backlink | authenticates `/api/v4/user` identity |
+
+The health check proves URL/token authentication, not every granular repository permission. The
+selected repository permissions are exercised by an actual review. `reviewer init` shows the same
+contract before prompting only the selected provider's credentials.
+```
+
+- [ ] **Step 4: Update skill/security/limitations prose**
+
+- Rename the skill heading to `configure-review — update layered policy and branches` in English and
+  its Russian equivalent.
+- Add `tracked branches` to its When/Когда line.
+- State that branch values always go to home per-repo YAML.
+- Remove both GitLab-only workaround paragraphs from Try/Known limitations.
+- Keep the security statement that credentials are env-only.
+
+- [ ] **Step 5: Run README tests**
+
+Run: `.venv/bin/pytest tests/docs/test_readme_onboarding.py -q`
+
+Expected: PASS, including paired section order.
+
+- [ ] **Step 6: Commit README updates**
+
+```bash
+git add README.md README.ru.md tests/docs/test_readme_onboarding.py
+git commit -m "docs(config): описывает владение настройками и VCS credentials"
+```
+
+---
+
+### Task 5: Align Board Provider Reference
+
+**Files:**
+- Modify: `docs/board-providers.md:118-223`
+- Modify: `tests/docs/test_board_provider_docs.py`
+
+- [ ] **Step 1: Add failing access-contract docs guards**
+
+```python
+# tests/docs/test_board_provider_docs.py
+def test_board_docs_explain_structured_setup_contract():
+    text = _read("docs/board-providers.md")
+    section = text.split("## Configuration", 1)[1].split("## YouGile", 1)[0]
+    for marker in (
+        "minimum permissions",
+        "read operations",
+        "write operations",
+        "validation",
+        "selected provider",
+        "reviewer init",
+    ):
+        assert marker in section
+
+
+def test_yougile_docs_do_not_require_admin_role():
+    text = _read("docs/board-providers.md")
+    section = text.split("## YouGile", 1)[1].split("## YouTrack", 1)[0]
+    assert "admin role is not required" in section
+    assert "API-capable account" in section
+    assert "allowOnlyOpenId" in section
+```
+
+- [ ] **Step 2: Run guards and verify RED**
+
+Run: `.venv/bin/pytest tests/docs/test_board_provider_docs.py -q -k "structured_setup or admin_role"`
+
+Expected: FAIL because current prose does not use the exact structured-contract wording.
+
+- [ ] **Step 3: Add authoritative setup contract prose**
+
+After the credentials paragraph in `## Configuration`, add:
+
+```markdown
+`reviewer init` asks for credentials only after a selected provider is known. Registry setup
+metadata is complete and structured: every registered provider declares minimum permissions,
+read operations, write operations, validation semantics, and an official setup URL. The installer
+shows that contract before the first secret prompt. `reviewer check` repeats provider validation
+without returning credentials.
+```
+
+In YouGile, add:
+
+```markdown
+An admin role is not required by reviewer itself. The API-capable account must be able to access the
+selected company and perform the listed task operations. With `allowOnlyOpenId`, use a ready key from
+such an account because the password acquisition endpoint is disabled.
+```
+
+- [ ] **Step 4: Run board docs tests**
+
+Run: `.venv/bin/pytest tests/docs/test_board_provider_docs.py -q`
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit board docs**
+
+```bash
+git add docs/board-providers.md tests/docs/test_board_provider_docs.py
+git commit -m "docs(boards): фиксирует setup access contract"
+```
+
+---
+
+### Task 6: Part D Verification
+
+**Files:**
+- Modify only if verification exposes scoped defects.
+
+- [ ] **Step 1: Run focused skill/docs suite**
+
+Run:
+
+```bash
+.venv/bin/pytest \
+  tests/skills/test_configure_review_skill.py \
+  tests/docs/test_readme_onboarding.py \
+  tests/docs/test_board_provider_docs.py -q
+```
+
+Expected: all pass.
+
+- [ ] **Step 2: Run all skill and docs guards**
+
+Run: `.venv/bin/pytest tests/skills tests/docs -q`
+
+Expected: all pass.
+
+- [ ] **Step 3: Check formatting and whitespace**
+
+Run: `.venv/bin/ruff check tests/skills/test_configure_review_skill.py tests/docs`
+
+Expected: `All checks passed!`
+
+Run: `git diff --check`
+
+Expected: exit code 0 with no output.
+
+- [ ] **Step 4: Audit the forbidden branch paths**
+
+Run: `git diff dev...HEAD -- plugin/skills/configure-review/SKILL.md README.md README.ru.md docs/board-providers.md`
+
+Expected: the skill writes `repository` only to home per-repo YAML, never runs summaries, and both READMEs contain paired ownership/VCS sections.
+
+- [ ] **Step 5: Commit verification fixes if needed**
+
+Stage only Part D files and commit:
+
+```bash
+git commit -m "fix(config): закрывает регрессии configure-review"
+```
+
+Do not create an empty commit.

--- a/docs/superpowers/plans/2026-08-08-PRI-223-provider-credentials.md
+++ b/docs/superpowers/plans/2026-08-08-PRI-223-provider-credentials.md
@@ -1,0 +1,854 @@
+# PRI-223 Provider Credentials Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make `reviewer init` request credentials only for the selected VCS/board provider, show structured least-privilege guidance, and make `reviewer check` support GitHub-only, GitLab-only, and dual-provider deployments.
+
+**Architecture:** A small provider-access value object carries permissions/read/write/validation metadata. Existing board specs and a compact VCS setup catalog consume it; `reviewer init` filters interactive prompts while retaining the canonical full env render schema. `reviewer check` validates every configured VCS token independently.
+
+**Tech Stack:** Python 3.11+, dataclasses, Click, httpx, pytest, Ruff.
+
+---
+
+## File Map
+
+- Create `reviewer/config/provider_access.py`: immutable access metadata and deterministic renderer.
+- Modify `reviewer/tasks/boards/registry.py`: require access metadata in every board setup spec.
+- Modify all 11 `reviewer/tasks/boards/<provider>.py` specs: declare exact access contract.
+- Modify `reviewer/tasks/boards/setup.py`: render structured access before credential prompts.
+- Modify `reviewer/install.py`: VCS setup catalog, canonical VCS group, scoped prompt helpers.
+- Modify `reviewer/entrypoints/cli.py`: selected-VCS setup and multi-provider VCS health check.
+- Modify focused tests under `tests/config`, `tests/tasks/boards`, `tests/install`, and `tests/entrypoints`.
+
+## Global Constraints
+
+- Preserve every existing env key and runtime fallback; only interactive prompting changes.
+- `--yes` and `--dry-run` perform no prompt, browser, provider validation, or network operation.
+- Existing credentials for an unselected provider survive unchanged and are never printed.
+- YouGile acquisition logic remains one implementation in `setup.py`; do not duplicate it.
+- All setup/validation errors must remain secret-safe.
+- Follow RED → GREEN for every production change.
+
+---
+
+### Task 1: Provider Access Metadata
+
+**Files:**
+- Create: `reviewer/config/provider_access.py`
+- Create: `tests/config/test_provider_access.py`
+- Modify: `reviewer/tasks/boards/registry.py:19-66,189-216`
+- Modify: `tests/tasks/boards/provider_fakes.py:1-70`
+- Modify: `tests/tasks/boards/test_registry.py:90-140,367-400`
+- Modify: `tests/test_install_wizard.py:52-84`
+
+- [ ] **Step 1: Write failing renderer tests**
+
+```python
+# tests/config/test_provider_access.py
+import pytest
+
+from reviewer.config.provider_access import ProviderAccessSpec, render_provider_access
+
+
+def test_render_provider_access_has_stable_complete_order():
+    access = ProviderAccessSpec(
+        minimum_permissions="Issues: Read and write",
+        read_operations=("читать задачи", "читать комментарии"),
+        write_operations=("создавать задачи", "закрывать задачи"),
+        validation="identity и доступ к проекту",
+    )
+
+    text = render_provider_access(
+        label="Example",
+        help_text="Создайте token.",
+        help_url="https://example.test/token",
+        access=access,
+    )
+
+    markers = (
+        "Example",
+        "Создайте token.",
+        "Минимальные права: Issues: Read and write",
+        "Чтение: читать задачи; читать комментарии",
+        "Запись: создавать задачи; закрывать задачи",
+        "Проверка: identity и доступ к проекту",
+        "https://example.test/token",
+    )
+    positions = [text.index(marker) for marker in markers]
+    assert positions == sorted(positions)
+
+
+@pytest.mark.parametrize(
+    "field",
+    ("minimum_permissions", "read_operations", "write_operations", "validation"),
+)
+def test_provider_access_rejects_empty_contract(field):
+    values = {
+        "minimum_permissions": "read/write",
+        "read_operations": ("read",),
+        "write_operations": ("write",),
+        "validation": "identity",
+    }
+    values[field] = () if field.endswith("operations") else ""
+
+    with pytest.raises(ValueError, match=field):
+        ProviderAccessSpec(**values)
+```
+
+- [ ] **Step 2: Run tests and verify RED**
+
+Run: `.venv/bin/pytest tests/config/test_provider_access.py -q`
+
+Expected: collection error because `reviewer.config.provider_access` does not exist.
+
+- [ ] **Step 3: Implement the immutable model and renderer**
+
+```python
+# reviewer/config/provider_access.py
+"""Общие несекретные подсказки по доступу внешнего provider."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class ProviderAccessSpec:
+    """Минимальные права и фактические операции reviewer."""
+
+    minimum_permissions: str
+    read_operations: tuple[str, ...]
+    write_operations: tuple[str, ...]
+    validation: str
+
+    def __post_init__(self) -> None:
+        for name in ("minimum_permissions", "validation"):
+            if not getattr(self, name).strip():
+                raise ValueError(f"{name} must not be empty")
+        for name in ("read_operations", "write_operations"):
+            values = getattr(self, name)
+            if not values or any(not value.strip() for value in values):
+                raise ValueError(f"{name} must not be empty")
+
+
+def render_provider_access(
+    *,
+    label: str,
+    help_text: str,
+    help_url: str,
+    access: ProviderAccessSpec,
+) -> str:
+    """Сформировать одинаковую provider setup-подсказку без credentials."""
+    return "\n".join(
+        (
+            f"[{label}]",
+            help_text,
+            f"Минимальные права: {access.minimum_permissions}",
+            f"Чтение: {'; '.join(access.read_operations)}",
+            f"Запись: {'; '.join(access.write_operations)}",
+            f"Проверка: {access.validation}",
+            f"Официальная инструкция: {help_url}",
+        )
+    )
+```
+
+- [ ] **Step 4: Require access metadata in board specs**
+
+Add to `ProviderSetupSpec`:
+
+```python
+from reviewer.config.provider_access import ProviderAccessSpec
+
+
+@dataclass(frozen=True)
+class ProviderSetupSpec:
+    label: str
+    help_url: str
+    help_text: str
+    access: ProviderAccessSpec
+    acquisition: Callable[[SetupIO], dict[str, str]] | None = None
+    help_url_builder: Callable[[Mapping[str, str]], str] | None = None
+```
+
+Extend `_validate_spec` after the existing setup metadata check:
+
+```python
+        if not isinstance(spec.setup.access, ProviderAccessSpec):
+            raise ValueError("provider access metadata must be complete")
+```
+
+Update fake `ProviderSetupSpec` constructors with this exact fixture:
+
+```python
+ProviderAccessSpec(
+    minimum_permissions="test read/write",
+    read_operations=("read test data",),
+    write_operations=("write test data",),
+    validation="test identity",
+)
+```
+
+- [ ] **Step 5: Add registry completeness assertion**
+
+In `test_default_registry_builds_and_validates_every_registered_provider` add:
+
+```python
+            assert spec.setup.access.minimum_permissions
+            assert spec.setup.access.read_operations
+            assert spec.setup.access.write_operations
+            assert spec.setup.access.validation
+```
+
+- [ ] **Step 6: Run focused tests**
+
+Run: `.venv/bin/pytest tests/config/test_provider_access.py tests/tasks/boards/test_registry.py tests/test_install_wizard.py -q`
+
+Expected: access tests pass; production registry tests fail until all 11 specs are updated in Task 2.
+
+- [ ] **Step 7: Keep the RED contract uncommitted until Task 2 is green**
+
+Do not commit a registry contract that production providers cannot yet satisfy. Continue directly
+to Task 2 with all Task 1 changes in the worktree.
+
+---
+
+### Task 2: Access Contracts for Every Board Provider
+
+**Files:**
+- Modify: `reviewer/tasks/boards/yougile.py:90-123`
+- Modify: `reviewer/tasks/boards/youtrack.py:91-128`
+- Modify: `reviewer/tasks/boards/jira.py:61-89`
+- Modify: `reviewer/tasks/boards/github.py:87-135`
+- Modify: `reviewer/tasks/boards/trello.py:75-124`
+- Modify: `reviewer/tasks/boards/linear.py:180-215`
+- Modify: `reviewer/tasks/boards/clickup.py:66-113`
+- Modify: `reviewer/tasks/boards/asana.py:86-128`
+- Modify: `reviewer/tasks/boards/yandex_tracker.py:81-139`
+- Modify: `reviewer/tasks/boards/kaiten.py:99-148`
+- Modify: `reviewer/tasks/boards/weeek.py:96-143`
+- Test: `tests/tasks/boards/test_registry.py`
+
+- [ ] **Step 1: Add a failing exact provider matrix test**
+
+```python
+# tests/tasks/boards/test_registry.py
+ACCESS_MARKERS = {
+    "yougile": ("company", "tasks", "create", "validate_connection"),
+    "youtrack": ("YouTrack service", "issues", "create", "validate_connection"),
+    "jira": ("Jira Cloud", "issues", "transition", "validate_connection"),
+    "github": ("Issues: Read and write", "issues", "close", "validate_connection"),
+    "trello": ("account", "cards", "move", "validate_connection"),
+    "linear": ("Read and Write", "issues", "create", "validate_connection"),
+    "clickup": ("workspace", "tasks", "create", "validate_connection"),
+    "asana": ("project", "tasks", "complete", "validate_connection"),
+    "yandex_tracker": ("tracker:read", "issues", "transition", "validate_connection"),
+    "kaiten": ("board", "cards", "move", "validate_connection"),
+    "weeek": ("project", "tasks", "complete", "validate_connection"),
+}
+
+
+def test_every_board_provider_documents_access_contract():
+    registry = default_board_registry()
+    for board_type, markers in ACCESS_MARKERS.items():
+        access = registry.get(board_type).setup.access
+        rendered = " ".join(
+            (
+                access.minimum_permissions,
+                *access.read_operations,
+                *access.write_operations,
+                access.validation,
+            )
+        )
+        for marker in markers:
+            assert marker.casefold() in rendered.casefold(), (board_type, marker)
+```
+
+- [ ] **Step 2: Run the matrix test and verify RED**
+
+Run: `.venv/bin/pytest tests/tasks/boards/test_registry.py::test_every_board_provider_documents_access_contract -q`
+
+Expected: FAIL because production setup specs do not yet pass `access`.
+
+- [ ] **Step 3: Add exact access metadata to all specs**
+
+Import `ProviderAccessSpec` in each provider module and use these values:
+
+| Provider | minimum_permissions | read_operations | write_operations | validation |
+|---|---|---|---|---|
+| YouGile | `API-capable account with company/task read and write; admin role is not required` | `read companies, boards, columns, tasks, chats and attachments` | `create/update/complete tasks and native subtasks` | `validate_connection checks identity, project visibility and lifecycle capabilities` |
+| YouTrack | `permanent token with YouTrack service scope and project issue read/write` | `read issues, fields, links and attachments` | `create issues, update status and append PR links` | `validate_connection checks current user and project visibility` |
+| Jira | `Jira Cloud user with Browse Projects, Create Issues, Edit Issues and Transition Issues` | `read projects, issues, fields, transitions and attachments` | `create/edit/transition issues and append PR links` | `validate_connection checks identity, project and reported permissions` |
+| GitHub Issues | `fine-grained PAT with Issues: Read and write for the selected repository` | `read repository issues, labels, milestones and comments` | `create/update/close issues and append PR links` | `validate_connection checks identity, repository access and write capability` |
+| Trello | `API key and account token with access to the selected board` | `read boards, lists, cards, checklists and attachments` | `create/move/update/archive cards and append PR links` | `validate_connection checks member identity and board visibility` |
+| Linear | `personal API key with Read and Write for the selected team` | `read teams, workflow states, issues, relations and attachments metadata` | `create/update issues, change state and append PR links` | `validate_connection checks viewer identity and team visibility` |
+| ClickUp | `personal token for a member with access to the selected workspace/list` | `read teams, lists, statuses, tasks, relations and attachments` | `create/update/complete tasks and append PR links` | `validate_connection checks user identity and list visibility` |
+| Asana | `personal access token for a member with project read/write access` | `read workspaces, projects, sections, tasks, dependencies and attachments` | `create/update/complete tasks and append PR links` | `validate_connection checks user identity and project visibility` |
+| Yandex Tracker | `OAuth tracker:read + tracker:write or IAM role with equivalent queue access` | `read queues, issues, fields, links and attachments` | `create/update/transition issues and append PR links` | `validate_connection checks identity, organization and queue visibility` |
+| Kaiten | `API key of a user with read/write access to the selected space and board` | `read spaces, boards, columns, cards, links and attachments` | `create/update/move cards and append PR links` | `validate_connection checks user identity and board visibility` |
+| Weeek | `workspace token owner with read/write access to the selected project and board` | `read workspaces, projects, boards, columns, tasks and attachments` | `create/update/complete tasks and append PR links` | `validate_connection checks user identity and project visibility` |
+
+Represent operations as one-element tuples containing the exact table strings.
+
+- [ ] **Step 4: Run all board contract tests**
+
+Run: `.venv/bin/pytest tests/tasks/boards -q`
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit the green access model and all board metadata**
+
+```bash
+git add reviewer/config/provider_access.py reviewer/tasks/boards tests/config/test_provider_access.py tests/tasks/boards tests/test_install_wizard.py
+git commit -m "feat(boards): описывает права и операции providers"
+```
+
+---
+
+### Task 3: Structured Board Setup Output and YouGile Guidance
+
+**Files:**
+- Modify: `reviewer/tasks/boards/setup.py:262-292`
+- Modify: `reviewer/tasks/boards/yougile.py:110-118`
+- Test: `tests/install/test_board_setup.py`
+
+- [ ] **Step 1: Add failing output-order and YouGile tests**
+
+```python
+# tests/install/test_board_setup.py
+def test_setup_prints_access_contract_before_first_secret_prompt():
+    provider = FakeProvider({"status": "ok", "warnings": []})
+    spec = replace(jira_provider_spec(), factory=lambda _context: provider)
+    io = FakeIO(
+        answers={
+            "Jira Cloud site URL": "https://acme.atlassian.net",
+            "Atlassian account email": "bot@example.test",
+            "Atlassian API token": "jira-secret",
+        },
+        confirms=[False],
+    )
+
+    configure_board_provider(spec, io)
+
+    rendered = "\n".join(io.messages)
+    assert "Минимальные права:" in rendered
+    assert "Чтение:" in rendered
+    assert "Запись:" in rendered
+    assert "Проверка:" in rendered
+    assert io.events.index("echo") < next(
+        index
+        for index, event in enumerate(io.events)
+        if event == "prompt:Atlassian API token"
+    )
+
+
+def test_yougile_access_does_not_require_admin_role():
+    from reviewer.config.provider_access import render_provider_access
+    from reviewer.tasks.boards.yougile import provider_spec as yougile_provider_spec
+
+    spec = yougile_provider_spec()
+    text = render_provider_access(
+        label=spec.setup.label,
+        help_text=spec.setup.help_text,
+        help_url=spec.setup.help_url,
+        access=spec.setup.access,
+    )
+    assert "admin role is not required" in text
+    assert "allowOnlyOpenId" in text
+    assert "API-capable" in text
+```
+
+Update the existing `FakeIO.echo` method without changing message storage:
+
+```python
+    def echo(self, text: str) -> None:
+        self.events.append("echo")
+        self.messages.append(text)
+```
+
+- [ ] **Step 2: Run tests and verify RED**
+
+Run: `.venv/bin/pytest tests/install/test_board_setup.py -q -k "access_contract or admin_role"`
+
+Expected: FAIL because setup still echoes only `help_text + help_url`.
+
+- [ ] **Step 3: Render structured access**
+
+Replace line 267 in `configure_board_provider` with:
+
+```python
+    _echo(
+        io,
+        render_provider_access(
+            label=spec.setup.label,
+            help_text=spec.setup.help_text,
+            help_url=spec.setup.help_url,
+            access=spec.setup.access,
+        ),
+    )
+```
+
+Keep acquisition, manual fallback, validation and close paths unchanged.
+
+- [ ] **Step 4: Run setup tests**
+
+Run: `.venv/bin/pytest tests/install/test_board_setup.py tests/install/test_install_wizard.py -q`
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit setup output**
+
+```bash
+git add reviewer/tasks/boards/setup.py reviewer/tasks/boards/yougile.py tests/install/test_board_setup.py
+git commit -m "feat(init): показывает права выбранной доски"
+```
+
+---
+
+### Task 4: VCS Setup Catalog and Canonical Env Schema
+
+**Files:**
+- Modify: `reviewer/install.py:115-242,260-276`
+- Modify: `tests/test_install_wizard.py`
+- Modify: `tests/install/test_install_wizard.py`
+
+- [ ] **Step 1: Write failing VCS catalog tests**
+
+```python
+# tests/test_install_wizard.py
+from reviewer.install import VCS_SETUPS, vcs_env_group
+
+
+def test_vcs_catalog_declares_github_and_gitlab_access():
+    assert tuple(VCS_SETUPS) == ("github", "gitlab")
+    assert [field.key for field in VCS_SETUPS["github"].credential_fields] == [
+        "GITHUB_TOKEN"
+    ]
+    assert [field.key for field in VCS_SETUPS["gitlab"].credential_fields] == [
+        "GITLAB_URL",
+        "GITLAB_TOKEN",
+    ]
+    assert "Pull requests: Read and write" in VCS_SETUPS["github"].access.minimum_permissions
+    assert "Contents: Read" in VCS_SETUPS["github"].access.minimum_permissions
+    assert VCS_SETUPS["gitlab"].access.minimum_permissions == "PAT/project token with api scope"
+
+
+def test_vcs_group_is_canonical_union_with_provider_fallback():
+    keys = [field.key for field in vcs_env_group().fields]
+    assert keys == ["VCS_PROVIDER", "GITHUB_TOKEN", "GITLAB_URL", "GITLAB_TOKEN"]
+    assert len(keys) == len(set(keys))
+```
+
+- [ ] **Step 2: Run tests and verify RED**
+
+Run: `.venv/bin/pytest tests/test_install_wizard.py -q -k "vcs_catalog or vcs_group"`
+
+Expected: import error for `VCS_SETUPS` / `vcs_env_group`.
+
+- [ ] **Step 3: Implement VCS specs**
+
+Add to `reviewer/install.py` after `EnvGroup`:
+
+```python
+@dataclass(frozen=True)
+class VcsSetupSpec:
+    provider: str
+    label: str
+    credential_fields: tuple[EnvField, ...]
+    help_url: str
+    help_text: str
+    access: ProviderAccessSpec
+
+
+VCS_SETUPS = {
+    "github": VcsSetupSpec(
+        provider="github",
+        label="GitHub",
+        credential_fields=(
+            EnvField("GITHUB_TOKEN", "GitHub personal access token", secret=True),
+        ),
+        help_url="https://github.com/settings/personal-access-tokens/new",
+        help_text="Создайте fine-grained PAT для репозитория reviewer.",
+        access=ProviderAccessSpec(
+            minimum_permissions="Pull requests: Read and write; Contents: Read",
+            read_operations=("PR metadata, files, comments, contents and compare",),
+            write_operations=("review comments/summary and PR body backlink",),
+            validation="reviewer check authenticates /user; repository rights are exercised by review",
+        ),
+    ),
+    "gitlab": VcsSetupSpec(
+        provider="gitlab",
+        label="GitLab",
+        credential_fields=(
+            EnvField("GITLAB_URL", "GitLab base URL", default="https://gitlab.com"),
+            EnvField("GITLAB_TOKEN", "GitLab personal/project access token", secret=True),
+        ),
+        help_url="https://docs.gitlab.com/user/profile/personal_access_tokens/",
+        help_text="Создайте PAT или project access token для GitLab API v4.",
+        access=ProviderAccessSpec(
+            minimum_permissions="PAT/project token with api scope",
+            read_operations=("MR metadata, changes, notes, repository files and compare",),
+            write_operations=("MR discussions/notes and description backlink",),
+            validation="reviewer check authenticates /api/v4/user; project rights are exercised by review",
+        ),
+    ),
+}
+
+
+def vcs_env_group() -> EnvGroup:
+    fields = [EnvField("VCS_PROVIDER", "VCS fallback provider", default="github")]
+    for spec in VCS_SETUPS.values():
+        fields.extend(spec.credential_fields)
+    return EnvGroup(title="VCS", fields=fields, optional=True)
+```
+
+Make `WIZARD_GROUPS` use a Voyage-only required group plus `vcs_env_group()`; remove the old separate GitLab group and GitHub field from `Обязательные`. Update `_GROUP_HEADERS["VCS"]` with the existing auto-detect/fallback explanation.
+
+- [ ] **Step 4: Preserve render/redaction contracts**
+
+Update old tests to assert:
+
+```python
+assert "GITHUB_TOKEN=" in rendered
+assert "GITLAB_URL=https://gitlab.com" in rendered
+assert "GITLAB_TOKEN=" in rendered
+assert "VCS_PROVIDER=github" in rendered
+```
+
+Do not remove any key from `ENV_TEMPLATE`, `.env.example`, Settings, or `extra` handling.
+
+- [ ] **Step 5: Run install tests**
+
+Run: `.venv/bin/pytest tests/test_install_wizard.py tests/install/test_install_wizard.py -q`
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit catalog/schema**
+
+```bash
+git add reviewer/install.py tests/test_install_wizard.py tests/install/test_install_wizard.py
+git commit -m "refactor(init): описывает VCS setup catalog"
+```
+
+---
+
+### Task 5: Provider-Scoped VCS Prompting in `reviewer init`
+
+**Files:**
+- Modify: `reviewer/install.py` (small prompt helpers)
+- Modify: `reviewer/entrypoints/cli.py:1149-1231`
+- Modify: `tests/install/test_install_wizard.py:303-374`
+- Modify: `tests/entrypoints/test_cli_init_onboarding.py:46-60,168-210`
+
+- [ ] **Step 1: Write failing scoped prompt tests**
+
+```python
+# tests/install/test_install_wizard.py
+@pytest.mark.parametrize(
+    ("selected", "prompted", "not_prompted"),
+    [
+        ("github", {"GITHUB_TOKEN"}, {"GITLAB_URL", "GITLAB_TOKEN"}),
+        ("gitlab", {"GITLAB_URL", "GITLAB_TOKEN"}, {"GITHUB_TOKEN"}),
+    ],
+)
+def test_init_prompts_only_selected_vcs_provider(
+    selected, prompted, not_prompted, tmp_path, monkeypatch
+):
+    dest = tmp_path / ".env"
+    seen = []
+    monkeypatch.setattr("reviewer.install.default_env_path", lambda: dest)
+    monkeypatch.setattr(
+        "reviewer.entrypoints.cli._select_vcs_provider",
+        lambda *_args, **_kwargs: selected,
+    )
+    monkeypatch.setattr(
+        "reviewer.entrypoints.cli._prompt_vcs_provider",
+        lambda _inst, spec, current: seen.extend(field.key for field in spec.credential_fields)
+        or {field.key: current.get(field.key, "") or field.default for field in spec.credential_fields},
+    )
+    monkeypatch.setattr("click.confirm", lambda *_args, **_kwargs: True)
+    monkeypatch.setattr("reviewer.entrypoints.cli._shutil.which", lambda _name: None)
+
+    result = CliRunner().invoke(cli, ["init", "--scope", "global"])
+
+    assert result.exit_code == 0, result.output
+    assert set(seen) == prompted
+    assert set(seen).isdisjoint(not_prompted)
+
+
+def test_unselected_existing_vcs_credentials_survive(tmp_path, monkeypatch):
+    dest = tmp_path / ".env"
+    dest.write_text("GITLAB_TOKEN=keep-me\n", encoding="utf-8")
+    monkeypatch.setattr("reviewer.install.default_env_path", lambda: dest)
+    monkeypatch.setattr("reviewer.entrypoints.cli._select_vcs_provider", lambda *_a, **_k: "github")
+    monkeypatch.setattr(
+        "reviewer.entrypoints.cli._prompt_vcs_provider",
+        lambda *_a, **_k: {"GITHUB_TOKEN": "new-github"},
+    )
+    monkeypatch.setattr("click.confirm", lambda *_a, **_k: True)
+    monkeypatch.setattr("reviewer.entrypoints.cli._shutil.which", lambda _name: None)
+
+    result = CliRunner().invoke(cli, ["init", "--scope", "global"])
+
+    assert result.exit_code == 0, result.output
+    assert "GITLAB_TOKEN=keep-me" in dest.read_text(encoding="utf-8")
+```
+
+- [ ] **Step 2: Run tests and verify RED**
+
+Run: `.venv/bin/pytest tests/install/test_install_wizard.py -q -k "selected_vcs or unselected_existing_vcs"`
+
+Expected: FAIL because selection/prompt helpers do not exist.
+
+- [ ] **Step 3: Add small CLI seams**
+
+Add near init helpers in `cli.py`:
+
+```python
+def _select_vcs_provider(inst, current: Mapping[str, str]) -> str:
+    detected = derive_vcs_from_remote(remote_url(repo_root(".") or ".") or "")
+    default = detected[0] if detected is not None else current.get("VCS_PROVIDER", "github")
+    choices = tuple(inst.VCS_SETUPS)
+    return click.prompt("Выберите VCS provider", type=click.Choice(choices), default=default)
+
+
+def _prompt_vcs_provider(inst, spec, current: Mapping[str, str]) -> dict[str, str]:
+    click.echo(render_provider_access(
+        label=spec.label,
+        help_text=spec.help_text,
+        help_url=spec.help_url,
+        access=spec.access,
+    ))
+    if click.confirm(f"Открыть официальную инструкцию {spec.help_url}?", default=False):
+        click.launch(spec.help_url)
+    group = inst.EnvGroup(title=spec.label, fields=list(spec.credential_fields))
+    return inst.prompt_groups([group], current=dict(current), yes=False)
+```
+
+Import `Mapping`, `derive_vcs_from_remote`, and `render_provider_access` at module scope. Pass the
+existing lazy `reviewer.install` module as `inst` from `init`; do not add a second eager installer
+import.
+
+- [ ] **Step 4: Filter dynamic provider groups in init**
+
+In the interactive global stage:
+
+1. Locate `vcs_group` and `board_group`.
+2. Pass ordinary groups plus only the two common board fields to `prompt_groups`.
+3. Initialize all omitted VCS/board fields from `current` or default.
+4. On `Подключить VCS provider?` (default true), select one VCS, set `VCS_PROVIDER`, and update only selected fields.
+5. Keep existing board confirm/selection/retry unchanged.
+
+The core initialization must be:
+
+```python
+for group in (vcs_group, board_group):
+    for field in group.fields:
+        values.setdefault(field.key, current.get(field.key, "") or field.default)
+```
+
+- [ ] **Step 5: Extend noninteractive side-effect guards**
+
+Add `_select_vcs_provider` and `_prompt_vcs_provider` to `_forbid_noninteractive_side_effects` in `tests/entrypoints/test_cli_init_onboarding.py`; both `--yes` and `--dry-run` must still pass.
+
+- [ ] **Step 6: Run init tests**
+
+Run: `.venv/bin/pytest tests/install/test_install_wizard.py tests/entrypoints/test_cli_init_onboarding.py -q`
+
+Expected: PASS.
+
+- [ ] **Step 7: Commit scoped prompts**
+
+```bash
+git add reviewer/install.py reviewer/entrypoints/cli.py tests/install/test_install_wizard.py tests/entrypoints/test_cli_init_onboarding.py
+git commit -m "feat(init): спрашивает credentials выбранного VCS"
+```
+
+---
+
+### Task 6: GitHub/GitLab-Aware `reviewer check`
+
+**Files:**
+- Modify: `reviewer/entrypoints/cli.py:609-712`
+- Create: `tests/entrypoints/test_check_vcs.py`
+
+- [ ] **Step 1: Write failing VCS check tests**
+
+```python
+# tests/entrypoints/test_check_vcs.py
+import httpx
+
+from reviewer.config.settings import Settings
+from reviewer.entrypoints.cli import _check_vcs_providers
+
+
+class _Response:
+    def __init__(self, status_code, payload):
+        self.status_code = status_code
+        self._payload = payload
+
+    def json(self):
+        return self._payload
+
+
+def test_check_accepts_gitlab_only_and_uses_configured_base(monkeypatch, capsys):
+    seen = []
+
+    def get(url, **kwargs):
+        seen.append((url, kwargs["headers"]))
+        return _Response(200, {"username": "bot"})
+
+    monkeypatch.setattr(httpx, "get", get)
+    failed = _check_vcs_providers(Settings(
+        _env_file=None,
+        github_token="",
+        gitlab_token="gl-secret",
+        gitlab_url="https://gitlab.example",
+    ))
+    output = capsys.readouterr().out
+
+    assert failed is False
+    assert seen == [("https://gitlab.example/api/v4/user", {"PRIVATE-TOKEN": "gl-secret"})]
+    assert "GitLab API: аутентификация OK" in output
+    assert "gl-secret" not in output
+
+
+def test_check_requires_at_least_one_vcs_token(capsys):
+    failed = _check_vcs_providers(Settings(
+        _env_file=None,
+        github_token="",
+        gitlab_token="",
+    ))
+    output = capsys.readouterr().out
+
+    assert failed is True
+    assert "не настроен ни один VCS token" in output
+
+
+def test_check_validates_both_configured_tokens(monkeypatch, capsys):
+    monkeypatch.setattr(httpx, "get", lambda url, **_kwargs: _Response(200, {"login": "gh", "username": "gl"}))
+
+    failed = _check_vcs_providers(Settings(
+        _env_file=None,
+        github_token="gh-secret",
+        gitlab_token="gl-secret",
+    ))
+    output = capsys.readouterr().out
+
+    assert failed is False
+    assert "GitHub API: аутентификация OK" in output
+    assert "GitLab API: аутентификация OK" in output
+```
+
+- [ ] **Step 2: Run tests and verify RED**
+
+Run: `.venv/bin/pytest tests/entrypoints/test_check_vcs.py -q`
+
+Expected: FAIL because GitHub is still mandatory and GitLab is not checked.
+
+- [ ] **Step 3: Implement `_check_vcs_providers`**
+
+```python
+def _check_vcs_providers(settings: Settings) -> bool:
+    configured = []
+    if settings.github_token:
+        configured.append((
+            "GitHub",
+            "https://api.github.com/user",
+            {"Authorization": f"Bearer {settings.github_token}"},
+            "login",
+        ))
+    if settings.gitlab_token:
+        configured.append((
+            "GitLab",
+            f"{settings.gitlab_url.rstrip('/')}/api/v4/user",
+            {"PRIVATE-TOKEN": settings.gitlab_token},
+            "username",
+        ))
+    if not configured:
+        click.echo("✗ VCS: не настроен ни один VCS token; запустите reviewer init --scope global")
+        return True
+
+    failed = False
+    for label, url, headers, identity_key in configured:
+        try:
+            response = httpx.get(url, headers=headers, timeout=10)
+            if response.status_code != 200:
+                click.echo(f"✗ {label} API: HTTP {response.status_code} — проверьте token/base URL")
+                failed = True
+                continue
+            identity = response.json().get(identity_key, "?")
+            click.echo(f"✓ {label} API: аутентификация OK (identity: {identity})")
+        except Exception as exc:  # noqa: BLE001 — health check reports safe type only
+            click.echo(f"✗ {label} API: {type(exc).__name__}")
+            failed = True
+    return failed
+```
+
+Call it after infrastructure checks and before boards. Remove the old mandatory `GITHUB_TOKEN` key loop entry and old GitHub-only block.
+
+- [ ] **Step 4: Add failure/redaction coverage**
+
+Add parameterized HTTP 401 and exception tests asserting neither configured secret nor credential-bearing URL appears in output.
+
+- [ ] **Step 5: Run check/CLI tests**
+
+Run: `.venv/bin/pytest tests/entrypoints/test_check_vcs.py tests/entrypoints/test_cli.py tests/entrypoints/test_check_boards.py -q`
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit VCS check**
+
+```bash
+git add reviewer/entrypoints/cli.py tests/entrypoints/test_check_vcs.py
+git commit -m "fix(check): поддерживает GitLab-only окружение"
+```
+
+---
+
+### Task 7: Part C Verification
+
+**Files:**
+- Modify only if verification exposes scoped defects.
+
+- [ ] **Step 1: Run focused Part C suite**
+
+Run:
+
+```bash
+.venv/bin/pytest \
+  tests/config/test_provider_access.py \
+  tests/tasks/boards \
+  tests/install/test_board_setup.py \
+  tests/install/test_install_wizard.py \
+  tests/test_install_wizard.py \
+  tests/entrypoints/test_cli_init_onboarding.py \
+  tests/entrypoints/test_check_vcs.py \
+  tests/entrypoints/test_check_boards.py -q
+```
+
+Expected: all pass.
+
+- [ ] **Step 2: Run changed-file lint**
+
+Run:
+
+```bash
+.venv/bin/ruff check reviewer/config/provider_access.py reviewer/install.py reviewer/entrypoints/cli.py reviewer/tasks/boards tests/config/test_provider_access.py tests/install tests/entrypoints/test_check_vcs.py tests/tasks/boards
+```
+
+Expected: `All checks passed!`
+
+- [ ] **Step 3: Audit provider scoping mechanically**
+
+Run: `git diff dev...HEAD -- reviewer/install.py reviewer/entrypoints/cli.py reviewer/tasks/boards/setup.py`
+
+Expected: interactive paths prompt only selected VCS/board specs; noninteractive path still uses canonical full schema; no credential values appear in messages.
+
+- [ ] **Step 4: Commit verification fixes if needed**
+
+Stage only files from this plan and commit:
+
+```bash
+git commit -m "fix(init): закрывает регрессии provider credentials"
+```
+
+Do not create an empty commit.

--- a/docs/superpowers/plans/2026-08-08-PRI-223-provider-credentials.md
+++ b/docs/superpowers/plans/2026-08-08-PRI-223-provider-credentials.md
@@ -274,7 +274,7 @@ Import `ProviderAccessSpec` in each provider module and use these values:
 
 | Provider | minimum_permissions | read_operations | write_operations | validation |
 |---|---|---|---|---|
-| YouGile | `API-capable account with company/task read and write; admin role is not required` | `read companies, boards, columns, tasks, chats and attachments` | `create/update/complete tasks and native subtasks` | `validate_connection checks identity, project visibility and lifecycle capabilities` |
+| YouGile | `API-capable account with company/task read and write; admin role is not required` | `read companies, boards, columns, tasks, chats and attachments` | `create/update/complete tasks and native subtasks` | `validate_connection checks identity and project visibility; health checks do not probe writes` |
 | YouTrack | `permanent token with YouTrack service scope and project issue read/write` | `read issues, fields, links and attachments` | `create issues, update status and append PR links` | `validate_connection checks current user and project visibility` |
 | Jira | `Jira Cloud user with Browse Projects, Create Issues, Edit Issues and Transition Issues` | `read projects, issues, fields, transitions and attachments` | `create/edit/transition issues and append PR links` | `validate_connection checks identity, project and reported permissions` |
 | GitHub Issues | `fine-grained PAT with Issues: Read and write for the selected repository` | `read repository issues, labels, milestones and comments` | `create/update/close issues and append PR links` | `validate_connection checks identity, repository access and write capability` |

--- a/docs/superpowers/specs/2026-08-08-PRI-223-credentials-configure-review-design.md
+++ b/docs/superpowers/specs/2026-08-08-PRI-223-credentials-configure-review-design.md
@@ -1,0 +1,344 @@
+# PRI-223 (части C и D) — Provider credentials и configure-review
+
+Задача: https://ru.yougile.com/team/686c049c8af8/#PRI-223
+
+Бриф: `docs/superpowers/briefs/2026-08-07-PRI-223-redesign-reviewer-init.md`
+
+## Скоуп
+
+Эта спека покрывает две оставшиеся части PRI-223:
+
+- C: provider-scoped credential setup для VCS и досок, явные минимальные права,
+  read/write-операции, официальный способ получения и проверка подключения;
+- D: настройка `repository.primary_branch` / `repository.index_branches` через
+  `configure-review`, фиксация модели владения конфигурацией в двух README и focused tests.
+
+Покрываемые пункты «Что сделать»: 1, 5, 9, 10 и оставшаяся часть 13.
+Покрываемые критерии: 5, 8, 9, 14 и C/D-часть 15. Общие security/noninteractive
+инварианты критериев 7 и 10 сохраняются.
+
+Вне скоупа:
+
+- часть A — per-repo branch resolver, смержена PR #159;
+- часть B — global/repo onboarding, смержена PR #160 и уже присутствует в `dev`;
+- новый общий runtime registry для VCS и досок;
+- проверка точных repository-level write permissions VCS-токена: GitHub/GitLab не дают
+  одинакового надёжного API для такой проверки без конкретного PR/MR;
+- автоматический запуск индексации или пересборки сводок из `configure-review`.
+
+## Текущее состояние
+
+`reviewer init` уже сохраняет canonical env-поля всех зарегистрированных досок, но в
+интерактивном режиме скрывает provider-specific поля до выбора одной доски. Выбранный board
+provider конфигурируется через `configure_board_provider`, который показывает `help_text`,
+запрашивает только объявленные credentials и вызывает `validate_connection`.
+
+YouGile acquisition уже реализован корректно: hidden login/password, `companies → keys`, выбор
+компании, manual fallback, отдельная обработка `allowOnlyOpenId`, очистка password и сохранение
+только API key/base URL. Эту логику не нужно переписывать.
+
+VCS остаётся асимметричным: fresh wizard спрашивает `GITHUB_TOKEN`, затем отдельную GitLab-группу
+с `GITLAB_TOKEN`, `GITLAB_URL` и `VCS_PROVIDER`. `reviewer check` требует GitHub даже для
+GitLab-only deployment и вообще не валидирует GitLab token.
+
+`configure-review` уже умеет выбирать home per-repo или committed policy target и сохранять
+чужие policy keys/comments, но блок `repository` не входит в scope скилла. При этом branch config
+по архитектуре части A разрешён только в home YAML, а committed `.review.yml` его задавать не
+может.
+
+## Рассмотренные подходы
+
+### 1. Расширить существующие контракты — выбран
+
+Оставить board registry и VCS runtime раздельными. Добавить общую маленькую value-модель описания
+доступа, заполнить её в существующих board setup specs и в двух VCS setup specs. `init` продолжит
+рендерить canonical env целиком, но интерактивно будет prompt-ить только выбранный provider.
+
+Плюсы: минимальный runtime blast radius, registry-driven board path не ветвится, требования к
+правам становятся структурными и тестируемыми. Минус: VCS получает небольшой setup catalog,
+отдельный от runtime provider selection.
+
+### 2. Единый registry VCS и досок
+
+Вынести factory, credential schema, setup и validation обоих доменов в один provider registry.
+Это дало бы формальную симметрию, но потребовало бы переносить стабильный VCS runtime и 11 board
+adapters, хотя задача меняет только onboarding metadata. Риск и объём несоразмерны результату.
+
+### 3. Только prompts и документация
+
+Сузить вопросы в `cli.py`, оставив права и операции свободным текстом. Diff был бы меньше, но
+полнота metadata не проверялась бы, новые providers легко регрессировали бы, а GitLab-only check
+остался бы неверным.
+
+## Архитектура части C
+
+### Общая модель access metadata
+
+Новый модуль `reviewer/config/provider_access.py` содержит только immutable data и renderer:
+
+```python
+@dataclass(frozen=True)
+class ProviderAccessSpec:
+    minimum_permissions: str
+    read_operations: tuple[str, ...]
+    write_operations: tuple[str, ...]
+    validation: str
+
+
+def render_provider_access(
+    *, label: str, help_text: str, help_url: str, access: ProviderAccessSpec
+) -> str: ...
+```
+
+Renderer выводит в одинаковом порядке:
+
+1. назначение credential;
+2. минимальные права;
+3. реальные read-операции reviewer;
+4. реальные write-операции reviewer;
+5. что именно проверяет `reviewer check` / provider validation;
+6. официальный URL.
+
+Модуль не знает Click, env, HTTP, VCS или board registry. Значения секретов ему не передаются.
+
+### Board setup metadata
+
+`ProviderSetupSpec` получает обязательное поле `access: ProviderAccessSpec`. Registry validation
+требует непустые permissions, read operations, write operations и validation для каждого
+зарегистрированного provider. Все 11 production specs заполняют metadata из уже реализованного
+lifecycle своих adapters; отсутствие writes представляется явным текстом, а не пустым полем.
+
+`configure_board_provider` вместо свободной пары `help_text + help_url` вызывает общий renderer,
+затем сохраняет текущий acquisition/prompt/validation flow без изменений. Это не меняет credential
+schema, factory или REST-код adapters.
+
+Для YouGile access metadata явно сообщает:
+
+- официальный hidden-input flow `login/password → companies → API key`;
+- admin role не требуется сам по себе: нужен API-capable account с доступом к выбранной компании
+  и операциям reviewer;
+- при `allowOnlyOpenId` автоматический password flow невозможен, поэтому нужен заранее созданный
+  key отдельного API-capable account;
+- password не записывается, manual key остаётся fallback.
+
+### VCS setup catalog
+
+`reviewer/install.py` получает immutable `VcsSetupSpec` и catalog из двух записей:
+
+```python
+@dataclass(frozen=True)
+class VcsSetupSpec:
+    provider: Literal["github", "gitlab"]
+    label: str
+    credential_fields: tuple[EnvField, ...]
+    help_url: str
+    help_text: str
+    access: ProviderAccessSpec
+```
+
+GitHub:
+
+- credential: `GITHUB_TOKEN`;
+- fine-grained PAT: target repository, Pull requests Read and write, Contents Read;
+- reads: PR metadata/diff/comments/content/compare;
+- writes: review comments/summary и PR body backlink;
+- check: authenticated `/user` identity, без обещания granular repo permission proof.
+
+GitLab:
+
+- credentials: `GITLAB_URL`, `GITLAB_TOKEN`;
+- PAT/project token с `api` scope, потому что `read_api` не разрешает публикацию discussions и
+  обновление MR description;
+- reads: MR metadata/changes/notes/repository files/compare;
+- writes: discussions/notes и MR description backlink;
+- check: authenticated `/api/v4/user` identity на выбранном base URL.
+
+`VCS_PROVIDER` остаётся runtime fallback. Catalog управляет только onboarding и не заменяет
+`repo_vcs`, который по-прежнему заполняется из git remote при индексации.
+
+### Интерактивный `reviewer init`
+
+Canonical `WIZARD_GROUPS` по-прежнему содержит все поддерживаемые env keys. Это нужно для
+детерминированного render, redaction, `--yes`/`--dry-run` и сохранения существующих advanced
+deployments.
+
+Интерактивный flow меняется так:
+
+1. Prompt обычных групп (`VOYAGE_API_KEY`, stores), исключая provider-specific VCS/board fields.
+2. Инициализировать все provider fields текущими значениями или дефолтами, чтобы невыбранные
+   существующие credentials не потерялись.
+3. Предложить настройку VCS. Default provider: распознанный локальный `origin` через
+   `derive_vcs_from_remote`; затем current `VCS_PROVIDER`; затем `github`.
+4. Показать structured access metadata выбранного VCS и спросить только его credential fields.
+   Записать выбранный тип в `VCS_PROVIDER`.
+5. Выполнить уже существующий board selection/setup flow; prompt-ить только выбранную board spec.
+6. Показать единый redacted preview и сохранить только после существующего final confirmation.
+
+Невыбранный provider не prompt-ится, не валидируется и не открывает browser. Его existing env
+values сохраняются byte-for-value через текущий render plan; на fresh config его canonical fields
+остаются пустыми.
+
+`--yes` и `--dry-run` не выбирают provider, не prompt-ят, не открывают browser и не вызывают сеть.
+Они используют current/default values ровно как часть B.
+
+### `reviewer check`
+
+Проверка VCS выделяется в `_check_vcs_providers(settings)`:
+
+- `VOYAGE_API_KEY` остаётся обязательным;
+- если не настроен ни один VCS token, readiness check завершается ошибкой с подсказкой
+  `reviewer init --scope global`;
+- каждый реально заданный `GITHUB_TOKEN` / `GITLAB_TOKEN` проверяется независимо;
+- GitHub вызывает `https://api.github.com/user`;
+- GitLab вызывает `<GITLAB_URL>/api/v4/user` с `PRIVATE-TOKEN`;
+- HTTP status и тип исключения выводятся без token/credential URL;
+- один невалидный настроенный token делает общий check красным, даже если второй валиден;
+- board validation остаётся следующим независимым этапом.
+
+Identity-check подтверждает URL/token/authentication. Exact repository permission проверяется
+реальной dry-run/review operation, потому что provider APIs не дают общего достоверного способа
+доказать все granular rights заранее. Это ограничение печатается и документируется явно.
+
+## Архитектура части D
+
+### Branch workflow в `configure-review`
+
+Frontmatter и Scope скилла добавляют `repository.primary_branch` и
+`repository.index_branches`. Новый branch step выполняется до анализа context policy:
+
+1. Определить git root через `git rev-parse --show-toplevel` и прочитать только `origin` через
+   `git remote get-url origin`; network git commands запрещены.
+2. Нормализовать `owner/name` теми же правилами SSH/HTTPS, что runtime; при отсутствующем или
+   нераспознанном remote спросить repo id.
+3. Получить effective primary/index/source через
+   `reviewer config show --repo <repo> --json`. Policy/VCS error не отменяет branch section;
+   malformed home config остаётся блокирующей безопасной ошибкой.
+4. Показать current values/source и спросить новый primary, затем полный ordered unique index list.
+   Primary обязан входить в index.
+5. Branch destination всегда
+   `$XDG_CONFIG_HOME/rag-reviewer/repos/<owner>/<name>.yml`. Committed `.review.yml` не может
+   получить `repository`, даже если пользователь выбрал committed target для policy.
+6. Прочитать destination, отклонить malformed/non-regular/symlink/credential-like config и
+   собрать line-oriented patch. Нельзя сериализовать весь документ через `yaml.safe_dump`.
+7. Если `repository` отсутствует, append canonical block. Если присутствует, заменить только
+   `primary_branch` и `index_branches`, сохранив sibling/unknown subkeys, top-level keys,
+   комментарии, окончания строк и style окружающего документа.
+8. Показать path, source, old/new branch values и полный patch до записи; запросить final confirm.
+9. После записи повторить `reviewer config show --repo <repo> --json` и проверить exact
+   primary/index/source.
+
+Если в одном запуске меняются branches и policy, preview перечисляет оба targets. Branch patch
+пишется в home per-repo, policy patch — в ранее выбранный home/committed target. Ни один файл не
+меняется до общего final confirmation.
+
+### Rebuild guidance
+
+- новый `index_branches` содержит ещё не индексированную ветку → предложить
+  `rag-reviewer:sync-codebase` для этой ветки;
+- primary сменился на уже индексированную tracked branch → rebuild не нужен;
+- удалённая tracked branch перестаёт выбираться, но старый base index автоматически не удаляется;
+- branch changes никогда не запускают `summarize-subsystems`;
+- все существующие mapping rules для paths/summary/context/task board сохраняются.
+
+### Документация
+
+README.md и README.ru.md получают синхронные разделы:
+
+1. Таблица «что где хранится»:
+   - global `.env`: secrets, DSN, runtime infrastructure и compatibility fallbacks;
+   - home global YAML: общие non-secret defaults;
+   - home per-repo YAML: branches и operator-owned repo policy;
+   - committed `.review.yml`: team-visible policy/task-board metadata без credentials;
+   - git remote/CLI: canonical repo identity;
+   - Postgres/Neo4j: derived indexes/runtime state, не source of configuration truth.
+2. VCS token matrix: получение, минимальные rights, reads, writes, check semantics.
+3. Сценарии:
+   - single repo: `reviewer init`, review/confirm preview, `reviewer check`;
+   - второй repo: `reviewer init --scope repo`, без изменения global `.env`;
+   - CI/server: secrets из secret manager/env, noninteractive init только для deterministic
+     preview/write, home config принадлежит service account, team policy хранится committed.
+4. Удаление устаревшего GitLab-only workaround после появления GitLab check.
+5. Skill reference переименовывается из «update `.review.yml`» в layered policy + branches.
+
+`docs/board-providers.md` остаётся authoritative board reference и получает только уточнения,
+которые соответствуют structured access metadata; VCS matrix живёт в README, а не в board docs.
+
+## Ошибки и безопасность
+
+- Любой setup exception до final preview не пишет `.env` или home YAML.
+- Secret values не входят в access metadata, preview, error, docs или validation report.
+- Existing credentials невыбранного provider не удаляются и не эхоятся.
+- Ошибка одного configured VCS в `check` не скрывается валидностью другого.
+- `configure-review` fail-closed для ambiguous/malformed/credential-like home YAML и не
+  откатывается молча на lower layer.
+- Committed `.review.yml` никогда не получает branch config.
+- YouGile login/password остаются transient local variables; automatic acquisition не запускается
+  в noninteractive modes.
+
+## Тестирование
+
+Все тесты unit, без реальной сети и localhost.
+
+### Provider metadata и setup
+
+- `tests/tasks/boards/test_registry.py`: каждый registered spec имеет полный access contract;
+- provider-specific contract tests: permissions/operations соответствуют adapter capabilities;
+- `tests/tasks/boards/test_setup.py`: renderer output, no secret values, acquisition/validation
+  порядок;
+- YouGile tests: companies/key success, manual fallback, `allowOnlyOpenId`, no admin claim,
+  password redaction/cleanup, noninteractive no-op.
+
+### Init и check
+
+- выбран GitHub → prompt только `GITHUB_TOKEN`, GitLab fields не prompt-ятся;
+- выбран GitLab → prompt только `GITLAB_URL`/`GITLAB_TOKEN`, GitHub не prompt-ится;
+- board provider contract остаётся scoped;
+- existing credentials невыбранного provider сохраняются;
+- fresh unselected credentials остаются пустыми;
+- access metadata показана до secret prompt;
+- `--yes`/`--dry-run` не prompt-ят, не валидируют и не используют сеть;
+- GitHub-only, GitLab-only и dual-token `reviewer check`;
+- no-token failure, per-provider HTTP failure и redaction.
+
+### Configure-review и docs
+
+- guard требует repo autodetect, `config show`, primary/index questions и source display;
+- guard запрещает запись `repository` в committed `.review.yml` и whole-file YAML rewrite;
+- guard требует сохранения sibling keys/comments, preview/confirm и post-write verification;
+- guard фиксирует branch rebuild guidance без запуска skills;
+- README tests требуют одинаковый порядок paired sections, storage table, три scenarios,
+  VCS matrix и отсутствие GitLab-only workaround.
+
+### Команды проверки
+
+```bash
+.venv/bin/pytest tests/install tests/entrypoints tests/tasks/boards tests/skills tests/docs -q
+.venv/bin/pytest -q
+.venv/bin/ruff check .
+git diff --check
+```
+
+## Acceptance mapping
+
+| Критерий | Реализация |
+|---|---|
+| 5. configure-review пишет branches, сохраняя ключи/comments | Branch workflow и guard tests части D |
+| 7. Secrets только env | Existing credential rejection + preview/check redaction |
+| 8. Только credentials выбранного provider | Scoped VCS и существующий scoped board flow |
+| 9. YouGile key flow без admin requirement | Existing acquisition + structured access text/tests |
+| 10. `--yes`/`--dry-run` без prompt/network/leak | Existing noninteractive path + new setup guards |
+| 14. README ownership/scenarios | Paired storage table, VCS matrix и три deployment scenarios |
+| 15. Tests C/D | Provider, CLI/check, skill и docs suites |
+
+## Риски
+
+- Обязательные access fields затрагивают 11 board specs. Это намеренный compile/test-time guard:
+  новый provider нельзя зарегистрировать без setup/security описания.
+- `WIZARD_GROUPS` одновременно служит render schema и prompt catalog. Интерактивная фильтрация
+  должна жить в маленьких helper-функциях; нельзя создавать второй список env keys вручную.
+- Exact permission wording быстро устаревает у SaaS providers. Официальный URL остаётся source of
+  truth, а tests проверяют полноту полей и ключевые минимальные scopes, не копируют всю внешнюю
+  документацию.
+- Prompt skill не является Python runtime. Надёжность branch edit обеспечивается exact
+  line-oriented instructions, preview/confirm, fail-closed правилами и post-write `config show`;
+  новый provider-specific YAML writer в рамках этой задачи не вводится.

--- a/plugin/.codex-plugin/plugin.json
+++ b/plugin/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "rag-reviewer",
-  "version": "0.4.2+codex.402aaefd5ade",
+  "version": "0.4.2+codex.c065a9277f74",
   "description": "Agentic PR review: hybrid RAG + code graph via MCP, review skills for Codex",
   "repository": "https://github.com/mimfort/rag_for_git",
   "license": "MIT",

--- a/plugin/skills/configure-review/SKILL.md
+++ b/plugin/skills/configure-review/SKILL.md
@@ -23,6 +23,25 @@ own `repository`, because branch selection must be available before a committed 
 Untracked `.venv`, `node_modules`, `__pycache__`, `dist`, and `build` are gitignored and never
 enter the index. Do not use a filesystem walk to find them.
 
+## Safe YAML preflight
+
+Inspect each selected policy or home YAML file with a local boolean-only process.
+Run this preflight before any tool call that can return file contents.
+Return only safe/blocked, never matching lines, values, or exception text. Do not use Read or Grep
+to perform this preflight. The process must reject non-regular or symlinked files, malformed or
+non-mapping YAML, and credential-like keys at any depth. Also reject duplicate mapping keys,
+including duplicate `repository` keys and duplicate branch fields. Reject anchors, aliases, and merge keys.
+Reject these cases before reading or mutating the file in model context.
+Only after a safe result may a content-returning tool read the file for a line-oriented edit.
+
+For a home target, derive the canonical home config root lexically even when it does not exist.
+Check every existing parent path component through the destination without following symlinks;
+reject symlinks and non-directories. Missing destinations, including a missing home config root,
+are allowed only when the nearest existing parent is a real directory and the normalized
+destination remains inside the canonical home config root. After creating any missing directories,
+run the path preflight again. Also re-check immediately before writing so a changed path never
+inherits an earlier safe result.
+
 ## Pipeline
 
 1. Resolve the canonical lowercase repository id and the target branch. Present these targets in
@@ -36,8 +55,9 @@ enter the index. Do not use a filesystem walk to find them.
    For a nested id such as `group/service`, use `home:repos/group/service.yml`. A home policy is
    owned by the OS account running reviewer: on a shared service account it can affect that
    account's workloads, so use committed policy for team-owned settings.
-2. After the target is selected, verify the repository with `git rev-parse --git-dir` and read the
-   selected file, preserving unrelated keys and comments. Do not inspect or copy credentials.
+2. After the target is selected, verify the repository with `git rev-parse --git-dir`, run the Safe
+   YAML preflight, and only then read the selected file, preserving unrelated keys and comments.
+   Do not inspect or copy credentials.
 3. Scan only tracked Python files:
    ```bash
    git -C <path> ls-tree -r --name-only <branch> | grep '\.py$'
@@ -75,10 +95,10 @@ branches.
    Never write `repository` to committed `.review.yml`, even when committed policy is selected for
    other keys. If policy and branches
    change together, treat them as two targets in one preview.
-5. Read the destination without following symlinks. Stop on malformed, non-regular, symlinked, or
-   credential-like YAML. Build a line-oriented patch: if `repository` is absent, append the
-   canonical block; if it exists, replace only `primary_branch` and `index_branches`. Preserve all
-   top-level keys, unknown repository subkeys, comments, line endings, and surrounding YAML style.
+5. Run the Safe YAML preflight on the destination before reading it. Stop on every blocked result.
+   Build a line-oriented patch: if `repository` is absent, append the canonical block; if it exists,
+   replace only `primary_branch` and `index_branches`. Preserve all top-level keys and unknown repository subkeys.
+   Preserve comments, line endings, and surrounding YAML style.
    Never serialize the complete file with `yaml.safe_dump`.
 6. Show the destination, source, old and new branch values, and the exact patch. Request one
    final confirmation before any branch or policy write. A rejection leaves every target unchanged.

--- a/plugin/skills/configure-review/SKILL.md
+++ b/plugin/skills/configure-review/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: configure-review
-description: Use when configuring or changing a repository's layered review policy, ignored tracked paths, retrieval limits, summary depth, or non-secret task-board metadata.
+description: Use when configuring or changing a repository's tracked branches, layered review policy, ignored tracked paths, retrieval limits, summary depth, or non-secret task-board metadata.
 ---
 
 # Configure Review
@@ -15,6 +15,10 @@ Manage `summary_cluster_depth`, `summary_cluster_depth_overrides`, `summary_topk
 `paths.ignore`, `context_limits`, and the optional `task_board` block, including its generic
 `sync_filter`. An empty `task_board:` disables the board for this repository. Never read, request,
 display, or write credential values in either policy target.
+
+Tracked branches are separate from review policy. Manage `repository.primary_branch` and
+`repository.index_branches` only in the home per-repo target. The committed `.review.yml` cannot
+own `repository`, because branch selection must be available before a committed ref can be read.
 
 Untracked `.venv`, `node_modules`, `__pycache__`, `dist`, and `build` are gitignored and never
 enter the index. Do not use a filesystem walk to find them.
@@ -42,9 +46,49 @@ enter the index. Do not use a filesystem walk to find them.
 4. Measure churn with `git log --since="6 months ago" --name-only --pretty=format: -- '*.py'`.
    If history is too short or unavailable, say so and recommend from structure alone.
 5. Propose depth and ignore changes. Ask the user about every candidate for `paths.ignore` and
-   **never write it silently**. Assemble a draft that preserves the selected file's unrelated
-   keys/comments, then request final confirmation before writing it. Follow the exact rebuild map
-   below; suggest but **do NOT run** a follow-up skill.
+    **never write it silently**. Assemble a draft that preserves the selected file's unrelated
+    keys/comments, then request final confirmation before writing it. Follow the exact rebuild map
+   below; suggest but **do NOT run** a follow-up skill. When branch and policy changes share a run,
+   assemble both drafts first, show both paths and diffs, and request one final confirmation before
+   either write.
+
+## Repository branches
+
+Handle branches before policy analysis whenever the user asks to inspect or change tracked
+branches.
+
+1. Resolve the local repository without network calls:
+   - `git rev-parse --show-toplevel` gives the git root;
+   - `git remote get-url origin` gives the canonical SSH/HTTPS remote candidate;
+   - normalize it to lowercase `<owner/name>` with the same SSH/HTTPS forms accepted by reviewer;
+   - if origin is absent or unrecognized, ask for `<owner/name>` explicitly.
+   Network git commands are forbidden.
+2. Run `reviewer config show --repo <owner/name> --json` and show the effective primary branch,
+   ordered index branches, and source. A policy/VCS diagnostic error does not erase the returned
+   branch section; a malformed home config is a blocking error and must not fall back silently.
+3. Ask for `repository.primary_branch`, then ask for the complete ordered unique
+   `repository.index_branches`. The primary must be present in the index list. Reject empty names,
+   duplicates, and a primary outside the list.
+4. The destination is always
+   `$XDG_CONFIG_HOME/rag-reviewer/repos/<owner>/<name>.yml` (or the equivalent
+   `~/.config/rag-reviewer/...` path when XDG is unset).
+   Never write `repository` to committed `.review.yml`, even when committed policy is selected for
+   other keys. If policy and branches
+   change together, treat them as two targets in one preview.
+5. Read the destination without following symlinks. Stop on malformed, non-regular, symlinked, or
+   credential-like YAML. Build a line-oriented patch: if `repository` is absent, append the
+   canonical block; if it exists, replace only `primary_branch` and `index_branches`. Preserve all
+   top-level keys, unknown repository subkeys, comments, line endings, and surrounding YAML style.
+   Never serialize the complete file with `yaml.safe_dump`.
+6. Show the destination, source, old and new branch values, and the exact patch. Request one
+   final confirmation before any branch or policy write. A rejection leaves every target unchanged.
+7. After writing, run `reviewer config show --repo <owner/name> --json` again and require the
+   exact primary/index/source expected from the home per-repo layer. Report a mismatch as an error.
+
+If newly added index branches are not indexed, suggest `rag-reviewer:sync-codebase` once per new
+branch, but do not run it. A primary change to an already indexed branch needs no rebuild. Removing
+a branch stops reviewer from selecting it but does not delete its old base index automatically.
+Branch changes never trigger subsystem-summary work.
 
 ## Rebuild guidance
 
@@ -172,5 +216,6 @@ Preserve every other configuration key and ask for confirmation before writing t
 
 ## Completion
 
-Report the changed keys, the selected generic targets/options, and any recommended follow-up. This
-skill makes configuration-only recommendations and has no index side effects.
+Report old/new branches, the selected branch source, changed policy keys, selected generic
+targets/options, and any recommended follow-up. This skill makes configuration-only recommendations
+and has no index side effects.

--- a/reviewer/config/provider_access.py
+++ b/reviewer/config/provider_access.py
@@ -1,0 +1,44 @@
+"""Общие несекретные подсказки по доступу внешнего provider."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class ProviderAccessSpec:
+    """Минимальные права и фактические операции reviewer."""
+
+    minimum_permissions: str
+    read_operations: tuple[str, ...]
+    write_operations: tuple[str, ...]
+    validation: str
+
+    def __post_init__(self) -> None:
+        for name in ("minimum_permissions", "validation"):
+            if not getattr(self, name).strip():
+                raise ValueError(f"{name} must not be empty")
+        for name in ("read_operations", "write_operations"):
+            values = getattr(self, name)
+            if not values or any(not value.strip() for value in values):
+                raise ValueError(f"{name} must not be empty")
+
+
+def render_provider_access(
+    *,
+    label: str,
+    help_text: str,
+    help_url: str,
+    access: ProviderAccessSpec,
+) -> str:
+    """Сформировать одинаковую provider setup-подсказку без credentials."""
+    return "\n".join(
+        (
+            f"[{label}]",
+            help_text,
+            f"Минимальные права: {access.minimum_permissions}",
+            f"Чтение: {'; '.join(access.read_operations)}",
+            f"Запись: {'; '.join(access.write_operations)}",
+            f"Проверка: {access.validation}",
+            f"Официальная инструкция: {help_url}",
+        )
+    )

--- a/reviewer/entrypoints/cli.py
+++ b/reviewer/entrypoints/cli.py
@@ -47,6 +47,7 @@ from reviewer.services.branch import resolve_branch
 from reviewer.services.gc import purge_orphaned_overlays
 from reviewer.services.review_service import ReviewService
 from reviewer.services.status import build_status_report, render_status, render_status_json
+from reviewer.tasks.boards.errors import sanitize_provider_text
 from reviewer.versioning import InstallMode, check_latest, detect_installation, upgrade_uv_tool
 
 if TYPE_CHECKING:
@@ -590,6 +591,9 @@ def _check_board_providers(
 
 def _check_vcs_providers(settings: Settings) -> bool:
     """Проверить authentication каждого настроенного VCS без вывода credentials."""
+    secrets = tuple(
+        token for token in (settings.github_token, settings.gitlab_token) if token
+    )
     configured: list[tuple[str, str, dict[str, str], str]] = []
     if settings.github_token:
         configured.append(
@@ -628,8 +632,31 @@ def _check_vcs_providers(settings: Settings) -> bool:
                 failed = True
                 continue
             payload = response.json()
-            identity = payload.get(identity_key, "?") if isinstance(payload, Mapping) else "?"
-            click.echo(f"✓ {label} API: аутентификация OK (identity: {identity})")
+            identity = payload.get(identity_key) if isinstance(payload, Mapping) else None
+            if not isinstance(identity, str) or not identity.strip():
+                click.echo(f"✗ {label} API: identity отсутствует или некорректен")
+                failed = True
+                continue
+            safe_identity = sanitize_provider_text(identity, secrets)
+            if label == "GitHub":
+                identity_valid = (
+                    len(safe_identity) <= 100
+                    and re.fullmatch(
+                        r"[A-Za-z0-9]+(?:-[A-Za-z0-9]+)*(?:\[bot\])?",
+                        safe_identity,
+                    )
+                    is not None
+                )
+            else:
+                identity_valid = (
+                    len(safe_identity) <= 255
+                    and re.fullmatch(r"[A-Za-z0-9_.-]+", safe_identity) is not None
+                )
+            if safe_identity != identity or not identity_valid:
+                click.echo(f"✗ {label} API: identity отсутствует или некорректен")
+                failed = True
+                continue
+            click.echo(f"✓ {label} API: аутентификация OK (identity: {safe_identity})")
         except Exception as exc:  # noqa: BLE001 — health check сообщает только безопасный тип
             click.echo(f"✗ {label} API: {type(exc).__name__}")
             failed = True

--- a/reviewer/entrypoints/cli.py
+++ b/reviewer/entrypoints/cli.py
@@ -32,6 +32,7 @@ from reviewer.config.onboarding import (
     parse_branch_csv,
     plan_repository_config,
 )
+from reviewer.config.provider_access import render_provider_access
 from reviewer.gitutil import file_at_ref, list_python_files, repo_root, rev_parse, remote_url
 from reviewer.graph.backend import build_code_graph
 from reviewer.graph.store import GraphStore
@@ -587,6 +588,54 @@ def _check_board_providers(
     return failed
 
 
+def _check_vcs_providers(settings: Settings) -> bool:
+    """Проверить authentication каждого настроенного VCS без вывода credentials."""
+    configured: list[tuple[str, str, dict[str, str], str]] = []
+    if settings.github_token:
+        configured.append(
+            (
+                "GitHub",
+                "https://api.github.com/user",
+                {"Authorization": f"Bearer {settings.github_token}"},
+                "login",
+            )
+        )
+    if settings.gitlab_token:
+        configured.append(
+            (
+                "GitLab",
+                f"{settings.gitlab_url.rstrip('/')}/api/v4/user",
+                {"PRIVATE-TOKEN": settings.gitlab_token},
+                "username",
+            )
+        )
+    if not configured:
+        click.echo(
+            "✗ VCS: не настроен ни один VCS token; "
+            "запустите reviewer init --scope global"
+        )
+        return True
+
+    failed = False
+    for label, url, headers, identity_key in configured:
+        try:
+            response = httpx.get(url, headers=headers, timeout=10)
+            if response.status_code != 200:
+                click.echo(
+                    f"✗ {label} API: HTTP {response.status_code} — "
+                    "проверьте token/base URL"
+                )
+                failed = True
+                continue
+            payload = response.json()
+            identity = payload.get(identity_key, "?") if isinstance(payload, Mapping) else "?"
+            click.echo(f"✓ {label} API: аутентификация OK (identity: {identity})")
+        except Exception as exc:  # noqa: BLE001 — health check сообщает только безопасный тип
+            click.echo(f"✗ {label} API: {type(exc).__name__}")
+            failed = True
+    return failed
+
+
 def _parse_board_projects(values: tuple[str, ...]) -> dict[str, str]:
     projects: dict[str, str] = {}
     for value in values:
@@ -615,16 +664,13 @@ def _parse_board_projects(values: tuple[str, ...]) -> dict[str, str]:
     help="Проект для provider validation; опцию можно повторять.",
 )
 def check(board_project_values: tuple[str, ...]) -> None:
-    """Проверить готовность окружения (ключи, Postgres, Neo4j, GitHub)."""
+    """Проверить готовность окружения и настроенных внешних providers."""
     s = Settings()
     board_projects = _parse_board_projects(board_project_values)
     failed = False
 
     # 1. Ключи
-    for label, val in (
-        ("VOYAGE_API_KEY", s.voyage_api_key),
-        ("GITHUB_TOKEN", s.github_token),
-    ):
+    for label, val in (("VOYAGE_API_KEY", s.voyage_api_key),):
         if val:
             click.echo(f"✓ {label} задан")
         else:
@@ -673,25 +719,8 @@ def check(board_project_values: tuple[str, ...]) -> None:
     else:
         click.echo("  scip-python: не найден — граф через tree-sitter (fallback)")
 
-    # 5. GitHub (только если токен задан)
-    if s.github_token:
-        try:
-            resp = httpx.get(
-                "https://api.github.com/user",
-                headers={"Authorization": f"Bearer {s.github_token}"},
-                timeout=10,
-            )
-            if resp.status_code == 200:
-                login = resp.json().get("login", "?")
-                click.echo(f"✓ GitHub API: аутентификация OK (логин: {login})")
-            else:
-                click.echo(f"✗ GitHub API: HTTP {resp.status_code} — проверьте токен")
-                failed = True
-        except Exception as e:
-            click.echo(f"✗ GitHub API: {e}")
-            failed = True
-    else:
-        click.echo("  GitHub API: токен не задан, проверка пропущена")
+    # 5. Настроенные VCS providers
+    failed = _check_vcs_providers(s) or failed
 
     # 6. Настроенные board providers
     failed = _check_board_providers(s, board_projects=board_projects) or failed
@@ -1123,6 +1152,42 @@ def _render_init_preview(
         click.echo(repo_plan.preview)
 
 
+def _select_vcs_provider(inst, current: Mapping[str, str]) -> str:
+    """Выбрать VCS с offline default из origin, затем env fallback."""
+    from reviewer.services.repo_id import derive_vcs_from_remote
+
+    root = repo_root(".")
+    detected = derive_vcs_from_remote(remote_url(root or ".") or "")
+    default = detected[0] if detected is not None else current.get("VCS_PROVIDER", "github")
+    choices = tuple(inst.VCS_SETUPS)
+    if default not in choices:
+        default = "github"
+    return click.prompt(
+        "Выберите VCS provider",
+        type=click.Choice(choices),
+        default=default,
+    )
+
+
+def _prompt_vcs_provider(inst, spec, current: Mapping[str, str]) -> dict[str, str]:
+    """Показать access contract и запросить поля только выбранного VCS."""
+    click.echo(
+        render_provider_access(
+            label=spec.label,
+            help_text=spec.help_text,
+            help_url=spec.help_url,
+            access=spec.access,
+        )
+    )
+    if click.confirm(
+        f"Открыть официальную инструкцию {spec.help_url}?",
+        default=False,
+    ):
+        click.launch(spec.help_url)
+    group = inst.EnvGroup(title=spec.label, fields=list(spec.credential_fields))
+    return inst.prompt_groups([group], current=dict(current), yes=False)
+
+
 @cli.command()
 @click.option("--path", "path_opt", default=None,
               help="куда писать .env (по умолчанию ~/.config/rag-reviewer/.env)")
@@ -1173,6 +1238,7 @@ def init(
             if interactive:
                 click.echo(f"Настройка rag-reviewer: {dest}")
                 click.echo("─" * 52)
+                vcs_group = next(group for group in groups if group.title == "VCS")
                 board_group = next(group for group in groups if group.title == "Доска задач")
                 common_fields = inst.common_board_env_fields(board_group)
                 values = inst.prompt_groups(
@@ -1187,14 +1253,24 @@ def init(
                             else group
                         )
                         for group in groups
+                        if group is not vcs_group
                     ],
                     current=current,
                     yes=False,
                 )
-                for field in board_group.fields:
-                    if field in common_fields:
-                        continue
-                    values[field.key] = current.get(field.key, "") or field.default
+                for group in (vcs_group, board_group):
+                    for field in group.fields:
+                        values.setdefault(
+                            field.key,
+                            current.get(field.key, "") or field.default,
+                        )
+
+                if click.confirm("\nПодключить VCS provider?", default=True):
+                    vcs_type = _select_vcs_provider(inst, current)
+                    values["VCS_PROVIDER"] = vcs_type
+                    values.update(
+                        _prompt_vcs_provider(inst, inst.VCS_SETUPS[vcs_type], current)
+                    )
 
                 if click.confirm("\nПодключить provider доски задач?", default=False):
                     registry = default_board_registry()

--- a/reviewer/install.py
+++ b/reviewer/install.py
@@ -22,6 +22,7 @@ from pathlib import Path, PureWindowsPath
 from typing import Callable
 from urllib.parse import urlsplit
 
+from reviewer.config.provider_access import ProviderAccessSpec
 from reviewer.tasks.boards.registry import default_board_registry as _default_board_registry
 
 PACKAGE = "rag-reviewer"
@@ -128,6 +129,65 @@ class EnvGroup:
     optional: bool = False
 
 
+@dataclass(frozen=True)
+class VcsSetupSpec:
+    """Несекретный setup-контракт одного VCS provider."""
+
+    provider: str
+    label: str
+    credential_fields: tuple[EnvField, ...]
+    help_url: str
+    help_text: str
+    access: ProviderAccessSpec
+
+
+VCS_SETUPS = {
+    "github": VcsSetupSpec(
+        provider="github",
+        label="GitHub",
+        credential_fields=(
+            EnvField("GITHUB_TOKEN", "GitHub personal access token", secret=True),
+        ),
+        help_url="https://github.com/settings/personal-access-tokens/new",
+        help_text="Создайте fine-grained PAT для репозитория reviewer.",
+        access=ProviderAccessSpec(
+            minimum_permissions="Pull requests: Read and write; Contents: Read",
+            read_operations=("PR metadata, files, comments, contents and compare",),
+            write_operations=("review comments/summary and PR body backlink",),
+            validation="reviewer check authenticates /user identity",
+        ),
+    ),
+    "gitlab": VcsSetupSpec(
+        provider="gitlab",
+        label="GitLab",
+        credential_fields=(
+            EnvField("GITLAB_URL", "GitLab base URL", default="https://gitlab.com"),
+            EnvField(
+                "GITLAB_TOKEN",
+                "GitLab personal/project access token",
+                secret=True,
+            ),
+        ),
+        help_url="https://docs.gitlab.com/user/profile/personal_access_tokens/",
+        help_text="Создайте PAT или project access token для GitLab API v4.",
+        access=ProviderAccessSpec(
+            minimum_permissions="PAT/project token with api scope",
+            read_operations=("MR metadata, changes, notes, repository files and compare",),
+            write_operations=("MR discussions/notes and description backlink",),
+            validation="reviewer check authenticates /api/v4/user identity",
+        ),
+    ),
+}
+
+
+def vcs_env_group() -> EnvGroup:
+    """Canonical union VCS-полей для render/preserve, не prompt selection."""
+    fields = [EnvField("VCS_PROVIDER", "VCS fallback provider", default="github")]
+    for spec in VCS_SETUPS.values():
+        fields.extend(spec.credential_fields)
+    return EnvGroup(title="VCS", fields=fields, optional=True)
+
+
 def board_env_group(registry) -> EnvGroup:
     """Построить canonical env-поля досок из registry metadata.
 
@@ -185,11 +245,6 @@ WIZARD_GROUPS: list[EnvGroup] = [
                 secret=True,
                 required=True,
             ),
-            EnvField(
-                key="GITHUB_TOKEN",
-                prompt_text="GITHUB_TOKEN (PAT: Pull requests read/write, Contents read)",
-                secret=True,
-            ),
         ],
     ),
     EnvGroup(
@@ -211,28 +266,7 @@ WIZARD_GROUPS: list[EnvGroup] = [
             ),
         ],
     ),
-    EnvGroup(
-        title="GitLab VCS",
-        optional=True,
-        fields=[
-            EnvField(
-                key="GITLAB_TOKEN",
-                prompt_text="GITLAB_TOKEN (PAT GitLab: api scope)",
-                default="",
-                secret=True,
-            ),
-            EnvField(
-                key="GITLAB_URL",
-                prompt_text="GITLAB_URL (self-hosted base URL)",
-                default="https://gitlab.com",
-            ),
-            EnvField(
-                key="VCS_PROVIDER",
-                prompt_text="VCS_PROVIDER (фолбэк-платформа: github)",
-                default="github",
-            ),
-        ],
-    ),
+    vcs_env_group(),
     board_env_group(_default_board_registry()),
 ]
 
@@ -258,10 +292,10 @@ def read_env(path: Path) -> dict[str, str]:
 
 
 _GROUP_HEADERS: dict[str, str] = {
-    "Обязательные": "# --- Voyage / GitHub ---",
+    "Обязательные": "# --- Voyage ---",
     "Хранилища (Postgres / Neo4j)": "# --- Postgres (ParadeDB :5433) / Neo4j (:7687) ---",
-    "GitLab VCS": (
-        "# --- GitLab VCS (опционально; multi-platform: ревью GitLab MR) ---\n"
+    "VCS": (
+        "# --- VCS credentials (GitHub / GitLab) ---\n"
         "# VCS_PROVIDER — фолбэк, когда репо не индексирован. Тип VCS\n"
         "# автоопределяется из git remote при `reviewer index`."
     ),
@@ -280,7 +314,7 @@ def render_env(values: dict[str, str], extra: dict[str, str]) -> str:
     """Сгенерировать содержимое .env по wizard-группам и прочим (extra) ключам."""
     lines: list[str] = [
         "# rag_for_git — конфигурация (сгенерировано reviewer init)",
-        "# Обязательный ключ: VOYAGE_API_KEY; GITHUB_TOKEN нужен для ревью PR.",
+        "# Обязательный ключ: VOYAGE_API_KEY; выбранный VCS token нужен для ревью PR.",
         "# Остальные переменные имеют дефолты в reviewer/config/settings.py.",
         "",
     ]

--- a/reviewer/tasks/boards/asana.py
+++ b/reviewer/tasks/boards/asana.py
@@ -24,6 +24,7 @@ from reviewer.tasks.boards.base import RawTask, TaskListing, TaskListingStats, p
 from reviewer.tasks.boards.errors import BoardProviderError
 from reviewer.tasks.boards.markup import html_to_md, md_to_html
 from reviewer.tasks.boards.pagination import paginate_cursor
+from reviewer.config.provider_access import ProviderAccessSpec
 from reviewer.tasks.boards.registry import (
     BoardProviderSpec,
     CredentialFieldSpec,
@@ -108,6 +109,12 @@ def provider_spec() -> BoardProviderSpec:
                 "Создайте personal access token в Asana: My Settings → Apps → "
                 "Manage developer apps (app.asana.com/0/my-apps) → Create new token. "
                 "Токен показывается один раз — сохраните его сразу."
+            ),
+            access=ProviderAccessSpec(
+                minimum_permissions="personal access token с read/write к выбранному project",
+                read_operations=("workspaces, projects, sections, tasks, dependencies и files",),
+                write_operations=("создание, правка и завершение tasks, добавление PR-ссылок",),
+                validation="user identity и видимость project",
             ),
         ),
         option_fields=(

--- a/reviewer/tasks/boards/clickup.py
+++ b/reviewer/tasks/boards/clickup.py
@@ -30,6 +30,7 @@ from reviewer.tasks.boards.attachments import (
 from reviewer.tasks.boards.base import RawTask, TaskListing, TaskListingStats, project_prefix
 from reviewer.tasks.boards.errors import BoardProviderError
 from reviewer.tasks.boards.pagination import paginate_page
+from reviewer.config.provider_access import ProviderAccessSpec
 from reviewer.tasks.boards.registry import (
     BoardProviderSpec,
     CredentialFieldSpec,
@@ -105,6 +106,12 @@ def provider_spec() -> BoardProviderSpec:
                 "Откройте в ClickUp аватар → Settings → Apps и в разделе API Token "
                 "нажмите Generate, затем Copy: personal token начинается с pk_ и не "
                 "истекает. Он передаётся в заголовке Authorization без префикса Bearer."
+            ),
+            access=ProviderAccessSpec(
+                minimum_permissions="personal token участника с доступом к workspace/list",
+                read_operations=("teams, lists, statuses, tasks, relations и attachments",),
+                write_operations=("создание, правка и завершение tasks, добавление PR-ссылок",),
+                validation="user identity и видимость list",
             ),
         ),
         default_api_base=API_BASE,

--- a/reviewer/tasks/boards/github.py
+++ b/reviewer/tasks/boards/github.py
@@ -28,6 +28,7 @@ import httpx
 from reviewer.tasks.boards.base import RawTask, TaskListing, TaskListingStats, project_prefix
 from reviewer.tasks.boards.errors import BoardProviderError
 from reviewer.tasks.boards.pagination import paginate_page
+from reviewer.config.provider_access import ProviderAccessSpec
 from reviewer.tasks.boards.registry import (
     BoardProviderSpec,
     CredentialFieldSpec,
@@ -126,6 +127,14 @@ def provider_spec() -> BoardProviderSpec:
                 "Создайте fine-grained personal access token с доступом к нужному "
                 "репозиторию и правом Issues: Read and write (classic token — scope repo). "
                 "Токен показывается один раз, сохраните его сразу."
+            ),
+            access=ProviderAccessSpec(
+                minimum_permissions=(
+                    "fine-grained PAT с Issues: Read and write для выбранного репозитория"
+                ),
+                read_operations=("issues, labels, milestones и comments",),
+                write_operations=("создание, правка и закрытие issues, добавление PR-ссылок",),
+                validation="identity, доступ к репозиторию и write capability",
             ),
             help_url_builder=_token_url,
         ),

--- a/reviewer/tasks/boards/jira.py
+++ b/reviewer/tasks/boards/jira.py
@@ -27,6 +27,7 @@ from reviewer.tasks.boards.attachments import (
 from reviewer.tasks.boards.base import RawTask, TaskListing, TaskListingStats, project_prefix
 from reviewer.tasks.boards.errors import BoardProviderError
 from reviewer.tasks.boards.http import BoardHttpClient
+from reviewer.config.provider_access import ProviderAccessSpec
 from reviewer.tasks.boards.registry import (
     BoardProviderSpec,
     CredentialFieldSpec,
@@ -76,12 +77,20 @@ def provider_spec() -> BoardProviderSpec:
             ),
         ),
         setup=ProviderSetupSpec(
-            "Jira Cloud",
-            "https://id.atlassian.com/manage-profile/security/api-tokens",
-            (
+            label="Jira Cloud",
+            help_url="https://id.atlassian.com/manage-profile/security/api-tokens",
+            help_text=(
                 "Создайте API token без scopes для прямого Jira Cloud site URL, "
                 "задайте понятные name/expiration и сразу сохраните token: повторно "
                 "его посмотреть нельзя. Пароль Atlassian не подходит."
+            ),
+            access=ProviderAccessSpec(
+                minimum_permissions=(
+                    "Browse Projects, Create Issues, Edit Issues и Transition Issues"
+                ),
+                read_operations=("проекты, задачи, поля, переходы и вложения",),
+                write_operations=("создание, правка и перевод задач, добавление PR-ссылок",),
+                validation="identity, проект и доступные Jira permissions",
             ),
         ),
         create_target_label="Статус создания",

--- a/reviewer/tasks/boards/jira.py
+++ b/reviewer/tasks/boards/jira.py
@@ -272,7 +272,9 @@ class JiraCloudBoard:
             "/rest/api/3/mypermissions",
             params={
                 "projectKey": project,
-                "permissions": "BROWSE_PROJECTS,CREATE_ISSUES,TRANSITION_ISSUES",
+                "permissions": (
+                    "BROWSE_PROJECTS,CREATE_ISSUES,EDIT_ISSUES,TRANSITION_ISSUES"
+                ),
             },
         ) or {}
         permissions = payload.get("permissions") or {}
@@ -285,12 +287,13 @@ class JiraCloudBoard:
         }
         warnings = [
             f"missing Jira permission: {permission}"
-            for permission, capability in (
-                ("BROWSE_PROJECTS", "read"),
-                ("CREATE_ISSUES", "create"),
-                ("TRANSITION_ISSUES", "transition"),
+            for permission in (
+                "BROWSE_PROJECTS",
+                "CREATE_ISSUES",
+                "EDIT_ISSUES",
+                "TRANSITION_ISSUES",
             )
-            if not capabilities[capability]
+            if not bool((permissions.get(permission) or {}).get("havePermission"))
         ]
         return capabilities, warnings
 
@@ -317,7 +320,7 @@ class JiraCloudBoard:
             capabilities, warnings = self._project_permissions(project)
         else:
             warnings.append(
-                "Jira project was not checked; create and transition permissions are unknown."
+                "Jira project was not checked; create, edit, and transition permissions are unknown."
             )
         return {
             "status": "ok",

--- a/reviewer/tasks/boards/kaiten.py
+++ b/reviewer/tasks/boards/kaiten.py
@@ -40,6 +40,7 @@ from reviewer.tasks.boards.attachments import (
 from reviewer.tasks.boards.base import RawTask, TaskListing, TaskListingStats, project_prefix
 from reviewer.tasks.boards.errors import BoardProviderError
 from reviewer.tasks.boards.pagination import paginate_offset
+from reviewer.config.provider_access import ProviderAccessSpec
 from reviewer.tasks.boards.registry import (
     BoardProviderSpec,
     CredentialFieldSpec,
@@ -139,6 +140,12 @@ def provider_spec() -> BoardProviderSpec:
                 "Укажите адрес компании вида https://<company>.kaiten.ru и создайте "
                 "API-ключ в профиле пользователя (раздел API key → CREATE API KEY). "
                 "Ключ постоянный: его можно отозвать и выпустить заново."
+            ),
+            access=ProviderAccessSpec(
+                minimum_permissions="API key пользователя с read/write к space и board",
+                read_operations=("spaces, boards, columns, cards, links и attachments",),
+                write_operations=("создание, правка и перенос cards, добавление PR-ссылок",),
+                validation="user identity и видимость board",
             ),
             help_url_builder=_api_key_url,
         ),

--- a/reviewer/tasks/boards/linear.py
+++ b/reviewer/tasks/boards/linear.py
@@ -18,6 +18,7 @@ import httpx
 from reviewer.tasks.boards.base import RawTask, TaskListing, TaskListingStats, project_prefix
 from reviewer.tasks.boards.errors import BoardProviderError
 from reviewer.tasks.boards.graphql import GraphQLClient
+from reviewer.config.provider_access import ProviderAccessSpec
 from reviewer.tasks.boards.registry import (
     BoardProviderSpec,
     CredentialFieldSpec,
@@ -200,13 +201,19 @@ def provider_spec() -> BoardProviderSpec:
             ),
         ),
         setup=ProviderSetupSpec(
-            "Linear",
-            "https://linear.app/settings/account/security",
-            (
+            label="Linear",
+            help_url="https://linear.app/settings/account/security",
+            help_text=(
                 "Settings → Account → Security & access → Personal API keys: создайте "
                 "ключ с правами Read и Write (плюс Create issues, если нужен create-task) "
                 "и, если ограничиваете доступ, разрешите нужные команды. Ключ виден "
                 "только при создании; OAuth не поддерживается."
+            ),
+            access=ProviderAccessSpec(
+                minimum_permissions="personal API key с Read and Write для выбранной team",
+                read_operations=("teams, workflow states, issues, relations и metadata вложений",),
+                write_operations=("создание и правка issues, смена state и PR-ссылки",),
+                validation="viewer identity и видимость team",
             ),
         ),
         default_api_base=DEFAULT_API_BASE,

--- a/reviewer/tasks/boards/registry.py
+++ b/reviewer/tasks/boards/registry.py
@@ -9,6 +9,7 @@ from functools import lru_cache
 from types import MappingProxyType
 from typing import TYPE_CHECKING, Literal
 
+from reviewer.config.provider_access import ProviderAccessSpec
 from reviewer.tasks.boards.base import JsonValue, TaskBoardProvider
 
 if TYPE_CHECKING:
@@ -38,6 +39,7 @@ class ProviderSetupSpec:
     label: str
     help_url: str
     help_text: str
+    access: ProviderAccessSpec
     acquisition: Callable[[SetupIO], dict[str, str]] | None = None
     help_url_builder: Callable[[Mapping[str, str]], str] | None = None
 
@@ -193,6 +195,8 @@ class BoardProviderRegistry:
             raise TypeError("provider factory must be callable")
         if not spec.setup.label or not spec.setup.help_url or not spec.setup.help_text:
             raise ValueError("provider setup metadata must be complete")
+        if not isinstance(spec.setup.access, ProviderAccessSpec):
+            raise ValueError("provider access metadata must be complete")
         if type(spec.capabilities) is not frozenset:
             raise TypeError("provider capabilities must be a frozenset")
         if spec.capabilities.difference(_PROVIDER_CAPABILITY_METHODS):

--- a/reviewer/tasks/boards/setup.py
+++ b/reviewer/tasks/boards/setup.py
@@ -10,6 +10,7 @@ from urllib.parse import urlsplit
 
 import httpx
 
+from reviewer.config.provider_access import render_provider_access
 from reviewer.tasks.boards.errors import (
     BoardProviderError,
     sanitize_provider_text,
@@ -264,7 +265,15 @@ def configure_board_provider(spec: BoardProviderSpec, io: SetupIO) -> dict[str, 
     if io.dry_run or io.non_interactive:
         return {}
 
-    _echo(io, f"{spec.setup.help_text}\n{spec.setup.help_url}")
+    _echo(
+        io,
+        render_provider_access(
+            label=spec.setup.label,
+            help_text=spec.setup.help_text,
+            help_url=spec.setup.help_url,
+            access=spec.setup.access,
+        ),
+    )
     if spec.setup.help_url_builder is None and io.confirm(
         f"Открыть официальную инструкцию {spec.setup.help_url}?",
         default=False,

--- a/reviewer/tasks/boards/trello.py
+++ b/reviewer/tasks/boards/trello.py
@@ -35,6 +35,7 @@ from reviewer.tasks.boards.attachments import (
 from reviewer.tasks.boards.base import RawTask, TaskListing, TaskListingStats, project_prefix
 from reviewer.tasks.boards.errors import BoardProviderError
 from reviewer.tasks.boards.pagination import paginate_cursor
+from reviewer.config.provider_access import ProviderAccessSpec
 from reviewer.tasks.boards.registry import (
     BoardProviderSpec,
     CredentialFieldSpec,
@@ -104,6 +105,12 @@ def provider_spec() -> BoardProviderSpec:
                 "«API Key» сгенерируйте key, затем по ссылке «Token» рядом с ним "
                 "выдайте токен своей учётной записи. Пара key+token даёт полный "
                 "доступ к аккаунту Trello — храните оба значения как секрет."
+            ),
+            access=ProviderAccessSpec(
+                minimum_permissions="API key и account token с доступом к выбранной доске",
+                read_operations=("boards, lists, cards, checklists и attachments",),
+                write_operations=("создание, перенос, правка и архивация cards",),
+                validation="identity участника и видимость доски",
             ),
         ),
         option_fields=(

--- a/reviewer/tasks/boards/weeek.py
+++ b/reviewer/tasks/boards/weeek.py
@@ -52,6 +52,7 @@ from reviewer.tasks.boards.base import RawTask, TaskListing, TaskListingStats, p
 from reviewer.tasks.boards.errors import BoardProviderError
 from reviewer.tasks.boards.markup import html_to_md, md_to_html
 from reviewer.tasks.boards.pagination import paginate_cursor
+from reviewer.config.provider_access import ProviderAccessSpec
 from reviewer.tasks.boards.registry import (
     BoardProviderSpec,
     CredentialFieldSpec,
@@ -135,6 +136,12 @@ def provider_spec() -> BoardProviderSpec:
                 "Откройте настройки воркспейса Weeek → раздел API и создайте access "
                 "token: все запросы выполняются от имени его создателя, поэтому нужен "
                 "аккаунт с доступом к проекту задач."
+            ),
+            access=ProviderAccessSpec(
+                minimum_permissions="token владельца с read/write к project и board",
+                read_operations=("workspaces, projects, boards, columns, tasks и attachments",),
+                write_operations=("создание, правка и завершение tasks, добавление PR-ссылок",),
+                validation="user identity и видимость project",
             ),
         ),
         default_api_base=_API_BASE,

--- a/reviewer/tasks/boards/yandex_tracker.py
+++ b/reviewer/tasks/boards/yandex_tracker.py
@@ -37,6 +37,7 @@ from reviewer.tasks.boards.attachments import _registrable_domain, fetch_attachm
 from reviewer.tasks.boards.base import RawTask, TaskListing, TaskListingStats, project_prefix
 from reviewer.tasks.boards.errors import BoardProviderError
 from reviewer.tasks.boards.pagination import paginate_page
+from reviewer.config.provider_access import ProviderAccessSpec
 from reviewer.tasks.boards.registry import (
     BoardProviderSpec,
     CredentialFieldSpec,
@@ -135,6 +136,14 @@ def provider_spec() -> BoardProviderSpec:
                 "ID организации — Администрирование → Организации; для Яндекс 360 задайте "
                 "YANDEX_TRACKER_ORG_ID, для Yandex Cloud — YANDEX_TRACKER_CLOUD_ORG_ID "
                 "(там же можно вместо OAuth использовать IAM-токен со схемой Bearer)."
+            ),
+            access=ProviderAccessSpec(
+                minimum_permissions=(
+                    "OAuth scopes tracker:read + tracker:write либо эквивалентная IAM role"
+                ),
+                read_operations=("queues, issues, fields, links и attachments",),
+                write_operations=("создание, правка и transition issues, PR-ссылки",),
+                validation="identity, organization и видимость queue",
             ),
         ),
         default_api_base=_API_BASE,

--- a/reviewer/tasks/boards/yougile.py
+++ b/reviewer/tasks/boards/yougile.py
@@ -127,7 +127,7 @@ def provider_spec() -> BoardProviderSpec:
                 write_operations=(
                     "создание, обновление и завершение задач и нативных подзадач",
                 ),
-                validation="identity, видимость проекта и lifecycle capabilities",
+                validation="identity и видимость проекта",
             ),
             acquisition=acquire_yougile_key,
         ),
@@ -370,7 +370,7 @@ class YougileBoard:
                 "name": company.get("name") or company.get("title"),
             },
             "project": project_info,
-            "capabilities": ["sync", "create", "finish", "attachments"],
+            "capabilities": {"read": True},
             "warnings": [],
         }
 

--- a/reviewer/tasks/boards/yougile.py
+++ b/reviewer/tasks/boards/yougile.py
@@ -30,6 +30,7 @@ from reviewer.tasks.boards.base import (
 from reviewer.tasks.boards.errors import BoardProviderError
 from reviewer.tasks.boards.http import BoardHttpClient
 from reviewer.tasks.boards.markup import html_to_md, md_to_html
+from reviewer.config.provider_access import ProviderAccessSpec
 from reviewer.tasks.boards.registry import (
     BoardProviderSpec,
     CredentialFieldSpec,
@@ -112,7 +113,21 @@ def provider_spec() -> BoardProviderSpec:
             help_url="https://ru.yougile.com/api-v2",
             help_text=(
                 "Получите API key автоматически или используйте официальный ручной flow. "
-                "При allowOnlyOpenId нужен готовый key от API-capable аккаунта."
+                "Admin role не обязателен: нужен API-capable аккаунт с доступом к компании. "
+                "При allowOnlyOpenId используйте готовый key такого аккаунта."
+            ),
+            access=ProviderAccessSpec(
+                minimum_permissions=(
+                    "доступ API-capable аккаунта к компании и чтению/записи задач; "
+                    "admin role не обязателен"
+                ),
+                read_operations=(
+                    "компании, доски, колонки, задачи, чаты и вложения",
+                ),
+                write_operations=(
+                    "создание, обновление и завершение задач и нативных подзадач",
+                ),
+                validation="identity, видимость проекта и lifecycle capabilities",
             ),
             acquisition=acquire_yougile_key,
         ),

--- a/reviewer/tasks/boards/youtrack.py
+++ b/reviewer/tasks/boards/youtrack.py
@@ -19,6 +19,7 @@ from reviewer.tasks.boards.attachments import fetch_attachment, host_allowed, _r
 from reviewer.tasks.boards.base import RawTask, TaskListing, TaskListingStats, project_prefix
 from reviewer.tasks.boards.errors import BoardProviderError
 from reviewer.tasks.boards.http import BoardHttpClient
+from reviewer.config.provider_access import ProviderAccessSpec
 from reviewer.tasks.boards.registry import (
     BoardProviderSpec,
     CredentialFieldSpec,
@@ -120,6 +121,14 @@ def provider_spec() -> BoardProviderSpec:
                 "Account Security URL — только удобная ссылка для bundled Hub. "
                 "При external Hub откройте Profile в YouTrack и следуйте ссылке "
                 "Account Security в профиль Hub."
+            ),
+            access=ProviderAccessSpec(
+                minimum_permissions=(
+                    "permanent token с YouTrack service scope и read/write к задачам проекта"
+                ),
+                read_operations=("задачи, поля, связи и вложения",),
+                write_operations=("создание задач, смена статуса и добавление PR-ссылок",),
+                validation="текущий пользователь и видимость проекта",
             ),
             help_url_builder=_permanent_token_url,
         ),

--- a/tests/config/test_provider_access.py
+++ b/tests/config/test_provider_access.py
@@ -1,0 +1,48 @@
+import pytest
+
+from reviewer.config.provider_access import ProviderAccessSpec, render_provider_access
+
+
+def test_render_provider_access_has_stable_complete_order():
+    access = ProviderAccessSpec(
+        minimum_permissions="Issues: Read and write",
+        read_operations=("читать задачи", "читать комментарии"),
+        write_operations=("создавать задачи", "закрывать задачи"),
+        validation="identity и доступ к проекту",
+    )
+
+    text = render_provider_access(
+        label="Example",
+        help_text="Создайте token.",
+        help_url="https://example.test/token",
+        access=access,
+    )
+
+    markers = (
+        "Example",
+        "Создайте token.",
+        "Минимальные права: Issues: Read and write",
+        "Чтение: читать задачи; читать комментарии",
+        "Запись: создавать задачи; закрывать задачи",
+        "Проверка: identity и доступ к проекту",
+        "https://example.test/token",
+    )
+    positions = [text.index(marker) for marker in markers]
+    assert positions == sorted(positions)
+
+
+@pytest.mark.parametrize(
+    "field",
+    ("minimum_permissions", "read_operations", "write_operations", "validation"),
+)
+def test_provider_access_rejects_empty_contract(field):
+    values = {
+        "minimum_permissions": "read/write",
+        "read_operations": ("read",),
+        "write_operations": ("write",),
+        "validation": "identity",
+    }
+    values[field] = () if field.endswith("operations") else ""
+
+    with pytest.raises(ValueError, match=field):
+        ProviderAccessSpec(**values)

--- a/tests/config/test_provider_credentials.py
+++ b/tests/config/test_provider_credentials.py
@@ -7,6 +7,7 @@ from reviewer.tasks.boards.registry import (
     CredentialFieldSpec,
     ProviderSetupSpec,
 )
+from tests.provider_access import FAKE_PROVIDER_ACCESS
 
 
 def _provider(context):
@@ -25,7 +26,9 @@ YOUGILE_SPEC = BoardProviderSpec(
             default="https://yougile.example/api", aliases=("TASK_BOARD_API_BASE",),
         ),
     ),
-    setup=ProviderSetupSpec("YouGile", "https://example.test", "Use a token."),
+    setup=ProviderSetupSpec(
+        "YouGile", "https://example.test", "Use a token.", FAKE_PROVIDER_ACCESS
+    ),
 )
 
 

--- a/tests/docs/test_board_provider_docs.py
+++ b/tests/docs/test_board_provider_docs.py
@@ -55,6 +55,28 @@ def _matrix_rows(text: str) -> dict[str, list[str]]:
     return rows
 
 
+def test_board_docs_explain_structured_setup_contract():
+    text = _read("docs/board-providers.md")
+    section = text.split("## Configuration", 1)[1].split("## YouGile", 1)[0]
+    for marker in (
+        "minimum permissions",
+        "read operations",
+        "write operations",
+        "validation",
+        "selected provider",
+        "reviewer init",
+    ):
+        assert marker in section
+
+
+def test_yougile_docs_do_not_require_admin_role():
+    text = _read("docs/board-providers.md")
+    section = text.split("## YouGile", 1)[1].split("## YouTrack", 1)[0]
+    assert "admin role is not required" in section
+    assert "API-capable account" in section
+    assert "allowOnlyOpenId" in section
+
+
 def test_capability_matrix_has_one_complete_row_per_registered_provider():
     """Матрица — строка на провайдера; каждая capability-колонка заполнена."""
     rows = _matrix_rows(_read("docs/board-providers.md"))

--- a/tests/docs/test_readme_onboarding.py
+++ b/tests/docs/test_readme_onboarding.py
@@ -230,15 +230,54 @@ def test_security_discloses_both_external_code_data_paths():
         assert "AI model provider" in section
 
 
-def test_gitlab_only_check_limitation_is_explicit():
+def test_readmes_document_configuration_ownership_and_scenarios():
+    cases = (
+        (
+            "README.md",
+            "### Configuration ownership",
+            ("Single repository", "Second repository", "CI / server"),
+        ),
+        (
+            "README.ru.md",
+            "### Владение конфигурацией",
+            ("Один репозиторий", "Второй репозиторий", "CI / server"),
+        ),
+    )
+    for filename, heading, scenarios in cases:
+        section = _section(_read(filename), heading)
+        for marker in (
+            "global `.env`",
+            "home global YAML",
+            "home per-repo YAML",
+            "committed `.review.yml`",
+            "git remote / CLI",
+            "Postgres / Neo4j",
+            "reviewer init --scope repo",
+            "reviewer config show --repo",
+        ):
+            assert marker in section, (filename, marker)
+        for scenario in scenarios:
+            assert scenario in section, (filename, scenario)
+
+
+def test_readmes_document_vcs_token_matrix_and_check_semantics():
     for filename in ("README.md", "README.ru.md"):
         text = _read(filename)
-        assert "`reviewer check`" in text
-        assert "`GITHUB_TOKEN`" in text
-        assert "`GITLAB_TOKEN`" in text
-        assert "GitLab-only" in text
-        assert "dry-run `/rag-reviewer:review-pr`" in text
-        assert "validate `GITLAB_TOKEN` by indexing" not in text
+        section = _section(text, "### VCS credentials")
+        for marker in (
+            "`GITHUB_TOKEN`",
+            "Pull requests: Read and write",
+            "Contents: Read",
+            "`GITLAB_TOKEN`",
+            "`api` scope",
+            "`/user`",
+            "`/api/v4/user`",
+            "identity",
+            "repository permissions",
+        ):
+            assert marker in section, (filename, marker)
+        assert "GitLab-only" not in text
+        assert "dry-run `/rag-reviewer:review-pr`" not in text
 
 
 def test_team_route_validates_the_selected_board_project():

--- a/tests/entrypoints/test_check_boards.py
+++ b/tests/entrypoints/test_check_boards.py
@@ -14,6 +14,7 @@ from reviewer.tasks.boards.registry import (
     CredentialFieldSpec,
     ProviderSetupSpec,
 )
+from tests.provider_access import FAKE_PROVIDER_ACCESS
 
 
 class CheckProvider:
@@ -84,6 +85,7 @@ def _registry(provider: CheckProvider) -> BoardProviderRegistry:
                     "Fake",
                     "https://fake.example/setup",
                     "Create a token.",
+                    FAKE_PROVIDER_ACCESS,
                 ),
             )
         ]

--- a/tests/entrypoints/test_check_vcs.py
+++ b/tests/entrypoints/test_check_vcs.py
@@ -1,0 +1,99 @@
+import httpx
+
+from reviewer.config.settings import Settings
+from reviewer.entrypoints.cli import _check_vcs_providers
+
+
+class _Response:
+    def __init__(self, status_code, payload):
+        self.status_code = status_code
+        self._payload = payload
+
+    def json(self):
+        return self._payload
+
+
+def test_check_accepts_gitlab_only_and_uses_configured_base(monkeypatch, capsys):
+    seen = []
+
+    def get(url, **kwargs):
+        seen.append((url, kwargs["headers"]))
+        return _Response(200, {"username": "bot"})
+
+    monkeypatch.setattr(httpx, "get", get)
+    failed = _check_vcs_providers(
+        Settings(
+            _env_file=None,
+            github_token="",
+            gitlab_token="gl-secret",
+            gitlab_url="https://gitlab.example",
+        )
+    )
+    output = capsys.readouterr().out
+
+    assert failed is False
+    assert seen == [
+        (
+            "https://gitlab.example/api/v4/user",
+            {"PRIVATE-TOKEN": "gl-secret"},
+        )
+    ]
+    assert "GitLab API: аутентификация OK" in output
+    assert "gl-secret" not in output
+
+
+def test_check_requires_at_least_one_vcs_token(capsys):
+    failed = _check_vcs_providers(
+        Settings(
+            _env_file=None,
+            github_token="",
+            gitlab_token="",
+        )
+    )
+    output = capsys.readouterr().out
+
+    assert failed is True
+    assert "не настроен ни один VCS token" in output
+
+
+def test_check_validates_both_configured_tokens(monkeypatch, capsys):
+    urls = []
+
+    def get(url, **_kwargs):
+        urls.append(url)
+        return _Response(200, {"login": "gh", "username": "gl"})
+
+    monkeypatch.setattr(httpx, "get", get)
+    failed = _check_vcs_providers(
+        Settings(
+            _env_file=None,
+            github_token="gh-secret",
+            gitlab_token="gl-secret",
+        )
+    )
+    output = capsys.readouterr().out
+
+    assert failed is False
+    assert urls == [
+        "https://api.github.com/user",
+        "https://gitlab.com/api/v4/user",
+    ]
+    assert "GitHub API: аутентификация OK" in output
+    assert "GitLab API: аутентификация OK" in output
+
+
+def test_check_vcs_failure_does_not_echo_secret(monkeypatch, capsys):
+    monkeypatch.setattr(
+        httpx,
+        "get",
+        lambda *_args, **_kwargs: _Response(401, {"token": "gh-secret"}),
+    )
+
+    failed = _check_vcs_providers(
+        Settings(_env_file=None, github_token="gh-secret", gitlab_token="")
+    )
+    output = capsys.readouterr().out
+
+    assert failed is True
+    assert "GitHub API: HTTP 401" in output
+    assert "gh-secret" not in output

--- a/tests/entrypoints/test_check_vcs.py
+++ b/tests/entrypoints/test_check_vcs.py
@@ -1,4 +1,5 @@
 import httpx
+import pytest
 
 from reviewer.config.settings import Settings
 from reviewer.entrypoints.cli import _check_vcs_providers
@@ -82,6 +83,21 @@ def test_check_validates_both_configured_tokens(monkeypatch, capsys):
     assert "GitLab API: аутентификация OK" in output
 
 
+def test_check_accepts_github_app_bot_identity(monkeypatch, capsys):
+    monkeypatch.setattr(
+        httpx,
+        "get",
+        lambda *_args, **_kwargs: _Response(200, {"login": "github-actions[bot]"}),
+    )
+
+    failed = _check_vcs_providers(
+        Settings(_env_file=None, github_token="gh-secret", gitlab_token="")
+    )
+
+    assert failed is False
+    assert "identity: github-actions[bot]" in capsys.readouterr().out
+
+
 def test_check_vcs_failure_does_not_echo_secret(monkeypatch, capsys):
     monkeypatch.setattr(
         httpx,
@@ -97,3 +113,74 @@ def test_check_vcs_failure_does_not_echo_secret(monkeypatch, capsys):
     assert failed is True
     assert "GitHub API: HTTP 401" in output
     assert "gh-secret" not in output
+
+
+@pytest.mark.parametrize(
+    "payload",
+    (
+        {},
+        {"login": None},
+        {"login": ""},
+        {"login": "   "},
+        {"login": 123},
+        {"login": "\x1b"},
+        {"login": "not a username"},
+        [],
+    ),
+)
+def test_check_rejects_missing_or_invalid_identity(monkeypatch, capsys, payload):
+    monkeypatch.setattr(
+        httpx,
+        "get",
+        lambda *_args, **_kwargs: _Response(200, payload),
+    )
+
+    failed = _check_vcs_providers(
+        Settings(_env_file=None, github_token="gh-secret", gitlab_token="")
+    )
+    output = capsys.readouterr().out
+
+    assert failed is True
+    assert "identity отсутствует или некорректен" in output
+    assert "аутентификация OK" not in output
+
+
+def test_check_sanitizes_untrusted_identity(monkeypatch, capsys):
+    monkeypatch.setattr(
+        httpx,
+        "get",
+        lambda *_args, **_kwargs: _Response(
+            200,
+            {"login": "gh-secret\nforged", "username": "gl-secret\nforged"},
+        ),
+    )
+
+    failed = _check_vcs_providers(
+        Settings(_env_file=None, github_token="gh-secret", gitlab_token="gl-secret")
+    )
+    output = capsys.readouterr().out
+
+    assert failed is True
+    assert "gh-secret" not in output
+    assert "gl-secret" not in output
+    assert "\nforged" not in output
+    assert "аутентификация OK" not in output
+    assert output.count("identity отсутствует или некорректен") == 2
+
+
+def test_check_redacts_identity_before_normalization(monkeypatch, capsys):
+    token = " gh-secret "
+    monkeypatch.setattr(
+        httpx,
+        "get",
+        lambda *_args, **_kwargs: _Response(200, {"login": token}),
+    )
+
+    failed = _check_vcs_providers(
+        Settings(_env_file=None, github_token=token, gitlab_token="")
+    )
+    output = capsys.readouterr().out
+
+    assert failed is True
+    assert "gh-secret" not in output
+    assert "аутентификация OK" not in output

--- a/tests/entrypoints/test_cli.py
+++ b/tests/entrypoints/test_cli.py
@@ -331,6 +331,7 @@ def test_check_all_ok(
     s = MagicMock()
     s.voyage_api_key = "key"
     s.github_token = "key"
+    s.gitlab_token = ""
     s.pg_dsn = "pg://test"
     s.pg_pool_min_size = 1
     s.pg_pool_max_size = 4

--- a/tests/entrypoints/test_cli_init_onboarding.py
+++ b/tests/entrypoints/test_cli_init_onboarding.py
@@ -54,6 +54,8 @@ def _forbid_noninteractive_side_effects(monkeypatch) -> None:
         "reviewer.tasks.boards.setup.configure_board_provider",
         fail("provider setup"),
     )
+    monkeypatch.setattr(cli_module, "_select_vcs_provider", fail("VCS selection"))
+    monkeypatch.setattr(cli_module, "_prompt_vcs_provider", fail("VCS setup"))
     monkeypatch.setattr(cli_module, "_run_codex_target", fail("Codex install"))
     monkeypatch.setattr("subprocess.run", fail("reviewer check"))
     monkeypatch.setattr(cli_module, "_config_context", fail("full config show"))
@@ -354,7 +356,7 @@ def test_init_final_rejection_or_abort_happens_before_first_write(
         "reviewer.entrypoints.cli.apply_repository_config",
         lambda _plan: pytest.fail("repo write called"),
     )
-    confirmations = iter([False, "final"])
+    confirmations = iter([False, False, "final"])
 
     def confirm(*_args, **_kwargs):
         answer = next(confirmations)

--- a/tests/install/test_board_setup.py
+++ b/tests/install/test_board_setup.py
@@ -60,6 +60,7 @@ class FakeIO:
         self.opened.append(url)
 
     def echo(self, text: str) -> None:
+        self.events.append("echo")
         self.messages.append(text)
 
     def save(self, values: dict[str, str]) -> None:
@@ -166,6 +167,32 @@ def test_setup_uses_fail_closed_validation_report_sanitizer() -> None:
     ):
         assert forbidden not in rendered
     assert provider.closed is True
+
+
+def test_setup_prints_access_contract_before_first_secret_prompt() -> None:
+    provider = FakeProvider({"status": "ok", "warnings": []})
+    spec = replace(jira_provider_spec(), factory=lambda _context: provider)
+    io = FakeIO(
+        answers={
+            "Jira Cloud site URL": "https://acme.atlassian.net",
+            "Atlassian account email": "bot@example.test",
+            "Atlassian API token": "jira-secret",
+        },
+        confirms=[False],
+    )
+
+    configure_board_provider(spec, io)
+
+    rendered = "\n".join(io.messages)
+    assert "Минимальные права:" in rendered
+    assert "Чтение:" in rendered
+    assert "Запись:" in rendered
+    assert "Проверка:" in rendered
+    assert io.events.index("echo") < next(
+        index
+        for index, event in enumerate(io.events)
+        if event == "prompt:Atlassian API token"
+    )
 
 
 def test_jira_setup_opens_official_page_only_after_confirmation_and_validates() -> None:

--- a/tests/install/test_codex_cli.py
+++ b/tests/install/test_codex_cli.py
@@ -97,8 +97,9 @@ def test_interactive_init_uses_the_canonical_codex_flow(monkeypatch, tmp_path):
             field.key: field.default for group in groups for field in group.fields
         },
     )
-    # board setup = no, write = yes, reviewer check = no, Codex install = yes
-    answers = iter([False, True, False, True])
+    # VCS setup = no, board setup = no, write = yes, reviewer check = no,
+    # Codex install = yes
+    answers = iter([False, False, True, False, True])
     monkeypatch.setattr("click.confirm", lambda prompt, default=True: next(answers))
     monkeypatch.setattr("reviewer.entrypoints.cli._shutil.which", lambda name: "/opt/codex")
     monkeypatch.setattr(

--- a/tests/install/test_install_wizard.py
+++ b/tests/install/test_install_wizard.py
@@ -9,6 +9,7 @@ from reviewer.tasks.boards.registry import (
     BoardProviderSpec,
     ProviderSetupSpec,
 )
+from tests.provider_access import FAKE_PROVIDER_ACCESS
 
 
 REMOVED_STANDARD_KEYS = {
@@ -267,6 +268,7 @@ def test_init_noninteractive_modes_never_touch_provider_setup_stages(
                     label="Sentinel",
                     help_url="https://sentinel.example/setup",
                     help_text="Sentinel setup.",
+                    access=FAKE_PROVIDER_ACCESS,
                     acquisition=acquire,
                 ),
             )

--- a/tests/install/test_install_wizard.py
+++ b/tests/install/test_install_wizard.py
@@ -329,7 +329,7 @@ def test_init_interactive_configures_selected_registry_provider(tmp_path, monkey
             "JIRA_API_TOKEN": "jira-secret",
         },
     )
-    answers = iter([True, True, False])
+    answers = iter([False, True, True, False])
     monkeypatch.setattr("click.confirm", lambda *_args, **_kwargs: next(answers))
     monkeypatch.setattr("reviewer.entrypoints.cli._shutil.which", lambda _name: None)
 
@@ -341,6 +341,102 @@ def test_init_interactive_configures_selected_registry_provider(tmp_path, monkey
     assert "JIRA_BASE_URL=https://acme.atlassian.net" in content
     assert "JIRA_EMAIL=bot@example.test" in content
     assert "JIRA_API_TOKEN=jira-secret" in content
+
+
+@pytest.mark.parametrize(
+    ("selected", "prompted", "not_prompted"),
+    [
+        ("github", {"GITHUB_TOKEN"}, {"GITLAB_URL", "GITLAB_TOKEN"}),
+        ("gitlab", {"GITLAB_URL", "GITLAB_TOKEN"}, {"GITHUB_TOKEN"}),
+    ],
+)
+def test_init_prompts_only_selected_vcs_provider(
+    selected,
+    prompted,
+    not_prompted,
+    tmp_path,
+    monkeypatch,
+):
+    dest = tmp_path / ".env"
+    seen = []
+    monkeypatch.setattr("reviewer.install.default_env_path", lambda: dest)
+    monkeypatch.setattr(
+        "reviewer.install.prompt_groups",
+        lambda groups, current, yes: {
+            field.key: current.get(field.key, "") or field.default
+            for group in groups
+            for field in group.fields
+        },
+    )
+    monkeypatch.setattr(
+        "reviewer.entrypoints.cli._select_vcs_provider",
+        lambda *_args, **_kwargs: selected,
+        raising=False,
+    )
+
+    def prompt_vcs(_inst, spec, current):
+        seen.extend(field.key for field in spec.credential_fields)
+        return {
+            field.key: current.get(field.key, "") or field.default
+            for field in spec.credential_fields
+        }
+
+    monkeypatch.setattr(
+        "reviewer.entrypoints.cli._prompt_vcs_provider",
+        prompt_vcs,
+        raising=False,
+    )
+    monkeypatch.setattr(
+        "click.confirm",
+        lambda text, **_kwargs: (
+            "VCS provider" in text or "Записать показанные изменения" in text
+        ),
+    )
+    monkeypatch.setattr("reviewer.entrypoints.cli._shutil.which", lambda _name: None)
+
+    result = CliRunner().invoke(cli, ["init", "--scope", "global"])
+
+    assert result.exit_code == 0, result.output
+    assert set(seen) == prompted
+    assert set(seen).isdisjoint(not_prompted)
+
+
+def test_unselected_existing_vcs_credentials_survive(tmp_path, monkeypatch):
+    dest = tmp_path / ".env"
+    dest.write_text("GITLAB_TOKEN=keep-me\n", encoding="utf-8")
+    monkeypatch.setattr("reviewer.install.default_env_path", lambda: dest)
+    monkeypatch.setattr(
+        "reviewer.install.prompt_groups",
+        lambda groups, current, yes: {
+            field.key: current.get(field.key, "") or field.default
+            for group in groups
+            for field in group.fields
+        },
+    )
+    monkeypatch.setattr(
+        "reviewer.entrypoints.cli._select_vcs_provider",
+        lambda *_args, **_kwargs: "github",
+        raising=False,
+    )
+    monkeypatch.setattr(
+        "reviewer.entrypoints.cli._prompt_vcs_provider",
+        lambda *_args, **_kwargs: {"GITHUB_TOKEN": "new-github"},
+        raising=False,
+    )
+    monkeypatch.setattr(
+        "click.confirm",
+        lambda text, **_kwargs: (
+            "VCS provider" in text or "Записать показанные изменения" in text
+        ),
+    )
+    monkeypatch.setattr("reviewer.entrypoints.cli._shutil.which", lambda _name: None)
+
+    result = CliRunner().invoke(cli, ["init", "--scope", "global"])
+
+    assert result.exit_code == 0, result.output
+    content = dest.read_text(encoding="utf-8")
+    assert "GITHUB_TOKEN=new-github" in content
+    assert "GITLAB_TOKEN=keep-me" in content
 
 
 def test_init_interactive_common_board_fields_do_not_require_rest_provider(
@@ -361,7 +457,7 @@ def test_init_interactive_common_board_fields_do_not_require_rest_provider(
         return values
 
     monkeypatch.setattr("reviewer.install.prompt_groups", prompt_groups)
-    answers = iter([False, True, False])
+    answers = iter([False, False, True, False])
     monkeypatch.setattr("click.confirm", lambda *_args, **_kwargs: next(answers))
     monkeypatch.setattr("reviewer.entrypoints.cli._shutil.which", lambda _name: None)
 

--- a/tests/mcp/test_board_provider_extensibility.py
+++ b/tests/mcp/test_board_provider_extensibility.py
@@ -13,6 +13,7 @@ from reviewer.tasks.boards.registry import (
     ProviderOptionSpec,
     ProviderSetupSpec,
 )
+from tests.provider_access import FAKE_PROVIDER_ACCESS
 from reviewer.tasks.sync import SyncService
 
 
@@ -146,7 +147,9 @@ def _service(*, secret_warning=False, fail_targets=False):
             ProviderOptionSpec("lane", "Lane"),
             ProviderOptionSpec("status_field", "Status field"),
         ),
-        setup=ProviderSetupSpec("Fake", "https://fake/help", "Configure."),
+        setup=ProviderSetupSpec(
+            "Fake", "https://fake/help", "Configure.", FAKE_PROVIDER_ACCESS
+        ),
     )
     registry = BoardProviderRegistry([spec])
     credentials = ProviderCredentialSource(values={"FAKE_TOKEN": "runtime-secret"})

--- a/tests/mcp/test_create_subtasks.py
+++ b/tests/mcp/test_create_subtasks.py
@@ -22,6 +22,7 @@ from reviewer.tasks.boards.registry import (
     ProviderOptionSpec,
     ProviderSetupSpec,
 )
+from tests.provider_access import FAKE_PROVIDER_ACCESS
 from reviewer.tasks.subtask_store import OperationConflictError
 from reviewer.tasks.subtasks import (
     SubtaskBatchResult,
@@ -265,7 +266,9 @@ def _service(
             board_type="fake",
             factory=factory.factory,
             credential_fields=(CredentialFieldSpec("FAKE_TOKEN", "Token", secret=True),),
-            setup=ProviderSetupSpec("Fake", "https://fake/help", "Configure."),
+            setup=ProviderSetupSpec(
+                "Fake", "https://fake/help", "Configure.", FAKE_PROVIDER_ACCESS
+            ),
             option_fields=(ProviderOptionSpec("lane", "Lane"),),
             capabilities=capabilities,
         )

--- a/tests/mcp/test_create_task.py
+++ b/tests/mcp/test_create_task.py
@@ -14,6 +14,7 @@ from reviewer.tasks.boards.registry import (
     ProviderBuildContext,
     ProviderSetupSpec,
 )
+from tests.provider_access import FAKE_PROVIDER_ACCESS
 
 
 class _Settings:
@@ -96,7 +97,9 @@ def service():
                 board_type=board_type,
                 factory=factory,
                 credential_fields=(CredentialFieldSpec(env, "Token", secret=True),),
-                setup=ProviderSetupSpec(board_type, "https://fake/help", "Configure."),
+                setup=ProviderSetupSpec(
+                    board_type, "https://fake/help", "Configure.", FAKE_PROVIDER_ACCESS
+                ),
             ))
             values[env] = "secret"
         svc._board_registry = BoardProviderRegistry(specs)

--- a/tests/mcp/test_finish_task.py
+++ b/tests/mcp/test_finish_task.py
@@ -10,6 +10,7 @@ from reviewer.tasks.boards.registry import (
     ProviderOptionSpec,
     ProviderSetupSpec,
 )
+from tests.provider_access import FAKE_PROVIDER_ACCESS
 
 
 class _FakeTaskService:
@@ -108,7 +109,9 @@ class _Svc(MCPReviewService):
                 factory=factory,
                 credential_fields=(CredentialFieldSpec(env, "Token", secret=True),),
                 option_fields=(ProviderOptionSpec("status_field", "Status field"),),
-                setup=ProviderSetupSpec(board_type, "https://fake/help", "Configure."),
+                setup=ProviderSetupSpec(
+                    board_type, "https://fake/help", "Configure.", FAKE_PROVIDER_ACCESS
+                ),
             ))
             values[env] = "secret"
         self._board_registry = BoardProviderRegistry(specs)

--- a/tests/mcp/test_get_board_targets.py
+++ b/tests/mcp/test_get_board_targets.py
@@ -10,6 +10,7 @@ from reviewer.tasks.boards.registry import (
     ProviderBuildContext,
     ProviderSetupSpec,
 )
+from tests.provider_access import FAKE_PROVIDER_ACCESS
 
 
 class _Provider:
@@ -78,7 +79,9 @@ class _Svc(MCPReviewService):
                 board_type=board_type,
                 factory=factory,
                 credential_fields=(CredentialFieldSpec(env, "Token", secret=True),),
-                setup=ProviderSetupSpec(board_type, "https://fake/help", "Configure."),
+                setup=ProviderSetupSpec(
+                    board_type, "https://fake/help", "Configure.", FAKE_PROVIDER_ACCESS
+                ),
                 capabilities=capabilities,
             ))
             values[env] = "secret"

--- a/tests/provider_access.py
+++ b/tests/provider_access.py
@@ -1,0 +1,9 @@
+from reviewer.config.provider_access import ProviderAccessSpec
+
+
+FAKE_PROVIDER_ACCESS = ProviderAccessSpec(
+    minimum_permissions="test read/write",
+    read_operations=("read test data",),
+    write_operations=("write test data",),
+    validation="test identity",
+)

--- a/tests/skills/test_configure_review_skill.py
+++ b/tests/skills/test_configure_review_skill.py
@@ -293,6 +293,54 @@ def test_skill_keeps_filter_generic_and_credentials_out_of_policy():
     assert re.search(r"Never read, request,\s+display, or write credential values", text)
 
 
+def test_skill_runs_non_disclosing_preflight_before_reading_yaml():
+    text = SKILL.read_text(encoding="utf-8")
+    preflight = text.index("## Safe YAML preflight")
+    first_read = text.index("read the selected file", preflight)
+
+    assert preflight < first_read
+    for marker in (
+        "before any tool call that can return file contents",
+        "safe/blocked",
+        "never matching lines, values, or exception text",
+        "Do not use Read or Grep",
+        "Only after a safe result",
+    ):
+        assert marker in text
+
+
+def test_skill_rejects_ambiguous_yaml_before_mutation():
+    text = SKILL.read_text(encoding="utf-8")
+    preflight = text.split("## Safe YAML preflight", 1)[1].split("## Pipeline", 1)[0]
+
+    for marker in (
+        "duplicate mapping keys",
+        "duplicate `repository`",
+        "duplicate branch fields",
+        "anchors",
+        "aliases",
+        "merge keys",
+    ):
+        assert marker in preflight
+    assert "before reading or mutating" in preflight
+
+
+def test_skill_preflight_rejects_symlinked_parents_and_defines_safe_create():
+    text = SKILL.read_text(encoding="utf-8")
+    preflight = text.split("## Safe YAML preflight", 1)[1].split("## Pipeline", 1)[0]
+
+    for marker in (
+        "every existing parent path component",
+        "home config root",
+        "Missing destinations",
+        "including a missing home config root",
+        "nearest existing parent",
+        "remains inside",
+        "re-check immediately before writing",
+    ):
+        assert marker in preflight
+
+
 def test_skill_manages_primary_and_index_branches():
     section = _branch_section()
     assert "repository.primary_branch" in section

--- a/tests/skills/test_configure_review_skill.py
+++ b/tests/skills/test_configure_review_skill.py
@@ -9,6 +9,13 @@ SKILL = (Path(__file__).resolve().parents[2]
          / "plugin" / "skills" / "configure-review" / "SKILL.md")
 
 
+def _branch_section() -> str:
+    text = SKILL.read_text(encoding="utf-8")
+    match = re.search(r"## Repository branches.*?(?=\n## )", text, re.DOTALL)
+    assert match
+    return match.group()
+
+
 def test_skill_instructs_russian_output():
     text = SKILL.read_text(encoding="utf-8")
     assert "Always answer the user in Russian" in text
@@ -284,3 +291,56 @@ def test_skill_keeps_filter_generic_and_credentials_out_of_policy():
 
     assert "Never put `sync_filter` under `options`" in text
     assert re.search(r"Never read, request,\s+display, or write credential values", text)
+
+
+def test_skill_manages_primary_and_index_branches():
+    section = _branch_section()
+    assert "repository.primary_branch" in section
+    assert "repository.index_branches" in section
+    assert "ordered unique" in section
+    assert "must be present in" in section
+
+
+def test_skill_resolves_repo_offline_and_shows_effective_source():
+    section = _branch_section()
+    assert "git rev-parse --show-toplevel" in section
+    assert "git remote get-url origin" in section
+    assert section.count("reviewer config show --repo <owner/name> --json") >= 2
+    for forbidden in ("git fetch", "git ls-remote", "git remote show"):
+        assert forbidden not in section
+    assert "source" in section
+
+
+def test_skill_writes_branches_only_to_home_per_repo():
+    section = _branch_section()
+    assert "$XDG_CONFIG_HOME/rag-reviewer/repos/<owner>/<name>.yml" in section
+    assert "Never write `repository` to committed `.review.yml`" in section
+    assert "even when committed policy is selected" in section
+
+
+def test_skill_preserves_branch_yaml_without_whole_file_dump():
+    section = _branch_section()
+    for marker in (
+        "line-oriented patch",
+        "top-level keys",
+        "unknown repository subkeys",
+        "comments",
+        "line endings",
+        "surrounding YAML style",
+    ):
+        assert marker in section
+    assert "Never serialize the complete file with `yaml.safe_dump`" in section
+
+
+def test_skill_previews_confirms_and_verifies_branch_change():
+    section = _branch_section()
+    assert "old and new" in section
+    assert "final confirmation" in section
+    assert "exact primary/index/source" in section
+
+
+def test_skill_never_runs_branch_followups():
+    section = _branch_section()
+    assert "rag-reviewer:sync-codebase" in section
+    assert "do not run" in section.lower()
+    assert "rag-reviewer:summarize-subsystems" not in section

--- a/tests/tasks/boards/provider_fakes.py
+++ b/tests/tasks/boards/provider_fakes.py
@@ -8,6 +8,7 @@ from reviewer.tasks.boards.registry import (
     ProviderBuildContext,
     ProviderSetupSpec,
 )
+from tests.provider_access import FAKE_PROVIDER_ACCESS
 
 
 class FakeBoard:
@@ -62,5 +63,6 @@ def fake_provider_spec(*, factory=None, board_type: str = "fake") -> BoardProvid
             label="Fake",
             help_url="https://example.test/fake",
             help_text="Configure the fake provider.",
+            access=FAKE_PROVIDER_ACCESS,
         ),
     )

--- a/tests/tasks/boards/test_jira_targets.py
+++ b/tests/tasks/boards/test_jira_targets.py
@@ -16,6 +16,7 @@ def test_discovery_deduplicates_status_ids_and_lists_issue_type_choices() -> Non
                         for name in (
                             "BROWSE_PROJECTS",
                             "CREATE_ISSUES",
+                            "EDIT_ISSUES",
                             "TRANSITION_ISSUES",
                         )
                     }
@@ -54,6 +55,7 @@ def test_discovery_warns_when_account_is_read_only() -> None:
                     "permissions": {
                         "BROWSE_PROJECTS": {"havePermission": True},
                         "CREATE_ISSUES": {"havePermission": False},
+                        "EDIT_ISSUES": {"havePermission": False},
                         "TRANSITION_ISSUES": {"havePermission": False},
                     }
                 },
@@ -64,6 +66,7 @@ def test_discovery_warns_when_account_is_read_only() -> None:
 
     assert result["warnings"] == [
         "missing Jira permission: CREATE_ISSUES",
+        "missing Jira permission: EDIT_ISSUES",
         "missing Jira permission: TRANSITION_ISSUES",
     ]
     assert result["targets"]
@@ -79,6 +82,7 @@ def test_discovery_warns_when_transition_permission_is_missing() -> None:
                     "permissions": {
                         "BROWSE_PROJECTS": {"havePermission": True},
                         "CREATE_ISSUES": {"havePermission": True},
+                        "EDIT_ISSUES": {"havePermission": True},
                         "TRANSITION_ISSUES": {"havePermission": False},
                     }
                 },
@@ -103,6 +107,7 @@ def test_discovery_does_not_request_statuses_without_browse_permission() -> None
                 "permissions": {
                     "BROWSE_PROJECTS": {"havePermission": False},
                     "CREATE_ISSUES": {"havePermission": False},
+                    "EDIT_ISSUES": {"havePermission": False},
                     "TRANSITION_ISSUES": {"havePermission": False},
                 }
             },
@@ -116,5 +121,6 @@ def test_discovery_does_not_request_statuses_without_browse_permission() -> None
     assert result["warnings"] == [
         "missing Jira permission: BROWSE_PROJECTS",
         "missing Jira permission: CREATE_ISSUES",
+        "missing Jira permission: EDIT_ISSUES",
         "missing Jira permission: TRANSITION_ISSUES",
     ]

--- a/tests/tasks/boards/test_jira_validation.py
+++ b/tests/tasks/boards/test_jira_validation.py
@@ -8,17 +8,21 @@ from tests.tasks.boards.jira_helpers import board
 
 
 def test_validation_reports_identity_project_and_independent_capabilities() -> None:
+    permission_queries: list[str] = []
+
     def handler(request: httpx.Request) -> httpx.Response:
         if request.url.path.endswith("/myself"):
             return httpx.Response(200, json={"accountId": "abc", "displayName": "Reviewer Bot"})
         if "/project/" in request.url.path:
             return httpx.Response(200, json={"id": "10000", "key": "PRI"})
+        permission_queries.append(request.url.params["permissions"])
         return httpx.Response(
             200,
             json={
                 "permissions": {
                     "BROWSE_PROJECTS": {"havePermission": True},
                     "CREATE_ISSUES": {"havePermission": False},
+                    "EDIT_ISSUES": {"havePermission": False},
                     "TRANSITION_ISSUES": {"havePermission": False},
                 }
             },
@@ -31,9 +35,13 @@ def test_validation_reports_identity_project_and_independent_capabilities() -> N
         "capabilities": {"read": True, "create": False, "transition": False},
         "warnings": [
             "missing Jira permission: CREATE_ISSUES",
+            "missing Jira permission: EDIT_ISSUES",
             "missing Jira permission: TRANSITION_ISSUES",
         ],
     }
+    assert permission_queries == [
+        "BROWSE_PROJECTS,CREATE_ISSUES,EDIT_ISSUES,TRANSITION_ISSUES"
+    ]
 
 
 def test_validation_without_project_only_checks_identity() -> None:
@@ -48,7 +56,7 @@ def test_validation_without_project_only_checks_identity() -> None:
     assert result["project"] is None
     assert result["capabilities"] == {"read": True}
     assert result["warnings"] == [
-        "Jira project was not checked; create and transition permissions are unknown."
+        "Jira project was not checked; create, edit, and transition permissions are unknown."
     ]
     assert calls == ["/rest/api/3/myself"]
 

--- a/tests/tasks/boards/test_registry.py
+++ b/tests/tasks/boards/test_registry.py
@@ -18,6 +18,7 @@ from reviewer.tasks.boards.registry import (
     ProviderSetupSpec,
     default_board_registry,
 )
+from tests.provider_access import FAKE_PROVIDER_ACCESS
 
 EXPECTED_BOARD_TYPES = (
     "yougile",
@@ -103,7 +104,9 @@ def fake_spec(
         board_type=board_type,
         factory=factory or (lambda _: _CompleteProvider()),
         credential_fields=(CredentialFieldSpec(secret_env, "Token", secret=True),),
-        setup=ProviderSetupSpec("Fake", "https://example.test/help", "Create a token."),
+        setup=ProviderSetupSpec(
+            "Fake", "https://example.test/help", "Create a token.", FAKE_PROVIDER_ACCESS
+        ),
         option_fields=options,
         capabilities=capabilities,
     )
@@ -368,6 +371,17 @@ def test_default_registry_registers_every_complete_provider_in_order():
     registry = default_board_registry()
 
     assert registry.registered_types() == EXPECTED_BOARD_TYPES
+
+
+def test_every_board_provider_documents_access_contract():
+    registry = default_board_registry()
+
+    for board_type in registry.registered_types():
+        access = registry.get(board_type).setup.access
+        assert access.minimum_permissions, board_type
+        assert access.read_operations, board_type
+        assert access.write_operations, board_type
+        assert access.validation, board_type
 
 
 def test_default_registry_builds_and_validates_every_registered_provider():

--- a/tests/tasks/boards/test_yougile_targets.py
+++ b/tests/tasks/boards/test_yougile_targets.py
@@ -1,7 +1,7 @@
 import pytest
 
 from reviewer.tasks.boards.errors import BoardProviderError
-from reviewer.tasks.boards.yougile import YougileBoard
+from reviewer.tasks.boards.yougile import YougileBoard, provider_spec
 
 
 class _Resp:
@@ -113,6 +113,15 @@ def test_yougile_validate_connection_resolves_exact_requested_project():
         "key": "PRI",
         "name": "PRI",
     }
+    assert result["capabilities"] == {"read": True}
+
+
+def test_yougile_access_metadata_matches_non_mutating_validation():
+    validation = provider_spec().setup.access.validation
+
+    assert "identity" in validation
+    assert "видимость проекта" in validation
+    assert "lifecycle" not in validation
 
 
 def test_yougile_validate_connection_rejects_inaccessible_requested_project():

--- a/tests/test_install_wizard.py
+++ b/tests/test_install_wizard.py
@@ -1,5 +1,11 @@
 """Тесты registry-driven wizard-групп installer."""
-from reviewer.install import WIZARD_GROUPS, board_env_group, common_board_env_fields
+from reviewer.install import (
+    VCS_SETUPS,
+    WIZARD_GROUPS,
+    board_env_group,
+    common_board_env_fields,
+    vcs_env_group,
+)
 from reviewer.tasks.boards.registry import (
     BoardProviderRegistry,
     BoardProviderSpec,
@@ -44,6 +50,27 @@ def test_wizard_has_gitlab_vcs_fields():
     assert "GITLAB_TOKEN" in keys
     assert "GITLAB_URL" in keys
     assert "VCS_PROVIDER" in keys
+
+
+def test_vcs_catalog_declares_github_and_gitlab_access():
+    assert tuple(VCS_SETUPS) == ("github", "gitlab")
+    assert [field.key for field in VCS_SETUPS["github"].credential_fields] == [
+        "GITHUB_TOKEN"
+    ]
+    assert [field.key for field in VCS_SETUPS["gitlab"].credential_fields] == [
+        "GITLAB_URL",
+        "GITLAB_TOKEN",
+    ]
+    github_permissions = VCS_SETUPS["github"].access.minimum_permissions
+    assert "Pull requests: Read and write" in github_permissions
+    assert "Contents: Read" in github_permissions
+    assert VCS_SETUPS["gitlab"].access.minimum_permissions == "PAT/project token with api scope"
+
+
+def test_vcs_group_is_canonical_union_with_provider_fallback():
+    keys = [field.key for field in vcs_env_group().fields]
+    assert keys == ["VCS_PROVIDER", "GITHUB_TOKEN", "GITLAB_URL", "GITLAB_TOKEN"]
+    assert len(keys) == len(set(keys))
 
 
 def test_wizard_has_yougile_api_base():

--- a/tests/test_install_wizard.py
+++ b/tests/test_install_wizard.py
@@ -6,6 +6,7 @@ from reviewer.tasks.boards.registry import (
     CredentialFieldSpec,
     ProviderSetupSpec,
 )
+from tests.provider_access import FAKE_PROVIDER_ACCESS
 
 
 REMOVED_STANDARD_KEYS = {
@@ -78,6 +79,7 @@ def test_board_group_uses_registry_metadata_without_legacy_aliases():
                     "Future",
                     "https://future.example/setup",
                     "Create a token.",
+                    FAKE_PROVIDER_ACCESS,
                 ),
             )
         ]


### PR DESCRIPTION
Задача: [PRI-223](https://ru.yougile.com/team/686c049c8af8/#PRI-223)
<!-- reviewer:task-link -->

## Summary
- добавляет единый access contract для board providers и безопасную проверку выбранных GitHub/GitLab credentials
- расширяет `configure-review` настройкой tracked branches только в home per-repo YAML с fail-closed preflight
- документирует ownership конфигурации, VCS permissions и сценарии single repo / second repo / CI
- синхронизирует Jira/YouGile validation semantics и Codex plugin manifests

## Test Plan
- [x] `.venv/bin/pytest -q` (`3590 passed, 117 deselected`)
- [x] `.venv/bin/ruff check .`
- [x] `.venv/bin/python scripts/update_codex_plugin_manifest.py --check`
- [x] `git diff --check`
- [x] независимое code review: findings отсутствуют