### PR TITLE
feat(web): вынести порты контейнера в runtime (PRI-222)

### DIFF
--- a/README.md
+++ b/README.md
@@ -696,6 +696,29 @@ cd web/frontend && npm install && npm run build && cd ../..
 reviewer serve
 ```
 
+The container keeps its internal listen port separate from the published loopback port. Build it
+once and choose both at runtime (replace `database` with a Postgres host reachable from the
+container):
+
+```bash
+docker build -f web/Dockerfile -t rag-reviewer-web .
+docker run --rm \
+  --env PG_DSN=postgresql://reviewer:reviewer@database:5432/reviewer \
+  --env REVIEWER_WEB_PORT=8080 \
+  --publish 127.0.0.1:18000:8080 \
+  rag-reviewer-web
+```
+
+The Compose service is opt-in, so ordinary `docker compose up` still starts infrastructure only:
+
+```bash
+docker compose --profile web up -d web
+REVIEWER_WEB_PORT=8080 REVIEWER_WEB_PUBLISH_PORT=18000 \
+  docker compose --profile web up -d web
+```
+
+Without overrides, both the internal and published ports default to `8000`.
+
 Set `WEB_ADMIN_USER` and `WEB_ADMIN_PASSWORD` before exposing it beyond localhost. Store and API
 errors are reported without preventing the process from starting where fail-soft behavior is safe.
 

--- a/README.ru.md
+++ b/README.ru.md
@@ -684,6 +684,30 @@ cd web/frontend && npm install && npm run build && cd ../..
 reviewer serve
 ```
 
+В контейнерном сценарии внутренний listen-port отделён от опубликованного loopback-порта. Образ
+собирается один раз, оба порта выбираются при запуске (`database` замените на доступный из
+контейнера Postgres host):
+
+```bash
+docker build -f web/Dockerfile -t rag-reviewer-web .
+docker run --rm \
+  --env PG_DSN=postgresql://reviewer:reviewer@database:5432/reviewer \
+  --env REVIEWER_WEB_PORT=8080 \
+  --publish 127.0.0.1:18000:8080 \
+  rag-reviewer-web
+```
+
+Compose-сервис включается явно, поэтому обычный `docker compose up` по-прежнему запускает только
+инфраструктуру:
+
+```bash
+docker compose --profile web up -d web
+REVIEWER_WEB_PORT=8080 REVIEWER_WEB_PUBLISH_PORT=18000 \
+  docker compose --profile web up -d web
+```
+
+Без переопределений внутренний и опубликованный порты равны `8000`.
+
 Перед доступом не только с localhost задайте `WEB_ADMIN_USER` и `WEB_ADMIN_PASSWORD`. Ошибки store
 и API сообщаются явно; там, где это безопасно, процесс сохраняет fail-soft startup.
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,6 +14,19 @@ services:
       NEO4J_AUTH: neo4j/reviewerpass
     ports: ["127.0.0.1:7474:7474", "127.0.0.1:7687:7687"]
     volumes: ["neo4j_data:/data"]
+  web:
+    # Web admin собирается и запускается только через явный `--profile web`.
+    profiles: ["web"]
+    build:
+      context: .
+      dockerfile: web/Dockerfile
+    environment:
+      PG_DSN: postgresql://reviewer:reviewer@paradedb:5432/reviewer
+      REVIEWER_WEB_HOST: 0.0.0.0
+      REVIEWER_WEB_PORT: ${REVIEWER_WEB_PORT:-8000}
+    ports:
+      - "127.0.0.1:${REVIEWER_WEB_PUBLISH_PORT:-8000}:${REVIEWER_WEB_PORT:-8000}"
+    depends_on: ["paradedb"]
   # ============================================================================
   # ВАЖНО: test-profile использует общий Compose project с dev-сервисами.
   # Безопасное удаление: docker compose --profile test rm -sfv paradedb-test neo4j-test

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,6 +24,8 @@ services:
       PG_DSN: postgresql://reviewer:reviewer@paradedb:5432/reviewer
       REVIEWER_WEB_HOST: 0.0.0.0
       REVIEWER_WEB_PORT: ${REVIEWER_WEB_PORT:-8000}
+      WEB_ADMIN_USER: ${WEB_ADMIN_USER:-}
+      WEB_ADMIN_PASSWORD: ${WEB_ADMIN_PASSWORD:-}
     ports:
       - "127.0.0.1:${REVIEWER_WEB_PUBLISH_PORT:-8000}:${REVIEWER_WEB_PORT:-8000}"
     depends_on: ["paradedb"]

--- a/docs/superpowers/briefs/2026-08-09-PRI-222-runtime-web-container-port.md
+++ b/docs/superpowers/briefs/2026-08-09-PRI-222-runtime-web-container-port.md
@@ -20,6 +20,8 @@ https://ru.yougile.com/team/686c049c8af8/#PRI-222
 - tests — инфраструктурная политика проверяет Compose как YAML без внешней сети и подходит для opt-in/profile/runtime-port инвариантов.
 
 ## Relevant code
+- `web/Dockerfile:26` — удалить `EXPOSE 8000` и inline `uvicorn.run(... port=8000)`; заменить на exec-form общего module startup.
+- `docker-compose.yml:1` — добавить opt-in сервис `web`, не меняя поведение обязательных инфраструктурных сервисов без profile.
 - `reviewer/entrypoints/cli.py:533` — `serve` уже принимает `--host` и `--port`, default порта 8000 остаётся здесь как совместимый runtime-дефолт.
 - `reviewer/web/app.py:33` — `create_app` создаёт HTTP-приложение независимо от listen-port; Docker-логика сюда не нужна.
 - (dropped 23: остальные Python-хиты не требуется менять или копировать; ключевые Docker/Compose-файлы не индексируются как Python-код)
@@ -30,10 +32,10 @@ https://ru.yougile.com/team/686c049c8af8/#PRI-222
 - (dropped 23: остальные тестовые хиты покрывают FastAPI/CLI internals или несвязанные Docker-инварианты и не информируют проверку runtime-портов)
 
 ## Constraints / open questions
-- `web/Dockerfile` и `docker-compose.yml` не попали в Python-only base retrieval; точные runtime-поля нужно подтвердить чтением рабочего дерева перед дизайном.
+- `web/Dockerfile` и `docker-compose.yml` не попали в Python-only base retrieval; их runtime-поля подтверждены прямым чтением рабочего дерева.
 - Smoke-тест должен реально доказывать повторное использование одного image на двух внутренних портах, но не должен попадать в обычный unit-прогон с запретом localhost/network.
 - Compose web-сервис обязан иметь явный `profiles` opt-in и не менять поведение базового `docker compose up`.
 - Criteria в store пусты как отдельное поле, но полный раздел «Критерии приёмки» присутствует в description и перенесён в Task.
 - Существующих артефактов PRI-222 не найдено; индекс `dev` свежий (`drift=0`), сводки были тёплыми и не обновлялись согласно ограничению «только на Luna».
 
-Собран на: session model (premium), режим: inline
+Собран на: mid tier default (session model; override unavailable), режим: inline

--- a/docs/superpowers/briefs/2026-08-09-PRI-222-runtime-web-container-port.md
+++ b/docs/superpowers/briefs/2026-08-09-PRI-222-runtime-web-container-port.md
@@ -1,0 +1,39 @@
+# Brief — PRI-222 Вынести настройку порта web-контейнера из Dockerfile
+https://ru.yougile.com/team/686c049c8af8/#PRI-222
+
+## Task
+- Ключ PRI-222 (store: ID-276, alias PRI-222), статус «Бэклог»; данные получены из reviewer store после `sync_board`.
+- Убрать `EXPOSE` и литерал `8000` из `web/Dockerfile`; один image должен принимать внутренний host/port при запуске без rebuild.
+- Сохранить единый startup-путь через `reviewer serve --host/--port` и совместимый пользовательский default 8000.
+- Добавить документированный `docker run` и opt-in Compose-профиль `web`; обычный `docker compose up` остаётся только инфраструктурным.
+- Приёмка: HTTP smoke-check одного image на двух внутренних портах, publish-port принадлежит runtime/deploy-конфигурации.
+
+## Related work
+- PRI-216 — переиспользовать паттерн изменения opt-in Compose-профиля вместе с декларативным unit-guard тестом и явной документацией ограничений.
+- (dropped 6: задачи про init, launcher, lite-режим, изоляцию unit-тестов и сводки не задают конкретный Docker/runtime-паттерн для этой реализации)
+
+## Subsystems
+- reviewer/entrypoints — CLI-команда `reviewer serve` уже владеет host/port и должна остаться единственным серверным startup-интерфейсом.
+- reviewer/web — FastAPI-приложение предоставляет HTTP endpoint для smoke-check и не должно получать Docker-специфичную конфигурацию.
+- tests/entrypoints — существующие CLI-тесты показывают паттерн `CliRunner` и monkeypatch, если потребуется закрепить контракт `serve`.
+- tests/docs — guard-тесты поддерживают синхронность пользовательских команд в `README.md` и `README.ru.md`.
+- tests — инфраструктурная политика проверяет Compose как YAML без внешней сети и подходит для opt-in/profile/runtime-port инвариантов.
+
+## Relevant code
+- `reviewer/entrypoints/cli.py:533` — `serve` уже принимает `--host` и `--port`, default порта 8000 остаётся здесь как совместимый runtime-дефолт.
+- `reviewer/web/app.py:33` — `create_app` создаёт HTTP-приложение независимо от listen-port; Docker-логика сюда не нужна.
+- (dropped 23: остальные Python-хиты не требуется менять или копировать; ключевые Docker/Compose-файлы не индексируются как Python-код)
+
+## Test exemplars
+- `tests/test_infrastructure_policy.py:249` — парсит `docker-compose.yml` через `yaml.safe_load` и закрепляет profile/environment/ports декларативными unit-asserts без запуска контейнеров.
+- `tests/docs/test_readme_onboarding.py:190` — проверяет команды onboarding одновременно в английском и русском README и задаёт паттерн документационного guard-теста.
+- (dropped 23: остальные тестовые хиты покрывают FastAPI/CLI internals или несвязанные Docker-инварианты и не информируют проверку runtime-портов)
+
+## Constraints / open questions
+- `web/Dockerfile` и `docker-compose.yml` не попали в Python-only base retrieval; точные runtime-поля нужно подтвердить чтением рабочего дерева перед дизайном.
+- Smoke-тест должен реально доказывать повторное использование одного image на двух внутренних портах, но не должен попадать в обычный unit-прогон с запретом localhost/network.
+- Compose web-сервис обязан иметь явный `profiles` opt-in и не менять поведение базового `docker compose up`.
+- Criteria в store пусты как отдельное поле, но полный раздел «Критерии приёмки» присутствует в description и перенесён в Task.
+- Существующих артефактов PRI-222 не найдено; индекс `dev` свежий (`drift=0`), сводки были тёплыми и не обновлялись согласно ограничению «только на Luna».
+
+Собран на: session model (premium), режим: inline

--- a/docs/superpowers/plans/2026-08-09-pri-222-runtime-web-container-port.md
+++ b/docs/superpowers/plans/2026-08-09-pri-222-runtime-web-container-port.md
@@ -1,0 +1,595 @@
+# PRI-222 Runtime Web Container Port Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Перенести host/port web-контейнера в runtime/deploy-слой, сохранив единый Python startup и opt-in Compose.
+
+**Architecture:** Лёгкий `reviewer.web.serve` владеет созданием FastAPI app и запуском Uvicorn; Click-команда и Docker module CLI только получают host/port разными способами. Dockerfile не знает номер порта, Compose раздельно задаёт внутренний listen-port и loopback host mapping, а реальный integration smoke повторно использует один image на двух портах.
+
+**Tech Stack:** Python 3.11+, argparse, Click, FastAPI/Uvicorn, Docker multi-stage build, Docker Compose, pytest, PyYAML.
+
+---
+
+## File Map
+
+- Create `reviewer/web/serve.py`: единственный runner Uvicorn и лёгкий module CLI с args/env.
+- Modify `reviewer/entrypoints/cli.py`: делегирование `reviewer serve` общему runner.
+- Create `tests/web/test_serve.py`: unit-контракт args/env, runner и Click delegation.
+- Modify `web/Dockerfile`: минимальные runtime dependencies и port-agnostic exec `CMD`.
+- Modify `docker-compose.yml`: opt-in `web` profile с раздельными listen/publish ports.
+- Modify `tests/test_infrastructure_policy.py`: декларативные guards Dockerfile и Compose.
+- Modify `README.md`, `README.ru.md`: docker run и Compose runtime examples.
+- Modify `tests/docs/test_readme_onboarding.py`: двуязычный documentation guard.
+- Create `tests/web/test_container_smoke.py`: один image, два внутренних порта, HTTP smoke.
+
+### Task 1: Единый web server runner
+
+**Files:**
+- Create: `reviewer/web/serve.py`
+- Create: `tests/web/test_serve.py`
+- Modify: `reviewer/entrypoints/cli.py:14-20,994-1005`
+
+- [ ] **Step 1: Написать failing unit-тесты module CLI, runner и Click delegation**
+
+Создать `tests/web/test_serve.py`:
+
+```python
+from __future__ import annotations
+
+from click.testing import CliRunner
+import pytest
+
+from reviewer.entrypoints.cli import cli
+from reviewer.web import serve
+
+
+def test_module_cli_uses_container_defaults(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls: list[tuple[str, int]] = []
+    monkeypatch.delenv("REVIEWER_WEB_HOST", raising=False)
+    monkeypatch.delenv("REVIEWER_WEB_PORT", raising=False)
+    monkeypatch.setattr(serve, "run_server", lambda host, port: calls.append((host, port)))
+
+    serve.main([])
+
+    assert calls == [("0.0.0.0", 8000)]
+
+
+def test_module_cli_reads_env_and_arguments_override_it(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: list[tuple[str, int]] = []
+    monkeypatch.setenv("REVIEWER_WEB_HOST", "0.0.0.0")
+    monkeypatch.setenv("REVIEWER_WEB_PORT", "8080")
+    monkeypatch.setattr(serve, "run_server", lambda host, port: calls.append((host, port)))
+
+    serve.main(["--host", "127.0.0.2", "--port", "9090"])
+
+    assert calls == [("127.0.0.2", 9090)]
+
+
+def test_module_cli_rejects_invalid_env_port(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    monkeypatch.setenv("REVIEWER_WEB_PORT", "not-a-port")
+
+    with pytest.raises(SystemExit) as exc_info:
+        serve.main([])
+
+    assert exc_info.value.code == 2
+    assert "invalid int value" in capsys.readouterr().err
+
+
+def test_run_server_builds_app_and_passes_host_port(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    settings = object()
+    app = object()
+    calls: list[tuple[object, str, int]] = []
+    monkeypatch.setattr("reviewer.config.settings.Settings", lambda: settings)
+    monkeypatch.setattr(
+        "reviewer.web.app.create_app",
+        lambda actual: app if actual is settings else None,
+    )
+    monkeypatch.setattr(
+        "uvicorn.run",
+        lambda actual, *, host, port: calls.append((actual, host, port)),
+    )
+
+    serve.run_server("127.0.0.2", 9090)
+
+    assert calls == [(app, "127.0.0.2", 9090)]
+    assert "http://127.0.0.2:9090" in capsys.readouterr().out
+
+
+def test_click_serve_delegates_to_shared_runner(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls: list[tuple[str, int]] = []
+    monkeypatch.setattr(serve, "run_server", lambda host, port: calls.append((host, port)))
+
+    result = CliRunner().invoke(cli, ["serve", "--host", "0.0.0.0", "--port", "8080"])
+
+    assert result.exit_code == 0
+    assert calls == [("0.0.0.0", 8080)]
+```
+
+- [ ] **Step 2: Запустить тест и подтвердить RED**
+
+Run: `.venv/bin/pytest tests/web/test_serve.py -q`
+
+Expected: collection FAIL с `ImportError: cannot import name 'serve' from 'reviewer.web'`.
+
+- [ ] **Step 3: Реализовать минимальный общий runner**
+
+Создать `reviewer/web/serve.py`:
+
+```python
+"""Общий runtime-запуск web-админки для CLI и контейнера."""
+
+from __future__ import annotations
+
+import argparse
+import os
+from collections.abc import Sequence
+
+DEFAULT_HOST = "127.0.0.1"
+DEFAULT_PORT = 8000
+CONTAINER_DEFAULT_HOST = "0.0.0.0"
+
+
+def run_server(host: str, port: int) -> None:
+    """Создать приложение и запустить Uvicorn на переданном runtime-адресе."""
+    import uvicorn
+
+    from reviewer.config.settings import Settings
+    from reviewer.web.app import create_app
+
+    app = create_app(Settings())
+    print(f"Запуск веб-сервера на http://{host}:{port} ...")
+    uvicorn.run(app, host=host, port=port)
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Запустить веб-админку reviewer")
+    parser.add_argument(
+        "--host",
+        default=os.getenv("REVIEWER_WEB_HOST", CONTAINER_DEFAULT_HOST),
+        help="Хост для uvicorn (env: REVIEWER_WEB_HOST)",
+    )
+    parser.add_argument(
+        "--port",
+        default=os.getenv("REVIEWER_WEB_PORT", str(DEFAULT_PORT)),
+        type=int,
+        help="Порт для uvicorn (env: REVIEWER_WEB_PORT)",
+    )
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> None:
+    """Разобрать container args/env и запустить общий server runner."""
+    args = _parser().parse_args(argv)
+    run_server(args.host, args.port)
+
+
+if __name__ == "__main__":
+    main()
+```
+
+В `reviewer/entrypoints/cli.py` импортировать defaults рядом с `Settings`:
+
+```python
+from reviewer.web.serve import DEFAULT_HOST, DEFAULT_PORT
+```
+
+и заменить команду `serve`:
+
+```python
+@cli.command()
+@click.option("--host", default=DEFAULT_HOST, show_default=True, help="Хост для uvicorn")
+@click.option("--port", default=DEFAULT_PORT, show_default=True, type=int, help="Порт для uvicorn")
+def serve(host: str, port: int) -> None:
+    """Запустить веб-админку наблюдаемости (FastAPI + uvicorn)."""
+    from reviewer.web.serve import run_server
+
+    run_server(host, port)
+```
+
+- [ ] **Step 4: Запустить unit-тесты и линт, подтвердить GREEN**
+
+Run: `.venv/bin/pytest tests/web/test_serve.py -q`
+
+Expected: `5 passed`.
+
+Run: `.venv/bin/ruff check reviewer/web/serve.py reviewer/entrypoints/cli.py tests/web/test_serve.py`
+
+Expected: `All checks passed!`.
+
+- [ ] **Step 5: Закоммитить общий startup**
+
+```bash
+git add reviewer/web/serve.py reviewer/entrypoints/cli.py tests/web/test_serve.py
+git commit -m "refactor(web): объединить CLI и контейнерный startup (PRI-222)"
+```
+
+### Task 2: Port-agnostic Dockerfile и opt-in Compose
+
+**Files:**
+- Modify: `web/Dockerfile:18-28`
+- Modify: `docker-compose.yml:17-59`
+- Modify: `tests/test_infrastructure_policy.py:257-338`
+
+- [ ] **Step 1: Добавить failing policy-тесты Dockerfile и Compose**
+
+После `test_compose_documents_start_interval_docker_requirement` добавить:
+
+```python
+def test_web_dockerfile_delegates_port_to_runtime() -> None:
+    root = Path(__file__).parents[1]
+    dockerfile = (root / "web" / "Dockerfile").read_text(encoding="utf-8")
+
+    assert "EXPOSE" not in dockerfile
+    assert "8000" not in dockerfile
+    assert 'CMD ["python", "-m", "reviewer.web.serve"]' in dockerfile
+    assert '"psycopg-pool>=3.2"' in dockerfile
+
+
+def test_compose_web_service_is_opt_in_with_separate_runtime_ports() -> None:
+    root = Path(__file__).parents[1]
+    compose = yaml.safe_load((root / "docker-compose.yml").read_text(encoding="utf-8"))
+    web = compose["services"]["web"]
+
+    assert web["profiles"] == ["web"]
+    assert web["build"] == {"context": ".", "dockerfile": "web/Dockerfile"}
+    assert web["environment"] == {
+        "PG_DSN": "postgresql://reviewer:reviewer@paradedb:5432/reviewer",
+        "REVIEWER_WEB_HOST": "0.0.0.0",
+        "REVIEWER_WEB_PORT": "${REVIEWER_WEB_PORT:-8000}",
+    }
+    assert web["ports"] == [
+        "127.0.0.1:${REVIEWER_WEB_PUBLISH_PORT:-8000}:${REVIEWER_WEB_PORT:-8000}"
+    ]
+    assert web["depends_on"] == ["paradedb"]
+```
+
+- [ ] **Step 2: Запустить policy-тесты и подтвердить RED**
+
+Run: `.venv/bin/pytest tests/test_infrastructure_policy.py::test_web_dockerfile_delegates_port_to_runtime tests/test_infrastructure_policy.py::test_compose_web_service_is_opt_in_with_separate_runtime_ports -q`
+
+Expected: первый тест FAIL на `EXPOSE`, второй FAIL с `KeyError: 'web'`.
+
+- [ ] **Step 3: Сделать Dockerfile port-agnostic**
+
+В runtime install добавить `psycopg-pool`, удалить `EXPOSE` и заменить `CMD`; итоговый backend tail:
+
+```dockerfile
+FROM python:3.12-slim AS backend
+WORKDIR /app
+# Только рантайм-зависимости веб-слоя (не весь reviewer)
+RUN pip install --no-cache-dir \
+    "fastapi>=0.115" "uvicorn[standard]>=0.30" "psycopg[binary]>=3.2" \
+    "psycopg-pool>=3.2" "pydantic-settings>=2.3"
+# Исходники reviewer (импортируются только reviewer.config + reviewer.web; остальное лежит без импорта)
+COPY reviewer/ ./reviewer/
+# Собранный фронт из stage 1 — путь совпадает с _FRONTEND_DIST в reviewer/web/app.py
+COPY --from=frontend /app/web/frontend/dist ./web/frontend/dist
+ENV PYTHONPATH=/app
+# create_app(Settings()) читает PG_DSN, host и port приходят только из runtime.
+CMD ["python", "-m", "reviewer.web.serve"]
+```
+
+- [ ] **Step 4: Добавить opt-in Compose-сервис**
+
+После `neo4j` и до test-profile header добавить:
+
+```yaml
+  web:
+    # Web admin собирается и запускается только через явный `--profile web`.
+    profiles: ["web"]
+    build:
+      context: .
+      dockerfile: web/Dockerfile
+    environment:
+      PG_DSN: postgresql://reviewer:reviewer@paradedb:5432/reviewer
+      REVIEWER_WEB_HOST: 0.0.0.0
+      REVIEWER_WEB_PORT: ${REVIEWER_WEB_PORT:-8000}
+    ports:
+      - "127.0.0.1:${REVIEWER_WEB_PUBLISH_PORT:-8000}:${REVIEWER_WEB_PORT:-8000}"
+    depends_on: ["paradedb"]
+```
+
+- [ ] **Step 5: Запустить policy и Compose checks, подтвердить GREEN**
+
+Run: `.venv/bin/pytest tests/test_infrastructure_policy.py -q`
+
+Expected: весь модуль PASS.
+
+Run: `docker compose --profile web config --quiet`
+
+Expected: exit code 0, пустой вывод.
+
+Run: `docker compose config --services`
+
+Expected: вывод содержит только `paradedb` и `neo4j`; `web` отсутствует.
+
+Run: `.venv/bin/ruff check tests/test_infrastructure_policy.py`
+
+Expected: `All checks passed!`.
+
+- [ ] **Step 6: Закоммитить deploy-конфигурацию**
+
+```bash
+git add web/Dockerfile docker-compose.yml tests/test_infrastructure_policy.py
+git commit -m "feat(web): вынести порты контейнера в runtime (PRI-222)"
+```
+
+### Task 3: Двуязычная документация runtime-портов
+
+**Files:**
+- Modify: `README.md:689-700`
+- Modify: `README.ru.md:677-688`
+- Modify: `tests/docs/test_readme_onboarding.py:226-232`
+
+- [ ] **Step 1: Написать failing documentation guard**
+
+Перед `test_readmes_document_configuration_ownership_and_scenarios` добавить:
+
+```python
+def test_readmes_document_web_container_runtime_ports() -> None:
+    for filename, heading in (
+        ("README.md", "### Web admin"),
+        ("README.ru.md", "### Web admin"),
+    ):
+        section = _section(_read(filename), heading)
+        for marker in (
+            "docker build -f web/Dockerfile -t rag-reviewer-web .",
+            "docker run --rm",
+            "REVIEWER_WEB_PORT=8080",
+            "127.0.0.1:18000:8080",
+            "docker compose --profile web up -d web",
+            "REVIEWER_WEB_PUBLISH_PORT=18000",
+        ):
+            assert marker in section, (filename, marker)
+```
+
+- [ ] **Step 2: Запустить guard и подтвердить RED**
+
+Run: `.venv/bin/pytest tests/docs/test_readme_onboarding.py::test_readmes_document_web_container_runtime_ports -q`
+
+Expected: FAIL на отсутствующей `docker build` команде.
+
+- [ ] **Step 3: Дополнить английскую Web admin секцию**
+
+После host-run code block в `README.md` добавить:
+
+````markdown
+The container keeps its internal listen port separate from the published loopback port. Build it
+once and choose both at runtime (replace `database` with a Postgres host reachable from the
+container):
+
+```bash
+docker build -f web/Dockerfile -t rag-reviewer-web .
+docker run --rm \
+  --env PG_DSN=postgresql://reviewer:reviewer@database:5432/reviewer \
+  --env REVIEWER_WEB_PORT=8080 \
+  --publish 127.0.0.1:18000:8080 \
+  rag-reviewer-web
+```
+
+The Compose service is opt-in, so ordinary `docker compose up` still starts infrastructure only:
+
+```bash
+docker compose --profile web up -d web
+REVIEWER_WEB_PORT=8080 REVIEWER_WEB_PUBLISH_PORT=18000 \
+  docker compose --profile web up -d web
+```
+
+Without overrides, both the internal and published ports default to `8000`.
+````
+
+- [ ] **Step 4: Дополнить русскую Web admin секцию теми же командами**
+
+После host-run code block в `README.ru.md` добавить:
+
+````markdown
+В контейнерном сценарии внутренний listen-port отделён от опубликованного loopback-порта. Образ
+собирается один раз, оба порта выбираются при запуске (`database` замените на доступный из
+контейнера Postgres host):
+
+```bash
+docker build -f web/Dockerfile -t rag-reviewer-web .
+docker run --rm \
+  --env PG_DSN=postgresql://reviewer:reviewer@database:5432/reviewer \
+  --env REVIEWER_WEB_PORT=8080 \
+  --publish 127.0.0.1:18000:8080 \
+  rag-reviewer-web
+```
+
+Compose-сервис включается явно, поэтому обычный `docker compose up` по-прежнему запускает только
+инфраструктуру:
+
+```bash
+docker compose --profile web up -d web
+REVIEWER_WEB_PORT=8080 REVIEWER_WEB_PUBLISH_PORT=18000 \
+  docker compose --profile web up -d web
+```
+
+Без переопределений внутренний и опубликованный порты равны `8000`.
+````
+
+- [ ] **Step 5: Запустить docs tests, подтвердить GREEN**
+
+Run: `.venv/bin/pytest tests/docs/test_readme_onboarding.py -q`
+
+Expected: весь модуль PASS, включая link/parity guards.
+
+Run: `.venv/bin/ruff check tests/docs/test_readme_onboarding.py`
+
+Expected: `All checks passed!`.
+
+- [ ] **Step 6: Закоммитить документацию**
+
+```bash
+git add README.md README.ru.md tests/docs/test_readme_onboarding.py
+git commit -m "docs(web): описать runtime-порты контейнера (PRI-222)"
+```
+
+### Task 4: Реальный smoke одного image на двух портах
+
+**Files:**
+- Create: `tests/web/test_container_smoke.py`
+
+- [ ] **Step 1: Написать integration smoke**
+
+Создать `tests/web/test_container_smoke.py`:
+
+```python
+from __future__ import annotations
+
+import shutil
+import subprocess
+import time
+import uuid
+from collections.abc import Iterator
+from pathlib import Path
+from urllib.error import URLError
+from urllib.request import urlopen
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def _docker(*args: str, check: bool = True) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["docker", *args],
+        cwd=ROOT,
+        check=check,
+        capture_output=True,
+        text=True,
+    )
+
+
+@pytest.fixture(scope="module")
+def web_image() -> Iterator[str]:
+    if shutil.which("docker") is None:
+        pytest.skip("Docker CLI недоступен")
+    info = _docker("info", check=False)
+    if info.returncode != 0:
+        pytest.skip(f"Docker daemon недоступен: {info.stderr.strip()}")
+
+    image = f"rag-reviewer-web-smoke:{uuid.uuid4().hex}"
+    _docker("build", "-f", "web/Dockerfile", "-t", image, ".")
+    try:
+        yield image
+    finally:
+        _docker("image", "rm", "--force", image, check=False)
+
+
+@pytest.mark.integration
+@pytest.mark.parametrize("internal_port", [18080, 18081])
+def test_same_image_serves_http_on_different_internal_ports(
+    web_image: str,
+    internal_port: int,
+) -> None:
+    name = f"reviewer-web-smoke-{uuid.uuid4().hex}"
+    started = _docker(
+        "run",
+        "--detach",
+        "--rm",
+        "--name",
+        name,
+        "--env",
+        "PG_DSN=postgresql://reviewer:reviewer@127.0.0.1:1/reviewer?connect_timeout=1",
+        "--env",
+        f"REVIEWER_WEB_PORT={internal_port}",
+        "--publish",
+        f"127.0.0.1::{internal_port}",
+        web_image,
+    )
+    container_id = started.stdout.strip()
+    try:
+        published = _docker("port", container_id, f"{internal_port}/tcp").stdout.strip()
+        host_port = int(published.rsplit(":", 1)[1])
+        url = f"http://127.0.0.1:{host_port}/"
+        last_error: Exception | None = None
+        for _ in range(60):
+            try:
+                with urlopen(url, timeout=1) as response:
+                    body = response.read()
+                assert response.status == 200
+                assert body
+                break
+            except URLError as exc:
+                last_error = exc
+                time.sleep(0.25)
+        else:
+            logs = _docker("logs", container_id, check=False)
+            pytest.fail(
+                f"web image не ответил на {url}: {last_error}; logs:\n{logs.stdout}\n{logs.stderr}"
+            )
+    finally:
+        _docker("rm", "--force", container_id, check=False)
+```
+
+- [ ] **Step 2: Запустить smoke и подтвердить оба варианта**
+
+Run: `.venv/bin/pytest -q -m integration tests/web/test_container_smoke.py`
+
+Expected: `2 passed`; в Docker build выполняется один раз, оба параметра используют один tag.
+
+- [ ] **Step 3: Запустить линт smoke-теста**
+
+Run: `.venv/bin/ruff check tests/web/test_container_smoke.py`
+
+Expected: `All checks passed!`.
+
+- [ ] **Step 4: Закоммитить smoke**
+
+```bash
+git add tests/web/test_container_smoke.py
+git commit -m "test(web): проверить image на разных внутренних портах (PRI-222)"
+```
+
+### Task 5: Полная проверка и готовность к PR
+
+**Files:**
+- Verify all changed files
+
+- [ ] **Step 1: Запустить целевые unit-тесты**
+
+Run: `.venv/bin/pytest tests/web/test_serve.py tests/test_infrastructure_policy.py tests/docs/test_readme_onboarding.py -q`
+
+Expected: PASS.
+
+- [ ] **Step 2: Запустить весь unit suite**
+
+Run: `.venv/bin/pytest -q`
+
+Expected: PASS; integration tests исключены настройкой `pyproject.toml`.
+
+- [ ] **Step 3: Запустить полный ruff**
+
+Run: `.venv/bin/ruff check .`
+
+Expected: `All checks passed!`.
+
+- [ ] **Step 4: Повторить deploy и container checks**
+
+Run: `docker compose --profile web config --quiet`
+
+Expected: exit code 0.
+
+Run: `docker compose config --services`
+
+Expected: только `paradedb` и `neo4j`.
+
+Run: `.venv/bin/pytest -q -m integration tests/web/test_container_smoke.py`
+
+Expected: `2 passed` на одном повторно собранном image.
+
+- [ ] **Step 5: Просмотреть итоговый diff и историю**
+
+Run: `git status --short && git diff dev...HEAD --check && git log --oneline dev..HEAD`
+
+Expected: нет незакоммиченных implementation-файлов, `git diff --check` без ошибок, история содержит docs/spec и четыре сфокусированных implementation-коммита.

--- a/docs/superpowers/specs/2026-08-09-pri-222-runtime-web-container-port-design.md
+++ b/docs/superpowers/specs/2026-08-09-pri-222-runtime-web-container-port-design.md
@@ -68,7 +68,9 @@ Click и контейнер различаются только способом
 ## Docker image
 
 `web/Dockerfile` сохраняет текущую multi-stage сборку и минимальный набор web-зависимостей.
-Из него удаляются `EXPOSE 8000` и inline Uvicorn. Новый exec-form startup:
+В runtime-набор добавляется отсутствующий `psycopg-pool>=3.2`, который напрямую импортирует
+`reviewer.web.history`; полный dependency stack пакета не устанавливается. Из Dockerfile
+удаляются `EXPOSE 8000` и inline Uvicorn. Новый exec-form startup:
 
 ```dockerfile
 CMD ["python", "-m", "reviewer.web.serve"]

--- a/docs/superpowers/specs/2026-08-09-pri-222-runtime-web-container-port-design.md
+++ b/docs/superpowers/specs/2026-08-09-pri-222-runtime-web-container-port-design.md
@@ -1,0 +1,164 @@
+# PRI-222 — Runtime-настройка порта web-контейнера
+
+Задача: https://ru.yougile.com/team/686c049c8af8/#PRI-222
+Бриф: `docs/superpowers/briefs/2026-08-09-PRI-222-runtime-web-container-port.md`
+
+## Проблема
+
+`web/Dockerfile` одновременно объявляет `EXPOSE 8000` и запускает Uvicorn с
+`port=8000` внутри inline `python -c`. Это создаёт второй startup-путь рядом с
+`reviewer serve --host/--port` и заставляет переопределять команду или пересобирать
+образ для другого внутреннего порта.
+
+Ранее сервис `web` был удалён из обычного Compose, потому что тяжёлая сборка SPA не
+должна запускаться вместе с обязательной инфраструктурой. PRI-222 не отменяет этот
+инвариант: Compose-сервис возвращается только под явным profile `web`.
+
+## Цели
+
+- Один Python startup-путь создаёт FastAPI app и запускает Uvicorn для host/port.
+- `web/Dockerfile` не содержит `EXPOSE` и литерал `8000`.
+- Один image без rebuild запускается минимум на двух внутренних портах.
+- Внутренний listen-port и опубликованный host-port настраиваются независимо.
+- Дефолтный контейнерный сценарий остаётся на порту 8000.
+- Обычный `docker compose up` не собирает и не запускает web.
+
+## Не цели
+
+- Не менять API, SPA, storage-схему или Basic Auth.
+- Не устанавливать в web-image полный RAG/graph/MCP dependency stack.
+- Не переносить Docker-настройки в `Settings`: listen host/port принадлежат процессу,
+  а не доменной конфигурации приложения.
+- Не добавлять `EXPOSE`: это metadata образа, а не runtime-публикация порта.
+
+## Выбранный подход
+
+Добавить лёгкий модуль `reviewer.web.serve`, общий для Click-команды и контейнера.
+Модуль импортируется без optional web dependencies; `uvicorn`, `Settings` и
+`create_app` загружаются лениво только внутри `run_server`. Поэтому обычные команды
+`reviewer` по-прежнему работают без `[web]` extra.
+
+Альтернативы отклонены:
+
+- shell-form `CMD` с inline `python -c` и env expansion сохраняет дублирующий startup;
+- установка полного пакета с dependencies ради console script утяжеляет специализированный
+  web-image и связывает его с RAG/graph stack.
+
+## Runtime-модуль
+
+`reviewer/web/serve.py` предоставляет:
+
+- `DEFAULT_HOST = "127.0.0.1"` и `DEFAULT_PORT = 8000` для публичной Click-команды;
+- `CONTAINER_DEFAULT_HOST = "0.0.0.0"` для module CLI внутри контейнера;
+- `run_server(host: str, port: int) -> None`, который создаёт `Settings`, передаёт их в
+  `create_app`, печатает адрес и вызывает `uvicorn.run`;
+- `main(argv: Sequence[str] | None = None) -> None` на stdlib `argparse`;
+- аргументы `--host`/`--port`, которые имеют приоритет над
+  `REVIEWER_WEB_HOST`/`REVIEWER_WEB_PORT`;
+- env/default chain: args → env → `0.0.0.0:8000` для module CLI.
+
+Строковый env-default порта проходит через `argparse` с `type=int`. Невалидное значение
+даёт стандартную понятную ошибку и ненулевой exit code до запуска Uvicorn.
+
+`reviewer.entrypoints.cli::serve` сохраняет публичные defaults `127.0.0.1:8000`, но
+вместо собственного создания app делегирует `run_server(host, port)`. Таким образом,
+Click и контейнер различаются только способом получения аргументов, а запуск сервера
+имеет одного владельца.
+
+## Docker image
+
+`web/Dockerfile` сохраняет текущую multi-stage сборку и минимальный набор web-зависимостей.
+Из него удаляются `EXPOSE 8000` и inline Uvicorn. Новый exec-form startup:
+
+```dockerfile
+CMD ["python", "-m", "reviewer.web.serve"]
+```
+
+Dockerfile не задаёт host/port через `ENV`: module CLI предоставляет совместимый runtime
+default, а deploy-слой может передать env или аргументы. Exec form сохраняет корректную
+доставку сигналов Python-процессу.
+
+## Compose
+
+В `docker-compose.yml` добавляется сервис `web`:
+
+```yaml
+web:
+  profiles: ["web"]
+  build:
+    context: .
+    dockerfile: web/Dockerfile
+  environment:
+    PG_DSN: postgresql://reviewer:reviewer@paradedb:5432/reviewer
+    REVIEWER_WEB_HOST: 0.0.0.0
+    REVIEWER_WEB_PORT: ${REVIEWER_WEB_PORT:-8000}
+  ports:
+    - "127.0.0.1:${REVIEWER_WEB_PUBLISH_PORT:-8000}:${REVIEWER_WEB_PORT:-8000}"
+  depends_on: ["paradedb"]
+```
+
+`REVIEWER_WEB_PORT` владеет внутренним listen-port. Отдельный
+`REVIEWER_WEB_PUBLISH_PORT` владеет host mapping. Loopback binding сохраняет политику
+безопасности dev-стека. Profile исключает web из обычного `docker compose up`, но
+`docker compose --profile web up -d web` поднимает web и его обязательную зависимость.
+
+## Документация
+
+Секции Web admin в `README.md` и `README.ru.md` сохраняют host-run через
+`reviewer serve` и добавляют два контейнерных сценария:
+
+1. `docker build -f web/Dockerfile -t rag-reviewer-web .` и `docker run` с явным
+   `PG_DSN`, независимыми внутренним портом и host mapping.
+2. `docker compose --profile web up -d web`, плюс пример переопределения
+   `REVIEWER_WEB_PORT` и `REVIEWER_WEB_PUBLISH_PORT`.
+
+Текст явно предупреждает, что profile opt-in и обычный Compose остаётся инфраструктурным.
+Английская и русская секции содержат одинаковые команды и env names.
+
+## Тестирование
+
+### Unit
+
+- `tests/web/test_serve.py`: defaults и приоритет args/env; невалидный env-port;
+  `run_server` создаёт app и передаёт точные host/port в `uvicorn.run`;
+  Click `reviewer serve` делегирует общему runner.
+- `tests/test_infrastructure_policy.py`: Dockerfile не содержит `EXPOSE` и `8000`,
+  использует exec-form module startup; Compose-сервис имеет profile `web`, ожидаемые
+  build/environment/depends_on и раздельные listen/publish переменные.
+- `tests/docs/test_readme_onboarding.py`: обе Web admin секции документируют image build,
+  `docker run`, opt-in profile и обе port variables.
+- `docker compose --profile web config --quiet` проверяет итоговый Compose-синтаксис.
+
+### Container smoke
+
+Новый `tests/web/test_container_smoke.py` помечен `integration`:
+
+- проверяет доступность Docker, иначе делает явный skip;
+- один раз собирает image из `web/Dockerfile`;
+- параметризованно запускает тот же image с двумя значениями
+  `REVIEWER_WEB_PORT` без rebuild;
+- публикует каждый внутренний порт на свободный loopback host-port и выполняет HTTP GET;
+- всегда удаляет контейнеры и временный image в `finally`/fixture teardown.
+
+Smoke не входит в обычный `pytest -q`, потому что unit-тестам запрещены сеть и внешние
+сервисы. Он запускается адресно при приёмке на машине с Docker.
+
+## Ошибки и безопасность
+
+- Невалидный port останавливает процесс до bind.
+- Занятый port и ошибки Uvicorn остаются явными runtime-ошибками без retry.
+- Недоступный Postgres сохраняет существующий fail-soft startup FastAPI; UI/API сообщают
+  проблему, но HTTP-процесс поднимается.
+- Публикация Compose по умолчанию только на `127.0.0.1`; внешний доступ требует явной
+  deploy-правки и настройки `WEB_ADMIN_USER`/`WEB_ADMIN_PASSWORD`.
+- Секреты не добавляются в Dockerfile или Compose.
+
+## Критерии готовности
+
+- В `web/Dockerfile` отсутствуют `EXPOSE` и `8000`.
+- Click и module CLI проходят через `run_server`.
+- Один собранный image проходит HTTP smoke на двух внутренних портах.
+- Compose config показывает `web` только как profile-сервис с независимыми port variables.
+- `docker compose up` без profile не включает web.
+- Default module CLI и Compose используют внутренний порт 8000 без дополнительной настройки.
+- Unit-тесты, ruff, Compose config и container smoke проходят.

--- a/reviewer/entrypoints/cli.py
+++ b/reviewer/entrypoints/cli.py
@@ -49,6 +49,7 @@ from reviewer.services.review_service import ReviewService
 from reviewer.services.status import build_status_report, render_status, render_status_json
 from reviewer.tasks.boards.errors import sanitize_provider_text
 from reviewer.versioning import InstallMode, check_latest, detect_installation, upgrade_uv_tool
+from reviewer.web.serve import DEFAULT_HOST, DEFAULT_PORT
 
 if TYPE_CHECKING:
     from reviewer.install_claude import ClaudeInstallResult
@@ -992,17 +993,13 @@ def gc() -> None:
 
 
 @cli.command()
-@click.option("--host", default="127.0.0.1", show_default=True, help="Хост для uvicorn")
-@click.option("--port", default=8000, show_default=True, type=int, help="Порт для uvicorn")
+@click.option("--host", default=DEFAULT_HOST, show_default=True, help="Хост для uvicorn")
+@click.option("--port", default=DEFAULT_PORT, show_default=True, type=int, help="Порт для uvicorn")
 def serve(host: str, port: int) -> None:
     """Запустить веб-админку наблюдаемости (FastAPI + uvicorn)."""
-    import uvicorn
-    from reviewer.web.app import create_app
+    from reviewer.web.serve import run_server
 
-    s = Settings()
-    app = create_app(s)
-    click.echo(f"Запуск веб-сервера на http://{host}:{port} ...")
-    uvicorn.run(app, host=host, port=port)
+    run_server(host, port)
 
 
 @cli.command()

--- a/reviewer/web/serve.py
+++ b/reviewer/web/serve.py
@@ -1,0 +1,49 @@
+"""Общий runtime-запуск web-админки для CLI и контейнера."""
+
+from __future__ import annotations
+
+import argparse
+import os
+from collections.abc import Sequence
+
+DEFAULT_HOST = "127.0.0.1"
+DEFAULT_PORT = 8000
+CONTAINER_DEFAULT_HOST = "0.0.0.0"
+
+
+def run_server(host: str, port: int) -> None:
+    """Создать приложение и запустить Uvicorn на переданном runtime-адресе."""
+    import uvicorn
+
+    from reviewer.config.settings import Settings
+    from reviewer.web.app import create_app
+
+    app = create_app(Settings())
+    print(f"Запуск веб-сервера на http://{host}:{port} ...")
+    uvicorn.run(app, host=host, port=port)
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Запустить веб-админку reviewer")
+    parser.add_argument(
+        "--host",
+        default=os.getenv("REVIEWER_WEB_HOST", CONTAINER_DEFAULT_HOST),
+        help="Хост для uvicorn (env: REVIEWER_WEB_HOST)",
+    )
+    parser.add_argument(
+        "--port",
+        default=os.getenv("REVIEWER_WEB_PORT", str(DEFAULT_PORT)),
+        type=int,
+        help="Порт для uvicorn (env: REVIEWER_WEB_PORT)",
+    )
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> None:
+    """Разобрать container args/env и запустить общий server runner."""
+    args = _parser().parse_args(argv)
+    run_server(args.host, args.port)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/docs/test_readme_onboarding.py
+++ b/tests/docs/test_readme_onboarding.py
@@ -230,6 +230,23 @@ def test_security_discloses_both_external_code_data_paths():
         assert "AI model provider" in section
 
 
+def test_readmes_document_web_container_runtime_ports() -> None:
+    for filename, heading in (
+        ("README.md", "### Web admin"),
+        ("README.ru.md", "### Web admin"),
+    ):
+        section = _section(_read(filename), heading)
+        for marker in (
+            "docker build -f web/Dockerfile -t rag-reviewer-web .",
+            "docker run --rm",
+            "REVIEWER_WEB_PORT=8080",
+            "127.0.0.1:18000:8080",
+            "docker compose --profile web up -d web",
+            "REVIEWER_WEB_PUBLISH_PORT=18000",
+        ):
+            assert marker in section, (filename, marker)
+
+
 def test_readmes_document_configuration_ownership_and_scenarios():
     cases = (
         (

--- a/tests/test_infrastructure_policy.py
+++ b/tests/test_infrastructure_policy.py
@@ -358,6 +358,8 @@ def test_compose_web_service_is_opt_in_with_separate_runtime_ports() -> None:
         "PG_DSN": "postgresql://reviewer:reviewer@paradedb:5432/reviewer",
         "REVIEWER_WEB_HOST": "0.0.0.0",
         "REVIEWER_WEB_PORT": "${REVIEWER_WEB_PORT:-8000}",
+        "WEB_ADMIN_USER": "${WEB_ADMIN_USER:-}",
+        "WEB_ADMIN_PASSWORD": "${WEB_ADMIN_PASSWORD:-}",
     }
     assert web["ports"] == [
         "127.0.0.1:${REVIEWER_WEB_PUBLISH_PORT:-8000}:${REVIEWER_WEB_PORT:-8000}"

--- a/tests/test_infrastructure_policy.py
+++ b/tests/test_infrastructure_policy.py
@@ -337,6 +337,34 @@ def test_compose_documents_start_interval_docker_requirement() -> None:
     ) in normalized
 
 
+def test_web_dockerfile_delegates_port_to_runtime() -> None:
+    root = Path(__file__).parents[1]
+    dockerfile = (root / "web" / "Dockerfile").read_text(encoding="utf-8")
+
+    assert "EXPOSE" not in dockerfile
+    assert "8000" not in dockerfile
+    assert 'CMD ["python", "-m", "reviewer.web.serve"]' in dockerfile
+    assert '"psycopg-pool>=3.2"' in dockerfile
+
+
+def test_compose_web_service_is_opt_in_with_separate_runtime_ports() -> None:
+    root = Path(__file__).parents[1]
+    compose = yaml.safe_load((root / "docker-compose.yml").read_text(encoding="utf-8"))
+    web = compose["services"]["web"]
+
+    assert web["profiles"] == ["web"]
+    assert web["build"] == {"context": ".", "dockerfile": "web/Dockerfile"}
+    assert web["environment"] == {
+        "PG_DSN": "postgresql://reviewer:reviewer@paradedb:5432/reviewer",
+        "REVIEWER_WEB_HOST": "0.0.0.0",
+        "REVIEWER_WEB_PORT": "${REVIEWER_WEB_PORT:-8000}",
+    }
+    assert web["ports"] == [
+        "127.0.0.1:${REVIEWER_WEB_PUBLISH_PORT:-8000}:${REVIEWER_WEB_PORT:-8000}"
+    ]
+    assert web["depends_on"] == ["paradedb"]
+
+
 def test_env_example_documents_exact_test_endpoint_defaults() -> None:
     root = Path(__file__).parents[1]
     values = {

--- a/tests/web/test_container_smoke.py
+++ b/tests/web/test_container_smoke.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+import shutil
+import subprocess
+import time
+import uuid
+from collections.abc import Iterator
+from http.client import RemoteDisconnected
+from pathlib import Path
+from urllib.error import URLError
+from urllib.request import urlopen
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def _docker(*args: str, check: bool = True) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["docker", *args],
+        cwd=ROOT,
+        check=check,
+        capture_output=True,
+        text=True,
+    )
+
+
+@pytest.fixture(scope="module")
+def web_image() -> Iterator[str]:
+    if shutil.which("docker") is None:
+        pytest.skip("Docker CLI недоступен")
+    info = _docker("info", check=False)
+    if info.returncode != 0:
+        pytest.skip(f"Docker daemon недоступен: {info.stderr.strip()}")
+
+    image = f"rag-reviewer-web-smoke:{uuid.uuid4().hex}"
+    _docker("build", "-f", "web/Dockerfile", "-t", image, ".")
+    try:
+        yield image
+    finally:
+        _docker("image", "rm", "--force", image, check=False)
+
+
+@pytest.mark.integration
+@pytest.mark.parametrize("internal_port", [18080, 18081])
+def test_same_image_serves_http_on_different_internal_ports(
+    web_image: str,
+    internal_port: int,
+) -> None:
+    name = f"reviewer-web-smoke-{uuid.uuid4().hex}"
+    started = _docker(
+        "run",
+        "--detach",
+        "--rm",
+        "--name",
+        name,
+        "--env",
+        "PG_DSN=postgresql://reviewer:reviewer@127.0.0.1:1/reviewer?connect_timeout=1",
+        "--env",
+        f"REVIEWER_WEB_PORT={internal_port}",
+        "--publish",
+        f"127.0.0.1::{internal_port}",
+        web_image,
+    )
+    container_id = started.stdout.strip()
+    try:
+        published = _docker("port", container_id, f"{internal_port}/tcp").stdout.strip()
+        host_port = int(published.rsplit(":", 1)[1])
+        url = f"http://127.0.0.1:{host_port}/"
+        last_error: Exception | None = None
+        deadline = time.monotonic() + 45
+        while time.monotonic() < deadline:
+            try:
+                with urlopen(url, timeout=1) as response:
+                    body = response.read()
+                assert response.status == 200
+                assert body
+                break
+            except (RemoteDisconnected, URLError) as exc:
+                last_error = exc
+                time.sleep(0.25)
+        else:
+            logs = _docker("logs", container_id, check=False)
+            pytest.fail(
+                f"web image не ответил на {url}: {last_error}; "
+                f"logs:\n{logs.stdout}\n{logs.stderr}"
+            )
+    finally:
+        _docker("rm", "--force", container_id, check=False)

--- a/tests/web/test_serve.py
+++ b/tests/web/test_serve.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+from click.testing import CliRunner
+import pytest
+
+from reviewer.entrypoints.cli import cli
+from reviewer.web import serve
+
+
+def test_module_cli_uses_container_defaults(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls: list[tuple[str, int]] = []
+    monkeypatch.delenv("REVIEWER_WEB_HOST", raising=False)
+    monkeypatch.delenv("REVIEWER_WEB_PORT", raising=False)
+    monkeypatch.setattr(serve, "run_server", lambda host, port: calls.append((host, port)))
+
+    serve.main([])
+
+    assert calls == [("0.0.0.0", 8000)]
+
+
+def test_module_cli_reads_env_and_arguments_override_it(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: list[tuple[str, int]] = []
+    monkeypatch.setenv("REVIEWER_WEB_HOST", "0.0.0.0")
+    monkeypatch.setenv("REVIEWER_WEB_PORT", "8080")
+    monkeypatch.setattr(serve, "run_server", lambda host, port: calls.append((host, port)))
+
+    serve.main(["--host", "127.0.0.2", "--port", "9090"])
+
+    assert calls == [("127.0.0.2", 9090)]
+
+
+def test_module_cli_rejects_invalid_env_port(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    monkeypatch.setenv("REVIEWER_WEB_PORT", "not-a-port")
+
+    with pytest.raises(SystemExit) as exc_info:
+        serve.main([])
+
+    assert exc_info.value.code == 2
+    assert "invalid int value" in capsys.readouterr().err
+
+
+def test_run_server_builds_app_and_passes_host_port(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    settings = object()
+    app = object()
+    calls: list[tuple[object, str, int]] = []
+    monkeypatch.setattr("reviewer.config.settings.Settings", lambda: settings)
+    monkeypatch.setattr(
+        "reviewer.web.app.create_app",
+        lambda actual: app if actual is settings else None,
+    )
+    monkeypatch.setattr(
+        "uvicorn.run",
+        lambda actual, *, host, port: calls.append((actual, host, port)),
+    )
+
+    serve.run_server("127.0.0.2", 9090)
+
+    assert calls == [(app, "127.0.0.2", 9090)]
+    assert "http://127.0.0.2:9090" in capsys.readouterr().out
+
+
+def test_click_serve_delegates_to_shared_runner(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls: list[tuple[str, int]] = []
+    monkeypatch.setattr(serve, "run_server", lambda host, port: calls.append((host, port)))
+
+    result = CliRunner().invoke(cli, ["serve", "--host", "0.0.0.0", "--port", "8080"])
+
+    assert result.exit_code == 0
+    assert calls == [("0.0.0.0", 8080)]

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -17,12 +17,12 @@ FROM python:3.12-slim AS backend
 WORKDIR /app
 # Только рантайм-зависимости веб-слоя (не весь reviewer)
 RUN pip install --no-cache-dir \
-    "fastapi>=0.115" "uvicorn[standard]>=0.30" "psycopg[binary]>=3.2" "pydantic-settings>=2.3"
+    "fastapi>=0.115" "uvicorn[standard]>=0.30" "psycopg[binary]>=3.2" \
+    "psycopg-pool>=3.2" "pydantic-settings>=2.3"
 # Исходники reviewer (импортируются только reviewer.config + reviewer.web; остальное лежит без импорта)
 COPY reviewer/ ./reviewer/
 # Собранный фронт из stage 1 — путь совпадает с _FRONTEND_DIST в reviewer/web/app.py
 COPY --from=frontend /app/web/frontend/dist ./web/frontend/dist
 ENV PYTHONPATH=/app
-EXPOSE 8000
-# create_app(Settings()) читает PG_DSN из окружения (задаётся в docker-compose)
-CMD ["python", "-c", "import uvicorn; from reviewer.config.settings import Settings; from reviewer.web.app import create_app; uvicorn.run(create_app(Settings()), host='0.0.0.0', port=8000)"]
+# create_app(Settings()) читает PG_DSN, host и port приходят только из runtime.
+CMD ["python", "-m", "reviewer.web.serve"]


### PR DESCRIPTION
Задача: [PRI-222](https://ru.yougile.com/team/686c049c8af8/#PRI-222)
<!-- reviewer:task-link -->

## Summary
- объединяет `reviewer serve` и контейнерный запуск через лёгкий `reviewer.web.serve`
- убирает `EXPOSE` и литерал `8000` из Dockerfile, добавляет runtime host/port и opt-in Compose profile
- документирует docker run/Compose сценарии и проверяет один image на двух внутренних портах
- передаёт Basic Auth credentials в Compose только через runtime env

## Test Plan
- [x] `.venv/bin/pytest -q` (`3598 passed, 119 deselected`)
- [x] `.venv/bin/pytest -q -m integration tests/web/test_container_smoke.py` (`2 passed`)
- [x] `.venv/bin/ruff check .`
- [x] `docker compose --profile web config --quiet`
- [x] `docker compose config --services` (только `paradedb`, `neo4j`)
- [x] `git diff --check dev...HEAD`

## Review
- отдельный code review не нашёл Critical/Important замечаний
- замечание о passthrough `WEB_ADMIN_USER/PASSWORD` исправлено в `381c2dd`