### PR TITLE
chore(release): rag-reviewer 0.4.4

### DIFF
--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "rag-reviewer",
-  "version": "0.4.3+codex.67fd471155e9",
+  "version": "0.4.4+codex.83c1d35785f4",
   "description": "Agentic PR review: hybrid RAG + code graph via MCP, review skills for Codex",
   "repository": "https://github.com/mimfort/rag_for_git",
   "license": "MIT",

--- a/README.md
+++ b/README.md
@@ -28,23 +28,20 @@ You need Python 3.11–3.13, [uv](https://docs.astral.sh/uv/), Docker, a Voyage 
 version-control system (VCS) token if reviewer should read or publish pull-request reviews. The
 stores run locally; embedding and reranking requests go to Voyage.
 
-1. Install the launcher, download the repository's Compose file into reviewer's config directory,
-   start the stores, and configure reviewer:
+1. Install the launcher, synchronize reviewer's managed artifacts, start the stores, and configure
+   reviewer:
 
    ```bash
    uv tool install rag-reviewer
-   mkdir -p ~/.config/rag-reviewer
-   curl -o ~/.config/rag-reviewer/docker-compose.yml \
-     https://raw.githubusercontent.com/mimfort/rag_for_git/main/docker-compose.yml
+   reviewer update
    docker compose -f ~/.config/rag-reviewer/docker-compose.yml up -d
    reviewer init
    ```
 
-   The Compose file lives next to the env file in `$XDG_CONFIG_HOME/rag-reviewer/`
-   (`~/.config/rag-reviewer/` by default), so one store stack serves every repository and the
-   Compose project name stays the same no matter which repository you are standing in. Plain
-   `curl -O` writes into the current directory instead; inside a clone of this repository it
-   overwrites the tracked `docker-compose.yml`.
+   `reviewer update` creates the managed Compose file next to the env file in
+   `$XDG_CONFIG_HOME/rag-reviewer/` (`~/.config/rag-reviewer/` by default). One store stack therefore
+   serves every repository, and the Compose project name stays independent of the current working
+   directory. The command also refreshes detected AI-client integrations and skills.
 
 2. See the supported AI clients and connect one:
 
@@ -102,9 +99,7 @@ reviewer env on every workstation instead of using the loopback Compose defaults
 1. **On the shared host, start the stores and configure secrets for the service account.**
 
    ```bash
-   mkdir -p ~/.config/rag-reviewer
-   curl -o ~/.config/rag-reviewer/docker-compose.yml \
-     https://raw.githubusercontent.com/mimfort/rag_for_git/main/docker-compose.yml
+   reviewer update
    docker compose -f ~/.config/rag-reviewer/docker-compose.yml up -d
    reviewer init
    ```
@@ -247,18 +242,40 @@ reviewer update
 (`--from rag-reviewer==0.4.3`, `--from git+…`); `--from PACKAGE COMMAND` is `uvx` syntax and
 `uv tool install` rejects it.
 
+For the one-time transition from 0.4.3, start the new lifecycle through latest uvx and explicitly
+allow it to upgrade the existing persistent tool:
+
+```bash
+uvx --refresh --from rag-reviewer@latest reviewer update --upgrade-tool
+```
+
+Every later update is the short command `reviewer update`. It performs one lifecycle:
+
+- checks PyPI and upgrades the persistent `uv tool` package when a newer version exists;
+- refreshes every detected AI-client MCP integration, native plugin, and file-based skill set;
+- synchronizes `$XDG_CONFIG_HOME/rag-reviewer/docker-compose.yml` from the canonical repository;
+- records the managed Compose content hash in `.reviewer-update.json`.
+
+If the Compose file differs from its recorded hash, reviewer treats it as user-modified, leaves it
+unchanged, and prints a warning. Update does not run `docker compose pull`, restart services, remove
+containers, or delete volumes, so existing databases, indexes, tasks, and subsystem summaries stay
+intact. Apply a new Compose definition when convenient with the documented `docker compose ... up
+-d` command.
+
 Temporary/latest invocation:
 
 ```bash
 uvx --from rag-reviewer@latest reviewer --help
 ```
 
-`reviewer update` checks before mutating a persistent uv tool installation. Use
-`reviewer install CLIENT --dry-run` to inspect integration writes.
+An ordinary uvx invocation never mutates a separate persistent tool; only the explicit
+`--upgrade-tool` bootstrap does. Use `reviewer install CLIENT --dry-run` to inspect a named
+integration write.
 
 ### AI clients
 
-Discover clients with `reviewer install --list`; install one client or every detected client:
+`reviewer update` refreshes all detected clients automatically. Use `reviewer install --list` and a
+named install when connecting a client for the first time, before it can be detected:
 
 ```bash
 reviewer install codex
@@ -283,7 +300,7 @@ claude plugin list --json
 claude plugin marketplace list --json
 ```
 
-After installation, start a new chat/CLI session; in an IDE, also use Reload Window.
+After installation or update, start a New Chat/new CLI session; in an IDE, also use Reload Window.
 
 ### Breaking skill-name migration
 

--- a/README.ru.md
+++ b/README.ru.md
@@ -28,23 +28,20 @@ inline-комментарии, привязанные к изменённым с
 системы контроля версий (VCS), если reviewer должен читать или публиковать ревью. Хранилища
 работают локально; запросы эмбеддингов и реранкинга отправляются в Voyage.
 
-1. Установите launcher, скачайте Compose-файл репозитория в каталог конфигурации reviewer,
-   поднимите хранилища и настройте reviewer:
+1. Установите launcher, синхронизируйте управляемые reviewer artifacts, поднимите хранилища и
+   настройте reviewer:
 
    ```bash
    uv tool install rag-reviewer
-   mkdir -p ~/.config/rag-reviewer
-   curl -o ~/.config/rag-reviewer/docker-compose.yml \
-     https://raw.githubusercontent.com/mimfort/rag_for_git/main/docker-compose.yml
+   reviewer update
    docker compose -f ~/.config/rag-reviewer/docker-compose.yml up -d
    reviewer init
    ```
 
-   Compose-файл лежит рядом с env-файлом в `$XDG_CONFIG_HOME/rag-reviewer/` (по умолчанию
-   `~/.config/rag-reviewer/`), поэтому один набор хранилищ обслуживает все репозитории, а имя
-   Compose-проекта не зависит от каталога, из которого вы запускаете команду. Голый `curl -O`
-   пишет в текущий каталог; внутри клона этого репозитория он перезапишет версионируемый
-   `docker-compose.yml`.
+   `reviewer update` создаёт управляемый Compose-файл рядом с env-файлом в
+   `$XDG_CONFIG_HOME/rag-reviewer/` (по умолчанию `~/.config/rag-reviewer/`). Поэтому один набор
+   хранилищ обслуживает все репозитории, а имя Compose-проекта не зависит от текущего каталога.
+   Команда также обновляет обнаруженные AI-client integrations и скиллы.
 
 2. Посмотрите поддерживаемые AI-клиенты и подключите нужный:
 
@@ -102,9 +99,7 @@ reviewer env на каждой машине вместо loopback defaults из 
 1. **На shared host поднимите хранилища и настройте секреты service account.**
 
    ```bash
-   mkdir -p ~/.config/rag-reviewer
-   curl -o ~/.config/rag-reviewer/docker-compose.yml \
-     https://raw.githubusercontent.com/mimfort/rag_for_git/main/docker-compose.yml
+   reviewer update
    docker compose -f ~/.config/rag-reviewer/docker-compose.yml up -d
    reviewer init
    ```
@@ -250,18 +245,41 @@ reviewer update
 `--from git+…`); форма `--from PACKAGE COMMAND` относится к `uvx`, и `uv tool install` её
 отвергает.
 
+Для одноразового перехода с 0.4.3 запустите новый lifecycle через latest uvx и явно разрешите ему
+обновить существующий persistent tool:
+
+```bash
+uvx --refresh --from rag-reviewer@latest reviewer update --upgrade-tool
+```
+
+Все последующие обновления выполняются короткой командой `reviewer update`. Она запускает единый
+lifecycle:
+
+- проверяет PyPI и обновляет persistent `uv tool` package при наличии новой версии;
+- обновляет MCP integration, native plugin и файловые скиллы каждого обнаруженного AI-клиента;
+- синхронизирует `$XDG_CONFIG_HOME/rag-reviewer/docker-compose.yml` с каноническим репозиторием;
+- записывает hash управляемого Compose-содержимого в `.reviewer-update.json`.
+
+Если Compose-файл отличается от записанного hash, reviewer считает его изменённым пользователем,
+оставляет без изменений и выводит предупреждение. Update не запускает `docker compose pull`, не
+перезапускает services, не удаляет containers или volumes, поэтому существующие БД, индексы,
+задачи и subsystem summaries сохраняются. Новое Compose-описание можно применить позже
+документированной командой `docker compose ... up -d`.
+
 Временный/latest запуск:
 
 ```bash
 uvx --from rag-reviewer@latest reviewer --help
 ```
 
-`reviewer update` сначала проверяет версию и только потом меняет постоянную uv tool installation.
-`reviewer install CLIENT --dry-run` показывает записи integration до изменения файлов.
+Обычный uvx-запуск не меняет отдельный persistent tool; это делает только явный bootstrap-флаг
+`--upgrade-tool`. `reviewer install CLIENT --dry-run` показывает запись конкретной integration до
+изменения файлов.
 
 ### AI-клиенты
 
-Список клиентов показывает `reviewer install --list`; можно установить один или все обнаруженные:
+`reviewer update` автоматически обновляет все обнаруженные клиенты. `reviewer install --list` и
+именная установка нужны при первом подключении клиента, пока его ещё нельзя обнаружить:
 
 ```bash
 reviewer install codex
@@ -286,7 +304,8 @@ claude plugin list --json
 claude plugin marketplace list --json
 ```
 
-После установки начните новую chat/CLI session; в IDE также выполните Reload Window.
+После установки или обновления начните New Chat/new CLI session; в IDE также выполните Reload
+Window.
 
 ### Миграция с ломающим изменением имён скиллов
 

--- a/docs/superpowers/plans/2026-08-09-unified-update-command.md
+++ b/docs/superpowers/plans/2026-08-09-unified-update-command.md
@@ -1,0 +1,932 @@
+# Unified Update Command Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Turn `reviewer update` into the one-command package, client integration, skills, and no-clobber Compose update lifecycle.
+
+**Architecture:** Keep package-version detection in `reviewer/versioning.py`, add a focused `reviewer/update_lifecycle.py` for managed Compose state and fresh-process execution, and let the Click command reuse `reviewer install --all` through `Context.invoke`. A hidden artifact phase prevents recursion after an in-place `uv tool` upgrade; an explicit `--upgrade-tool` lets the latest uvx process bootstrap the already-installed 0.4.3 tool safely.
+
+**Tech Stack:** Python 3.11, Click, urllib, SHA-256/JSON sidecar state, uv tool/uvx, pytest, Ruff, bilingual Markdown guard tests.
+
+---
+
+## File Map
+
+- Create `reviewer/update_lifecycle.py`: download and safely synchronize the canonical Compose file; launch the updated persistent CLI in a fresh process.
+- Create `tests/test_update_lifecycle.py`: pure unit coverage for Compose ownership, download behavior, and subprocess dispatch.
+- Modify `reviewer/entrypoints/cli.py`: two-phase update orchestration, explicit uvx bootstrap, detected-client refresh, phase error aggregation.
+- Modify `tests/entrypoints/test_update_command.py`: CLI behavior for uv tool, uvx, editable, fresh-process, client refresh, and partial failures.
+- Modify `reviewer/launcher/metadata.py`: describe update as the complete mutating lifecycle.
+- Modify `tests/launcher/test_catalog.py`: lock the new launcher description.
+- Modify `README.md` and `README.ru.md`: remove manual Compose downloads and document bootstrap/steady-state update behavior in parallel.
+- Modify `tests/docs/test_readme_onboarding.py`: require the one-command lifecycle and reject onboarding `curl` instructions.
+- Modify `pyproject.toml`, `uv.lock`, `plugin/.claude-plugin/plugin.json`, `.codex-plugin/plugin.json`, and `plugin/.codex-plugin/plugin.json`: publish the feature as 0.4.4 with synchronized manifests.
+
+### Task 1: Managed Compose Synchronization
+
+**Files:**
+- Create: `reviewer/update_lifecycle.py`
+- Create: `tests/test_update_lifecycle.py`
+
+- [ ] **Step 1: Write failing tests for create, adopt, no-op, managed update, and modified preservation**
+
+```python
+import hashlib
+import json
+
+from reviewer.update_lifecycle import sync_compose_file
+
+
+def _digest(content: bytes) -> str:
+    return "sha256:" + hashlib.sha256(content).hexdigest()
+
+
+def test_sync_compose_creates_missing_target_and_state(tmp_path):
+    content = b"services:\n  db: {}\n"
+
+    result = sync_compose_file(content, config_dir=tmp_path)
+
+    assert result.action == "created"
+    assert result.path.read_bytes() == content
+    state = json.loads((tmp_path / ".reviewer-update.json").read_text())
+    assert state == {"docker_compose_sha256": _digest(content)}
+
+
+def test_sync_compose_adopts_exact_unmanaged_download(tmp_path):
+    content = b"services:\n  db: {}\n"
+    (tmp_path / "docker-compose.yml").write_bytes(content)
+
+    result = sync_compose_file(content, config_dir=tmp_path)
+
+    assert result.action == "adopted"
+    assert json.loads((tmp_path / ".reviewer-update.json").read_text()) == {
+        "docker_compose_sha256": _digest(content)
+    }
+
+
+def test_sync_compose_reports_current_managed_file(tmp_path):
+    content = b"services:\n  db: {}\n"
+    sync_compose_file(content, config_dir=tmp_path)
+
+    result = sync_compose_file(content, config_dir=tmp_path)
+
+    assert result.action == "current"
+
+
+def test_sync_compose_updates_only_file_matching_recorded_hash(tmp_path):
+    old = b"services:\n  db: {image: old}\n"
+    new = b"services:\n  db: {image: new}\n"
+    sync_compose_file(old, config_dir=tmp_path)
+
+    result = sync_compose_file(new, config_dir=tmp_path)
+
+    assert result.action == "updated"
+    assert result.path.read_bytes() == new
+
+
+def test_sync_compose_preserves_modified_managed_file_and_old_state(tmp_path):
+    old = b"services:\n  db: {image: old}\n"
+    new = b"services:\n  db: {image: new}\n"
+    sync_compose_file(old, config_dir=tmp_path)
+    target = tmp_path / "docker-compose.yml"
+    target.write_bytes(b"services:\n  db: {ports: [custom]}\n")
+    state_before = (tmp_path / ".reviewer-update.json").read_bytes()
+
+    result = sync_compose_file(new, config_dir=tmp_path)
+
+    assert result.action == "preserved"
+    assert target.read_bytes() == b"services:\n  db: {ports: [custom]}\n"
+    assert (tmp_path / ".reviewer-update.json").read_bytes() == state_before
+
+
+def test_sync_compose_preserves_unmanaged_nonmatching_file(tmp_path):
+    target = tmp_path / "docker-compose.yml"
+    target.write_bytes(b"custom\n")
+
+    result = sync_compose_file(b"canonical\n", config_dir=tmp_path)
+
+    assert result.action == "preserved"
+    assert target.read_bytes() == b"custom\n"
+    assert not (tmp_path / ".reviewer-update.json").exists()
+```
+
+- [ ] **Step 2: Run the focused tests and verify RED**
+
+Run: `.venv/bin/pytest tests/test_update_lifecycle.py -q`
+
+Expected: collection fails with `ModuleNotFoundError: No module named 'reviewer.update_lifecycle'`.
+
+- [ ] **Step 3: Implement the minimal no-clobber state machine with atomic writes**
+
+```python
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Literal
+
+
+COMPOSE_URL = (
+    "https://raw.githubusercontent.com/mimfort/rag_for_git/main/docker-compose.yml"
+)
+STATE_NAME = ".reviewer-update.json"
+
+
+@dataclass(frozen=True)
+class ComposeSyncResult:
+    action: Literal["created", "adopted", "current", "updated", "preserved"]
+    path: Path
+
+
+def default_config_dir() -> Path:
+    root = os.environ.get("XDG_CONFIG_HOME")
+    return (Path(root).expanduser() if root else Path.home() / ".config") / "rag-reviewer"
+
+
+def _digest(content: bytes) -> str:
+    return "sha256:" + hashlib.sha256(content).hexdigest()
+
+
+def _atomic_write(path: Path, content: bytes) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with tempfile.NamedTemporaryFile(dir=path.parent, delete=False) as tmp:
+        tmp.write(content)
+        temporary = Path(tmp.name)
+    temporary.replace(path)
+
+
+def _read_recorded_hash(path: Path) -> str | None:
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return None
+    value = payload.get("docker_compose_sha256") if isinstance(payload, dict) else None
+    return value if isinstance(value, str) and value.startswith("sha256:") else None
+
+
+def _write_state(path: Path, digest: str) -> None:
+    content = json.dumps(
+        {"docker_compose_sha256": digest}, indent=2, ensure_ascii=False
+    ).encode("utf-8") + b"\n"
+    _atomic_write(path, content)
+
+
+def sync_compose_file(
+    content: bytes,
+    *,
+    config_dir: Path | None = None,
+) -> ComposeSyncResult:
+    directory = config_dir or default_config_dir()
+    target = directory / "docker-compose.yml"
+    state_path = directory / STATE_NAME
+    incoming_hash = _digest(content)
+
+    if not target.exists():
+        _atomic_write(target, content)
+        _write_state(state_path, incoming_hash)
+        return ComposeSyncResult("created", target)
+
+    existing = target.read_bytes()
+    existing_hash = _digest(existing)
+    recorded_hash = _read_recorded_hash(state_path)
+    if existing_hash == incoming_hash:
+        action = "current" if recorded_hash == incoming_hash else "adopted"
+        _write_state(state_path, incoming_hash)
+        return ComposeSyncResult(action, target)
+    if recorded_hash is None or recorded_hash != existing_hash:
+        return ComposeSyncResult("preserved", target)
+
+    _atomic_write(target, content)
+    _write_state(state_path, incoming_hash)
+    return ComposeSyncResult("updated", target)
+```
+
+- [ ] **Step 4: Run the focused tests and verify GREEN**
+
+Run: `.venv/bin/pytest tests/test_update_lifecycle.py -q`
+
+Expected: `6 passed`.
+
+- [ ] **Step 5: Commit the managed Compose state machine**
+
+```bash
+git add reviewer/update_lifecycle.py tests/test_update_lifecycle.py
+git commit -m "feat(update): безопасно синхронизировать Compose"
+```
+
+### Task 2: Compose Download and Fresh-Process Dispatch
+
+**Files:**
+- Modify: `reviewer/update_lifecycle.py`
+- Modify: `tests/test_update_lifecycle.py`
+
+- [ ] **Step 1: Add failing tests for HTTPS download and subprocess output capture**
+
+```python
+from contextlib import nullcontext
+from types import SimpleNamespace
+
+from reviewer.update_lifecycle import download_compose, run_fresh_artifact_refresh
+
+
+def test_download_compose_uses_canonical_url_and_no_cache_headers():
+    seen = {}
+
+    def opener(request, timeout):
+        seen["url"] = request.full_url
+        seen["cache"] = request.headers["Cache-control"]
+        seen["timeout"] = timeout
+        return nullcontext(SimpleNamespace(read=lambda: b"services: {}\n"))
+
+    assert download_compose(opener=opener, timeout=7) == b"services: {}\n"
+    assert seen == {
+        "url": (
+            "https://raw.githubusercontent.com/mimfort/rag_for_git/"
+            "main/docker-compose.yml"
+        ),
+        "cache": "no-cache, no-store",
+        "timeout": 7,
+    }
+
+
+def test_run_fresh_artifact_refresh_invokes_reviewer_hidden_phase():
+    calls = []
+
+    def run(argv, **kwargs):
+        calls.append((argv, kwargs))
+        return SimpleNamespace(returncode=0, stdout="compose current\n", stderr="")
+
+    result = run_fresh_artifact_refresh(
+        which=lambda name: "/tools/reviewer" if name == "reviewer" else None,
+        run=run,
+    )
+
+    assert calls == [
+        (
+            ["/tools/reviewer", "update", "--refresh-artifacts"],
+            {"capture_output": True, "text": True},
+        )
+    ]
+    assert result.returncode == 0
+    assert result.stdout == "compose current\n"
+
+
+def test_run_fresh_artifact_refresh_reports_missing_executable():
+    result = run_fresh_artifact_refresh(which=lambda name: None)
+
+    assert result.returncode == 127
+    assert "reviewer не найден" in result.stderr
+```
+
+- [ ] **Step 2: Run the new tests and verify RED**
+
+Run: `.venv/bin/pytest tests/test_update_lifecycle.py -q`
+
+Expected: import fails for `download_compose` and `run_fresh_artifact_refresh`.
+
+- [ ] **Step 3: Implement download and fresh-process helpers**
+
+```python
+import shutil
+import subprocess
+import urllib.request
+from collections.abc import Callable
+
+
+@dataclass(frozen=True)
+class RefreshProcessResult:
+    returncode: int
+    stdout: str
+    stderr: str
+
+
+def download_compose(
+    *,
+    opener: Callable = urllib.request.urlopen,
+    timeout: int = 30,
+) -> bytes:
+    request = urllib.request.Request(
+        COMPOSE_URL,
+        headers={"Cache-Control": "no-cache, no-store", "Pragma": "no-cache"},
+    )
+    with opener(request, timeout=timeout) as response:
+        return response.read()
+
+
+def run_fresh_artifact_refresh(
+    *,
+    which: Callable[[str], str | None] = shutil.which,
+    run: Callable = subprocess.run,
+) -> RefreshProcessResult:
+    executable = which("reviewer")
+    if executable is None:
+        return RefreshProcessResult(127, "", "reviewer не найден в PATH")
+    result = run(
+        [executable, "update", "--refresh-artifacts"],
+        capture_output=True,
+        text=True,
+    )
+    return RefreshProcessResult(
+        result.returncode,
+        result.stdout or "",
+        result.stderr or "",
+    )
+```
+
+- [ ] **Step 4: Run lifecycle tests and Ruff**
+
+Run: `.venv/bin/pytest tests/test_update_lifecycle.py -q && .venv/bin/ruff check reviewer/update_lifecycle.py tests/test_update_lifecycle.py`
+
+Expected: all lifecycle tests pass and Ruff exits 0.
+
+- [ ] **Step 5: Commit download and process dispatch**
+
+```bash
+git add reviewer/update_lifecycle.py tests/test_update_lifecycle.py
+git commit -m "feat(update): запускать обновлённый CLI отдельным процессом"
+```
+
+### Task 3: Two-Phase CLI and Explicit uvx Bootstrap
+
+**Files:**
+- Modify: `reviewer/entrypoints/cli.py:51,1486-1530`
+- Modify: `tests/entrypoints/test_update_command.py`
+
+- [ ] **Step 1: Replace exact legacy-output tests with failing lifecycle assertions**
+
+```python
+def test_update_uv_tool_upgrade_runs_artifacts_in_fresh_process(monkeypatch):
+    info = InstallationInfo(InstallMode.UV_TOOL, "0.4.3", "/usr/bin/uv")
+    refreshed = Mock(return_value=SimpleNamespace(returncode=0, stdout="artifacts ok\n", stderr=""))
+    monkeypatch.setattr(cli_mod, "detect_installation", lambda: info)
+    monkeypatch.setattr(cli_mod, "check_latest", lambda value: VersionCheck(value, "0.4.4", True))
+    monkeypatch.setattr(cli_mod, "upgrade_uv_tool", lambda value: UpgradeResult(0, ""))
+    monkeypatch.setattr(cli_mod, "run_fresh_artifact_refresh", refreshed)
+
+    result = CliRunner().invoke(cli_mod.cli, ["update"])
+
+    assert result.exit_code == 0, result.output
+    assert "Доступна новая версия: 0.4.3 → 0.4.4" in result.output
+    assert "artifacts ok" in result.output
+    refreshed.assert_called_once_with()
+
+
+def test_update_uv_tool_stops_before_artifacts_when_upgrade_fails(monkeypatch):
+    info = InstallationInfo(InstallMode.UV_TOOL, "0.4.3", "/usr/bin/uv")
+    refreshed = Mock()
+    monkeypatch.setattr(cli_mod, "detect_installation", lambda: info)
+    monkeypatch.setattr(cli_mod, "check_latest", lambda value: VersionCheck(value, "0.4.4", True))
+    monkeypatch.setattr(cli_mod, "upgrade_uv_tool", lambda value: UpgradeResult(1, "registry unavailable"))
+    monkeypatch.setattr(cli_mod, "run_fresh_artifact_refresh", refreshed)
+
+    result = CliRunner().invoke(cli_mod.cli, ["update"])
+
+    assert result.exit_code != 0
+    assert "registry unavailable" in result.output
+    refreshed.assert_not_called()
+
+
+def test_update_current_version_refreshes_artifacts_in_process(monkeypatch):
+    info = InstallationInfo(InstallMode.UV_TOOL, "0.4.4", "/usr/bin/uv")
+    refresh = Mock()
+    monkeypatch.setattr(cli_mod, "detect_installation", lambda: info)
+    monkeypatch.setattr(cli_mod, "check_latest", lambda value: VersionCheck(value, "0.4.4", False))
+    monkeypatch.setattr(cli_mod, "_refresh_update_artifacts", refresh)
+
+    result = CliRunner().invoke(cli_mod.cli, ["update"])
+
+    assert result.exit_code == 0, result.output
+    refresh.assert_called_once()
+
+
+def test_update_uvx_upgrade_tool_is_explicit(monkeypatch):
+    info = InstallationInfo(InstallMode.UVX, "0.4.4", "/usr/bin/uv")
+    upgrade = Mock(return_value=UpgradeResult(0, ""))
+    refresh = Mock()
+    monkeypatch.setattr(cli_mod, "detect_installation", lambda: info)
+    monkeypatch.setattr(cli_mod, "check_latest", lambda value: VersionCheck(value, "0.4.4", False))
+    monkeypatch.setattr(cli_mod, "upgrade_uv_tool", upgrade)
+    monkeypatch.setattr(cli_mod, "_refresh_update_artifacts", refresh)
+
+    regular = CliRunner().invoke(cli_mod.cli, ["update"])
+    bootstrap = CliRunner().invoke(cli_mod.cli, ["update", "--upgrade-tool"])
+
+    assert regular.exit_code == 0, regular.output
+    assert bootstrap.exit_code == 0, bootstrap.output
+    upgrade.assert_called_once_with(info)
+    assert refresh.call_count == 2
+
+
+def test_update_editable_refreshes_artifacts_without_touching_source(monkeypatch):
+    info = InstallationInfo(InstallMode.EDITABLE, "0.4.4", "/usr/bin/uv")
+    refresh = Mock()
+    monkeypatch.setattr(cli_mod, "detect_installation", lambda: info)
+    monkeypatch.setattr(cli_mod, "_refresh_update_artifacts", refresh)
+
+    result = CliRunner().invoke(cli_mod.cli, ["update"])
+
+    assert result.exit_code == 0, result.output
+    assert "git pull && pip install -e ." in result.output
+    refresh.assert_called_once()
+```
+
+- [ ] **Step 2: Run CLI tests and verify RED**
+
+Run: `.venv/bin/pytest tests/entrypoints/test_update_command.py -q`
+
+Expected: failures mention missing `--upgrade-tool`, `_refresh_update_artifacts`, and `run_fresh_artifact_refresh` dispatch.
+
+- [ ] **Step 3: Implement hidden phase, bootstrap option, and fresh-process result handling**
+
+```python
+from reviewer.update_lifecycle import (
+    download_compose,
+    run_fresh_artifact_refresh,
+    sync_compose_file,
+)
+
+
+@cli.command()
+@click.option(
+    "--upgrade-tool",
+    is_flag=True,
+    help="обновить существующую persistent uv tool installation из latest uvx",
+)
+@click.option("--refresh-artifacts", is_flag=True, hidden=True)
+@click.pass_context
+def update(ctx: click.Context, upgrade_tool: bool, refresh_artifacts: bool) -> None:
+    """Обновить пакет, AI-client integrations, скилы и Compose-файл."""
+    if refresh_artifacts:
+        _refresh_update_artifacts(ctx)
+        return
+
+    installation = detect_installation()
+    if installation.mode is InstallMode.EDITABLE:
+        click.echo(f"Режим: dev (editable) | Версия: {installation.current}")
+        click.echo("Исходники не изменены. Для обновления: git pull && pip install -e .")
+        _refresh_update_artifacts(ctx)
+        return
+
+    mode = (
+        "uv tool (постоянная)"
+        if installation.mode is InstallMode.UV_TOOL
+        else "uvx (временная)"
+    )
+    click.echo(f"Режим: {mode} | Версия: {installation.current}")
+    tool_upgraded = False
+    version_check = check_latest(installation)
+    if version_check.latest is None:
+        click.echo("Не удалось получить информацию с PyPI. Обновляю доступные artifacts.")
+    elif not version_check.current_valid:
+        click.echo("Не удалось определить корректную текущую версию; пакет не изменён.")
+    elif version_check.update_available:
+        click.echo(
+            f"Доступна новая версия: {installation.current} → {version_check.latest}"
+        )
+        if installation.mode is InstallMode.UV_TOOL or upgrade_tool:
+            result = upgrade_uv_tool(installation)
+            if result.returncode != 0:
+                raise click.ClickException(f"Ошибка uv tool upgrade: {result.stderr}")
+            tool_upgraded = True
+            click.echo("✓ Python package обновлён.")
+            if installation.mode is InstallMode.UV_TOOL:
+                fresh = run_fresh_artifact_refresh()
+                if fresh.stdout:
+                    click.echo(fresh.stdout, nl=not fresh.stdout.endswith("\n"))
+                if fresh.returncode != 0:
+                    detail = fresh.stderr.strip() or "неизвестная ошибка"
+                    raise click.ClickException(
+                        f"Пакет обновлён, artifact refresh завершился ошибкой: {detail}"
+                    )
+                return
+    elif installation.current != "?":
+        click.echo(f"Версия актуальна: {installation.current}.")
+
+    if upgrade_tool and installation.mode is InstallMode.UVX and not tool_upgraded:
+        result = upgrade_uv_tool(installation)
+        if result.returncode != 0:
+            raise click.ClickException(f"Ошибка uv tool upgrade: {result.stderr}")
+        click.echo("✓ Persistent uv tool installation обновлена.")
+    _refresh_update_artifacts(ctx)
+```
+
+- [ ] **Step 4: Run update CLI tests and fix output assertions without weakening behavior checks**
+
+Run: `.venv/bin/pytest tests/entrypoints/test_update_command.py -q`
+
+Expected: all update-command tests pass; the existing UVX safety test proves a regular uvx invocation never calls `upgrade_uv_tool`.
+
+- [ ] **Step 5: Commit package/process orchestration**
+
+```bash
+git add reviewer/entrypoints/cli.py tests/entrypoints/test_update_command.py
+git commit -m "feat(update): объединить package и artifact lifecycle"
+```
+
+### Task 4: Detected Integrations and Partial-Failure Reporting
+
+**Files:**
+- Modify: `reviewer/entrypoints/cli.py`
+- Modify: `tests/entrypoints/test_update_command.py`
+
+- [ ] **Step 1: Add failing artifact-phase tests**
+
+```python
+from reviewer.update_lifecycle import ComposeSyncResult
+
+
+def test_refresh_artifacts_updates_compose_and_skips_absent_clients(monkeypatch, tmp_path):
+    target = tmp_path / "docker-compose.yml"
+    install_call = Mock()
+    monkeypatch.setattr(cli_mod, "download_compose", lambda: b"services: {}\n")
+    monkeypatch.setattr(
+        cli_mod,
+        "sync_compose_file",
+        lambda content: ComposeSyncResult("created", target),
+    )
+    monkeypatch.setattr(cli_mod, "_has_detected_clients", lambda: False)
+    monkeypatch.setattr(cli_mod, "_install_detected_clients", install_call)
+
+    result = CliRunner().invoke(cli_mod.cli, ["update", "--refresh-artifacts"])
+
+    assert result.exit_code == 0, result.output
+    assert f"Compose создан: {target}" in result.output
+    assert "AI-клиенты не обнаружены" in result.output
+    install_call.assert_not_called()
+
+
+def test_refresh_artifacts_preserves_modified_compose_and_updates_clients(monkeypatch, tmp_path):
+    target = tmp_path / "docker-compose.yml"
+    install_call = Mock()
+    monkeypatch.setattr(cli_mod, "download_compose", lambda: b"services: {}\n")
+    monkeypatch.setattr(
+        cli_mod,
+        "sync_compose_file",
+        lambda content: ComposeSyncResult("preserved", target),
+    )
+    monkeypatch.setattr(cli_mod, "_has_detected_clients", lambda: True)
+    monkeypatch.setattr(cli_mod, "_install_detected_clients", install_call)
+
+    result = CliRunner().invoke(cli_mod.cli, ["update", "--refresh-artifacts"])
+
+    assert result.exit_code == 0, result.output
+    assert "не перезаписан" in result.output
+    install_call.assert_called_once()
+
+
+def test_refresh_artifacts_attempts_clients_after_compose_download_failure(monkeypatch):
+    install_call = Mock()
+    monkeypatch.setattr(cli_mod, "download_compose", lambda: (_ for _ in ()).throw(OSError("offline")))
+    monkeypatch.setattr(cli_mod, "_has_detected_clients", lambda: True)
+    monkeypatch.setattr(cli_mod, "_install_detected_clients", install_call)
+
+    result = CliRunner().invoke(cli_mod.cli, ["update", "--refresh-artifacts"])
+
+    assert result.exit_code != 0
+    assert "Compose: OSError" in result.output
+    install_call.assert_called_once()
+
+
+def test_refresh_artifacts_aggregates_integration_failure(monkeypatch, tmp_path):
+    target = tmp_path / "docker-compose.yml"
+    monkeypatch.setattr(cli_mod, "download_compose", lambda: b"services: {}\n")
+    monkeypatch.setattr(
+        cli_mod,
+        "sync_compose_file",
+        lambda content: ComposeSyncResult("current", target),
+    )
+    monkeypatch.setattr(cli_mod, "_has_detected_clients", lambda: True)
+    monkeypatch.setattr(
+        cli_mod,
+        "_install_detected_clients",
+        lambda ctx: (_ for _ in ()).throw(click.ClickException("Codex failed")),
+    )
+
+    result = CliRunner().invoke(cli_mod.cli, ["update", "--refresh-artifacts"])
+
+    assert result.exit_code != 0
+    assert "Integrations: Codex failed" in result.output
+```
+
+- [ ] **Step 2: Run artifact-phase tests and verify RED**
+
+Run: `.venv/bin/pytest tests/entrypoints/test_update_command.py -q`
+
+Expected: failures mention missing `_has_detected_clients`, `_install_detected_clients`, and artifact status/error output.
+
+- [ ] **Step 3: Implement reuse of the existing installer and aggregate phase errors**
+
+```python
+def _has_detected_clients() -> bool:
+    from reviewer import install as inst
+
+    return bool(inst.detect_installed()) or _shutil.which("claude") is not None
+
+
+def _install_detected_clients(ctx: click.Context) -> None:
+    ctx.invoke(
+        install,
+        client=None,
+        all_clients=True,
+        list_clients=False,
+        path_opt=None,
+        pin=None,
+        no_latest=False,
+        no_skills=False,
+        dry_run=False,
+    )
+
+
+def _print_compose_result(result) -> None:
+    messages = {
+        "created": f"✓ Compose создан: {result.path}",
+        "adopted": f"✓ Compose принят под управление: {result.path}",
+        "current": f"✓ Compose актуален: {result.path}",
+        "updated": f"✓ Compose обновлён: {result.path}",
+        "preserved": (
+            f"⚠ Compose не перезаписан: обнаружены пользовательские изменения в "
+            f"{result.path}"
+        ),
+    }
+    click.echo(messages[result.action])
+
+
+def _refresh_update_artifacts(ctx: click.Context) -> None:
+    errors: list[str] = []
+    try:
+        compose = sync_compose_file(download_compose())
+        _print_compose_result(compose)
+    except Exception as exc:  # noqa: BLE001 - independent phases must continue
+        errors.append(f"Compose: {type(exc).__name__}")
+
+    if _has_detected_clients():
+        try:
+            _install_detected_clients(ctx)
+        except click.ClickException as exc:
+            errors.append(f"Integrations: {exc.format_message()}")
+    else:
+        click.echo("AI-клиенты не обнаружены; integration refresh пропущен.")
+
+    if errors:
+        raise click.ClickException("Обновление завершено частично: " + "; ".join(errors))
+    click.echo("Обновление завершено. Откройте New Chat/new CLI session; в IDE — Reload Window.")
+```
+
+- [ ] **Step 4: Run update/install regression tests**
+
+Run: `.venv/bin/pytest tests/entrypoints/test_update_command.py tests/install/test_install.py tests/install/test_install_skills_cli.py tests/install/test_claude_install.py tests/install/test_codex_install.py -q`
+
+Expected: all selected tests pass; generic and native lifecycle behavior remains covered by its existing contract tests.
+
+- [ ] **Step 5: Commit integration refresh**
+
+```bash
+git add reviewer/entrypoints/cli.py tests/entrypoints/test_update_command.py
+git commit -m "feat(update): обновлять integrations и скилы"
+```
+
+### Task 5: Launcher and Bilingual Documentation
+
+**Files:**
+- Modify: `reviewer/launcher/metadata.py:107-116`
+- Modify: `tests/launcher/test_catalog.py:152-157`
+- Modify: `README.md:25-55,102-135,236-287`
+- Modify: `README.ru.md:25-55,102-135,239-290`
+- Modify: `tests/docs/test_readme_onboarding.py:34-56,193-209`
+
+- [ ] **Step 1: Write failing launcher and README contract tests**
+
+```python
+def test_update_metadata_discloses_complete_mutating_lifecycle():
+    update = next(item for item in build_catalog(cli) if item.path == ("update",))
+
+    assert update.effects == (Effect.READ, Effect.NETWORK, Effect.WRITE)
+    assert "AI-client integrations" in update.details
+    assert "Compose" in update.details
+    assert "не перезаписывает пользовательские изменения" in update.details
+```
+
+Replace `test_quick_start_downloads_compose_and_indexes_before_checking` with:
+
+```python
+def test_quick_start_uses_unified_update_and_indexes_before_checking():
+    for filename, heading in (
+        ("README.md", "## Try reviewer"),
+        ("README.ru.md", "## Попробовать reviewer"),
+    ):
+        section = _section(_read(filename), heading)
+        assert "curl -o ~/.config/rag-reviewer/docker-compose.yml" not in section
+        _assert_in_order(
+            section,
+            (
+                "uv tool install rag-reviewer",
+                "reviewer update",
+                "docker compose -f ~/.config/rag-reviewer/docker-compose.yml up -d",
+                "reviewer init",
+                "reviewer index /path/to/repo --ref main",
+                "reviewer check",
+                "reviewer status /path/to/repo --branch main --json",
+            ),
+        )
+
+
+def test_readmes_document_unified_update_contract():
+    markers = (
+        "uvx --refresh --from rag-reviewer@latest reviewer update --upgrade-tool",
+        ".reviewer-update.json",
+        "New Chat",
+        "Reload Window",
+    )
+    for filename in ("README.md", "README.ru.md"):
+        text = _read(filename)
+        for marker in markers:
+            assert marker in text, (filename, marker)
+```
+
+- [ ] **Step 2: Run documentation/launcher tests and verify RED**
+
+Run: `.venv/bin/pytest tests/launcher/test_catalog.py tests/docs/test_readme_onboarding.py -q`
+
+Expected: old metadata wording and manual `curl` onboarding fail the new assertions.
+
+- [ ] **Step 3: Update launcher metadata**
+
+```python
+("update",): CommandPresentation(
+    summary="Обновить reviewer и integrations",
+    details=(
+        "Обновляет persistent uv tool package, обнаруженные AI-client integrations, "
+        "скилы и управляемый Compose; не перезаписывает пользовательские изменения Compose."
+    ),
+    effects=(Effect.READ, Effect.NETWORK, Effect.WRITE),
+    scenarios=("Полное обновление rag-reviewer",),
+    keywords=("pypi", "version", "upgrade", "skills", "compose"),
+    special_action="check_update",
+),
+```
+
+- [ ] **Step 4: Rewrite both onboarding routes and update sections in parallel**
+
+Use these exact command sequences in both languages:
+
+```bash
+uv tool install rag-reviewer
+reviewer update
+docker compose -f ~/.config/rag-reviewer/docker-compose.yml up -d
+reviewer init
+```
+
+```bash
+# One-time bootstrap from 0.4.3
+uvx --refresh --from rag-reviewer@latest reviewer update --upgrade-tool
+
+# Every later update
+reviewer update
+```
+
+Document that `.reviewer-update.json` records only the hash of reviewer-managed Compose content;
+modified Compose is preserved with a warning; package/client/plugin/skills/Compose phases run in one
+command; Docker services and volumes are not restarted or removed; users reopen New Chat/new CLI
+session and Reload Window in IDEs.
+
+- [ ] **Step 5: Run README and launcher tests**
+
+Run: `.venv/bin/pytest tests/launcher/test_catalog.py tests/docs/test_readme_onboarding.py -q`
+
+Expected: all selected tests pass with bilingual section order, links, and markers intact.
+
+- [ ] **Step 6: Commit user-facing lifecycle documentation**
+
+```bash
+git add reviewer/launcher/metadata.py tests/launcher/test_catalog.py README.md README.ru.md tests/docs/test_readme_onboarding.py
+git commit -m "docs(update): описать обновление одной командой"
+```
+
+### Task 6: Patch Release Metadata and Full Verification
+
+**Files:**
+- Modify: `pyproject.toml:3`
+- Modify: `uv.lock`
+- Modify: `plugin/.claude-plugin/plugin.json:3`
+- Modify: `.codex-plugin/plugin.json:3`
+- Modify: `plugin/.codex-plugin/plugin.json:3`
+
+- [ ] **Step 1: Bump the Python and Claude plugin version to 0.4.4**
+
+```toml
+[project]
+name = "rag-reviewer"
+version = "0.4.4"
+```
+
+```json
+{
+  "name": "rag-reviewer",
+  "version": "0.4.4",
+  "description": "Agentic PR review: hybrid RAG + code graph via MCP, review skills for Claude Code"
+}
+```
+
+- [ ] **Step 2: Regenerate lock and Codex manifests with repository scripts**
+
+Run: `uv lock && python scripts/update_codex_plugin_manifest.py`
+
+Expected: `uv.lock` records local package version 0.4.4 and both Codex manifest versions match the regular expression `0\.4\.4\+codex\.[0-9a-f]{12}`.
+
+- [ ] **Step 3: Verify generated metadata before committing**
+
+Run: `uv lock --check && python scripts/update_codex_plugin_manifest.py --check`
+
+Expected: both commands exit 0 without a diff.
+
+- [ ] **Step 4: Run focused and full verification**
+
+Run: `.venv/bin/pytest tests/test_update_lifecycle.py tests/entrypoints/test_update_command.py tests/docs/test_readme_onboarding.py tests/launcher/test_catalog.py -q`
+
+Expected: all focused tests pass.
+
+Run: `.venv/bin/ruff check .`
+
+Expected: Ruff exits 0.
+
+Run: `.venv/bin/pytest -q`
+
+Expected: the full non-integration suite passes with no external or localhost socket access.
+
+- [ ] **Step 5: Build and smoke-test the wheel in an isolated uvx environment**
+
+Run: `uv build`
+
+Expected: a 0.4.4 wheel and source distribution are created in `dist/`.
+
+Run: `uvx --refresh --from dist/rag_reviewer-0.4.4-py3-none-any.whl reviewer update --help`
+
+Expected: help exits 0 and lists `--upgrade-tool`; it does not run update or touch user configuration.
+
+- [ ] **Step 6: Commit release metadata**
+
+```bash
+git add pyproject.toml uv.lock plugin/.claude-plugin/plugin.json .codex-plugin/plugin.json plugin/.codex-plugin/plugin.json
+git commit -m "chore(release): версия 0.4.4 и пересборка манифестов"
+```
+
+### Task 7: Deliver Through dev and main
+
+**Files:**
+- No additional code files.
+
+- [ ] **Step 1: Review the complete branch diff and recent commits**
+
+Run: `git status --short && git diff origin/dev...HEAD --check && git log --oneline origin/dev..HEAD`
+
+Expected: only intended commits are listed and the worktree is clean.
+
+- [ ] **Step 2: Push a feature branch and open a PR to dev**
+
+Run: `git switch -c feat/unified-update && git push -u origin feat/unified-update`
+
+Run: `gh pr create --base dev --head feat/unified-update --title "feat(update): обновление одной командой" --body "Обновляет package, integrations, skills и Compose через reviewer update без перезаписи пользовательского Compose."`
+
+Expected: GitHub returns the PR URL. Prepare the body outside the repository or use `gh pr create --body` so no transient file is committed.
+
+- [ ] **Step 3: Wait for required checks and merge to dev**
+
+Run: `gh pr checks "$(gh pr view --json number --jq .number)" --watch`
+
+Expected: all required checks pass.
+
+Run: `gh pr merge "$(gh pr view --json number --jq .number)" --merge --delete-branch`
+
+Expected: the PR is merged into `dev` without force-push.
+
+- [ ] **Step 4: Open and merge the dev-to-main release PR**
+
+Run: `gh pr create --base main --head dev --title "chore(release): rag-reviewer 0.4.4" --body "Release unified update lifecycle from dev."`
+
+Run: `gh pr checks "$(gh pr view dev --json number --jq .number)" --watch`
+
+Expected: all required checks pass.
+
+Run: `gh pr merge "$(gh pr view dev --json number --jq .number)" --merge`
+
+Expected: `main` contains version 0.4.4 and triggers publish/plugin workflows.
+
+- [ ] **Step 5: Verify release workflows and PyPI artifact**
+
+Run: `gh run list --branch main --limit 10`
+
+Expected: Publish to PyPI, Codex plugin, HOL scanner, and tests associated with the main merge are successful.
+
+Run: `uvx --refresh --from rag-reviewer==0.4.4 reviewer update --help`
+
+Expected: the command resolves from PyPI and help lists `--upgrade-tool`.
+
+- [ ] **Step 6: Return the local checkout to updated dev**
+
+Run: `git switch dev && git pull --ff-only origin dev && git status --short --branch`
+
+Expected: `dev` matches `origin/dev` and the worktree is clean.

--- a/docs/superpowers/specs/2026-08-09-unified-update-command-design.md
+++ b/docs/superpowers/specs/2026-08-09-unified-update-command-design.md
@@ -28,7 +28,7 @@ For the release that introduces this lifecycle, a user still running the old CLI
 may need one bootstrap invocation through latest uvx:
 
 ```bash
-uvx --refresh --from rag-reviewer@latest reviewer update
+uvx --refresh --from rag-reviewer@latest reviewer update --upgrade-tool
 ```
 
 After that transition, the short command is sufficient:
@@ -56,7 +56,9 @@ reviewer update
   version is known, then launch the artifact phase with a fresh executable;
 - `uvx`: the package is temporary, so do not mutate an unrelated persistent tool;
   refresh artifacts with the currently invoked latest package and explain that
-  future CLI invocations should use `@latest`;
+  future CLI invocations should use `@latest`. The explicit `--upgrade-tool`
+  bootstrap flag is the sole exception: it upgrades an existing persistent
+  rag-reviewer tool, then runs artifact refresh from that updated installation;
 - editable checkout: never run `git pull` or replace developer source; refresh
   artifacts from the current checkout and print the existing source-update hint.
 

--- a/docs/superpowers/specs/2026-08-09-unified-update-command-design.md
+++ b/docs/superpowers/specs/2026-08-09-unified-update-command-design.md
@@ -1,0 +1,159 @@
+# Unified Update Command Design
+
+## Goal
+
+Make `reviewer update` the normal one-command lifecycle for an existing
+rag-reviewer installation. One invocation updates the persistent CLI package when
+applicable, refreshes every detected AI-client integration and its skills, and
+synchronizes the canonical Compose file without overwriting user changes.
+
+The same command must remain useful when no newer Python package exists: plugins,
+file-based skills, and the Compose file can change independently on the canonical
+`main` branch.
+
+## Chosen Approach
+
+Use a two-phase update driven by the latest available CLI process.
+
+1. The outer `reviewer update` identifies the installation mode and updates a
+   persistent `uv tool` installation when PyPI has a newer version.
+2. After a successful package phase, a fresh CLI process performs artifact refresh.
+   This prevents the already-running Python process from continuing with modules
+   loaded from the pre-upgrade package.
+3. The artifact phase reuses the existing `reviewer install --all` lifecycle for
+   detected clients and synchronizes the Compose file from its canonical HTTPS
+   source.
+
+For the release that introduces this lifecycle, a user still running the old CLI
+may need one bootstrap invocation through latest uvx:
+
+```bash
+uvx --refresh --from rag-reviewer@latest reviewer update
+```
+
+After that transition, the short command is sufficient:
+
+```bash
+reviewer update
+```
+
+### Alternatives Rejected
+
+- Continue in the original process after `uv tool upgrade`: unsafe because imports
+  and command behavior can remain from the old version while files on disk have
+  already changed.
+- Document `reviewer update` plus separate `install --all`, `install-skills`, and
+  `curl` commands: preserves current implementation but does not meet the
+  one-command goal.
+- Always replace the local Compose file: simplest implementation, but destroys
+  legitimate local port, image, profile, or service changes.
+
+## Package and Process Lifecycle
+
+`reviewer update` keeps the current installation-mode distinctions:
+
+- `uv tool`: check PyPI, run `uv tool upgrade rag-reviewer` only when a newer valid
+  version is known, then launch the artifact phase with a fresh executable;
+- `uvx`: the package is temporary, so do not mutate an unrelated persistent tool;
+  refresh artifacts with the currently invoked latest package and explain that
+  future CLI invocations should use `@latest`;
+- editable checkout: never run `git pull` or replace developer source; refresh
+  artifacts from the current checkout and print the existing source-update hint.
+
+The internal artifact-phase switch is hidden from normal help and prevents
+recursion. It is an implementation detail, not a second user-facing workflow.
+
+The first 0.4.3-to-new-lifecycle transition cannot be retrofitted into the already
+published 0.4.3 process. README therefore gives the latest-uvx bootstrap command
+for that transition and documents plain `reviewer update` as the steady-state
+command.
+
+## Integration Refresh
+
+Artifact refresh delegates to the existing installation contract rather than
+creating a second installer:
+
+- detect user-scope config clients through `CLIENTS` and public client CLI
+  availability;
+- run native Claude Code and Codex marketplace/plugin lifecycles;
+- rewrite generic MCP entries idempotently while preserving unrelated config and
+  existing backup behavior;
+- download the skills archive once and refresh every detected file-skills client;
+- skip the integration step successfully when no supported client is detected.
+
+Current installer safety remains authoritative. Native lifecycle errors are
+collected, generic config writes retain backups, and a failed skills download is
+reported explicitly without undoing an already-correct MCP entry.
+
+## Managed Compose File
+
+The canonical target is
+`$XDG_CONFIG_HOME/rag-reviewer/docker-compose.yml`, falling back to
+`~/.config/rag-reviewer/docker-compose.yml`. The artifact phase downloads the
+canonical file from the repository's `main` branch over HTTPS, so users no longer
+need a manual `curl` step.
+
+A sidecar state file in the same config directory stores the SHA-256 hash of the
+last content written or adopted by reviewer. Synchronization follows these rules:
+
+1. Missing target: write the downloaded file and its hash.
+2. Target exactly matches downloaded content: leave it unchanged and write or
+   repair the sidecar hash. This safely adopts an existing manual download.
+3. Target hash matches the sidecar hash: reviewer owns an unchanged file, so
+   atomically replace it with the new content and update the sidecar.
+4. Target differs from both the downloaded content and the sidecar hash, or has no
+   trustworthy sidecar: treat it as user-modified, do not overwrite it, and print
+   an actionable warning.
+
+The command does not run `docker compose down`, remove volumes, pull images, or
+restart services. Compose applies image and service changes only when the operator
+next runs the documented `docker compose ... up -d`; existing databases, indexes,
+task data, and subsystem summaries remain untouched.
+
+## Errors and Exit Status
+
+- Package upgrade failure stops before artifact refresh and exits non-zero.
+- Compose download/write failure does not prevent independent client refresh, but
+  the final command exits non-zero and names the failed phase.
+- One native client failure does not prevent other detected clients from being
+  attempted; the final result remains non-zero.
+- A deliberately preserved modified Compose file is a warning, not an execution
+  failure.
+- The command never prints a blanket success line when a required phase failed.
+
+Every successful or skipped phase emits a concise status so users can see whether
+the package, Compose file, MCP entries, and skills were changed or already current.
+
+## Documentation
+
+`README.md` and `README.ru.md` remain structurally parallel. Their quick-start and
+team routes stop asking users to download Compose manually. The update section
+documents:
+
+- the one-time latest-uvx bootstrap for users upgrading from 0.4.3;
+- steady-state `reviewer update` behavior;
+- automatic detected-client/plugin/skills refresh;
+- managed Compose ownership and the no-clobber warning;
+- the required New Chat/new CLI session or IDE Reload Window;
+- the fact that services and persistent Docker volumes are not restarted or
+  deleted by update.
+
+Launcher metadata must describe the new mutating lifecycle rather than the old
+"check only" wording.
+
+## Tests and Acceptance Criteria
+
+Unit tests cover:
+
+- package upgrade success/failure and fresh-process dispatch;
+- uvx and editable behavior without unintended persistent-tool mutation;
+- artifact refresh with no clients, generic clients, and native installer errors;
+- Compose create, adopt, no-op, managed update, modified-file preservation,
+  download failure, and sidecar consistency;
+- README parity and absence of manual Compose download commands in onboarding;
+- launcher metadata matching the command's effects.
+
+Final verification runs the focused tests first, then the full non-integration
+suite, Ruff, and package build/install smoke tests. The release is delivered
+through `dev` and then `main`; a patch version is published so the new lifecycle is
+actually available to the latest-uvx bootstrap command.

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "rag-reviewer",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "description": "Agentic PR review: hybrid RAG + code graph via MCP, review skills for Claude Code"
 }

--- a/plugin/.codex-plugin/plugin.json
+++ b/plugin/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "rag-reviewer",
-  "version": "0.4.3+codex.67fd471155e9",
+  "version": "0.4.4+codex.83c1d35785f4",
   "description": "Agentic PR review: hybrid RAG + code graph via MCP, review skills for Codex",
   "repository": "https://github.com/mimfort/rag_for_git",
   "license": "MIT",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "rag-reviewer"
-version = "0.4.3"
+version = "0.4.4"
 description = "AI pull-request reviewer: hybrid RAG + a code graph + Claude Code. Whole-repo context, inline GitHub comments grounded on exact code."
 readme = "README.md"
 license = { text = "MIT" }

--- a/reviewer/entrypoints/cli.py
+++ b/reviewer/entrypoints/cli.py
@@ -50,6 +50,7 @@ from reviewer.services.status import build_status_report, render_status, render_
 from reviewer.tasks.boards.errors import sanitize_provider_text
 from reviewer.update_lifecycle import (
     download_compose,
+    find_uv_tool_python,
     run_fresh_artifact_refresh,
     sync_compose_file,
 )
@@ -1578,6 +1579,20 @@ def update(ctx: click.Context, upgrade_tool: bool, refresh_artifacts: bool) -> N
         if result.returncode != 0:
             raise click.ClickException(f"Ошибка uv tool upgrade: {result.stderr}")
         click.echo("✓ Persistent uv tool installation обновлена.")
+        tool_python = find_uv_tool_python(installation.uv_executable)
+        if tool_python is None:
+            raise click.ClickException(
+                "Persistent tool обновлён, но его Python executable не найден"
+            )
+        fresh = run_fresh_artifact_refresh(python_executable=tool_python)
+        if fresh.stdout:
+            click.echo(fresh.stdout, nl=not fresh.stdout.endswith("\n"))
+        if fresh.returncode != 0:
+            detail = fresh.stderr.strip() or "неизвестная ошибка"
+            raise click.ClickException(
+                f"Persistent tool обновлён, artifact refresh завершился ошибкой: {detail}"
+            )
+        return
 
     version_check = check_latest(installation)
     if version_check.latest is None:

--- a/reviewer/entrypoints/cli.py
+++ b/reviewer/entrypoints/cli.py
@@ -48,7 +48,11 @@ from reviewer.services.gc import purge_orphaned_overlays
 from reviewer.services.review_service import ReviewService
 from reviewer.services.status import build_status_report, render_status, render_status_json
 from reviewer.tasks.boards.errors import sanitize_provider_text
-from reviewer.update_lifecycle import run_fresh_artifact_refresh
+from reviewer.update_lifecycle import (
+    download_compose,
+    run_fresh_artifact_refresh,
+    sync_compose_file,
+)
 from reviewer.versioning import InstallMode, check_latest, detect_installation, upgrade_uv_tool
 from reviewer.web.serve import DEFAULT_HOST, DEFAULT_PORT
 
@@ -1484,8 +1488,60 @@ def init(
         _print_codex_result(result)
 
 
+def _has_detected_clients() -> bool:
+    from reviewer import install as inst
+
+    return bool(inst.detect_installed()) or _shutil.which("claude") is not None
+
+
+def _install_detected_clients(ctx: click.Context) -> None:
+    ctx.invoke(
+        install,
+        client=None,
+        all_clients=True,
+        list_clients=False,
+        path_opt=None,
+        pin=None,
+        no_latest=False,
+        no_skills=False,
+        dry_run=False,
+    )
+
+
 def _refresh_update_artifacts(ctx: click.Context) -> None:
-    pass
+    errors: list[str] = []
+    try:
+        compose = sync_compose_file(download_compose())
+        statuses = {
+            "created": "создан",
+            "adopted": "принят под управление",
+            "current": "актуален",
+            "updated": "обновлён",
+        }
+        if compose.action == "preserved":
+            click.echo(
+                "⚠ Compose не перезаписан: обнаружены пользовательские изменения в "
+                f"{compose.path}"
+            )
+        else:
+            click.echo(f"✓ Compose {statuses[compose.action]}: {compose.path}")
+    except Exception as exc:  # noqa: BLE001 - independent phases must continue
+        errors.append(f"Compose: {type(exc).__name__}")
+    if _has_detected_clients():
+        try:
+            _install_detected_clients(ctx)
+        except click.ClickException as exc:
+            errors.append(f"Integrations: {exc.format_message()}")
+        except Exception as exc:  # noqa: BLE001 - do not expose profile paths or config content
+            errors.append(f"Integrations: {type(exc).__name__}")
+    else:
+        click.echo("AI-клиенты не обнаружены; integration refresh пропущен.")
+    if errors:
+        raise click.ClickException("Обновление завершено частично: " + "; ".join(errors))
+    click.echo(
+        "Обновление завершено. Откройте New Chat/new CLI session; "
+        "в IDE — Reload Window."
+    )
 
 
 @cli.command()

--- a/reviewer/entrypoints/cli.py
+++ b/reviewer/entrypoints/cli.py
@@ -48,6 +48,7 @@ from reviewer.services.gc import purge_orphaned_overlays
 from reviewer.services.review_service import ReviewService
 from reviewer.services.status import build_status_report, render_status, render_status_json
 from reviewer.tasks.boards.errors import sanitize_provider_text
+from reviewer.update_lifecycle import run_fresh_artifact_refresh
 from reviewer.versioning import InstallMode, check_latest, detect_installation, upgrade_uv_tool
 from reviewer.web.serve import DEFAULT_HOST, DEFAULT_PORT
 
@@ -1483,13 +1484,28 @@ def init(
         _print_codex_result(result)
 
 
+def _refresh_update_artifacts(ctx: click.Context) -> None:
+    pass
+
+
 @cli.command()
-def update() -> None:
+@click.option(
+    "--upgrade-tool",
+    is_flag=True,
+    help="обновить существующую persistent uv tool installation из latest uvx",
+)
+@click.option("--refresh-artifacts", is_flag=True, hidden=True)
+@click.pass_context
+def update(ctx: click.Context, upgrade_tool: bool, refresh_artifacts: bool) -> None:
     """Проверить наличие новой версии rag-reviewer на PyPI."""
+    if refresh_artifacts:
+        _refresh_update_artifacts(ctx)
+        return
     installation = detect_installation()
     if installation.mode is InstallMode.EDITABLE:
         click.echo(f"Режим: dev (editable) | Версия: {installation.current}")
         click.echo("Для обновления: git pull && pip install -e .")
+        _refresh_update_artifacts(ctx)
         return
 
     mode = "uv tool (постоянная)" if installation.mode is InstallMode.UV_TOOL else "uvx (временная)"
@@ -1498,16 +1514,24 @@ def update() -> None:
     version_check = check_latest(installation)
     if version_check.latest is None:
         click.echo("Не удалось получить информацию с PyPI. Проверьте сеть.")
+        _refresh_update_artifacts(ctx)
         return
 
     if not version_check.current_valid:
         click.echo("Не удалось определить корректную текущую версию. Обновление не запущено.")
+        _refresh_update_artifacts(ctx)
         return
 
     if not version_check.update_available and installation.current != "?":
         click.echo(f"Версия актуальна: {installation.current}.")
         if installation.mode is not InstallMode.UV_TOOL:
             click.echo("MCP-сервер обновляется автоматически — в конфиге клиента прописан @latest.")
+        if upgrade_tool and installation.mode is InstallMode.UVX:
+            result = upgrade_uv_tool(installation)
+            if result.returncode != 0:
+                raise click.ClickException(f"Ошибка uv tool upgrade: {result.stderr}")
+            click.echo("✓ Persistent uv tool installation обновлена.")
+        _refresh_update_artifacts(ctx)
         return
 
     click.echo(f"Доступна новая версия: {installation.current} → {version_check.latest}")
@@ -1518,9 +1542,17 @@ def update() -> None:
             return
         result = upgrade_uv_tool(installation)
         if result.returncode == 0:
-            click.echo("Обновлено. Перезапустите MCP-сервер.")
+            click.echo("✓ Python package обновлён.")
+            fresh = run_fresh_artifact_refresh()
+            if fresh.stdout:
+                click.echo(fresh.stdout, nl=not fresh.stdout.endswith("\n"))
+            if fresh.returncode != 0:
+                detail = fresh.stderr.strip() or "неизвестная ошибка"
+                raise click.ClickException(
+                    f"Пакет обновлён, artifact refresh завершился ошибкой: {detail}"
+                )
         else:
-            click.echo(f"Ошибка uv tool upgrade: {result.stderr}")
+            raise click.ClickException(f"Ошибка uv tool upgrade: {result.stderr}")
     else:
         # uvx: MCP-сервер обновится сам при следующем запуске (конфиг содержит @latest).
         # Для CLI-команд достаточно использовать @latest явно.
@@ -1528,6 +1560,12 @@ def update() -> None:
             "MCP-сервер подхватит обновление автоматически при следующем запуске (@latest в конфиге).\n"
             "Для CLI: uvx --from rag-reviewer@latest reviewer <команда>"
         )
+        if upgrade_tool:
+            result = upgrade_uv_tool(installation)
+            if result.returncode != 0:
+                raise click.ClickException(f"Ошибка uv tool upgrade: {result.stderr}")
+            click.echo("✓ Persistent uv tool installation обновлена.")
+        _refresh_update_artifacts(ctx)
 
 
 @cli.command("install-skills")

--- a/reviewer/entrypoints/cli.py
+++ b/reviewer/entrypoints/cli.py
@@ -1553,7 +1553,7 @@ def _refresh_update_artifacts(ctx: click.Context) -> None:
 @click.option("--refresh-artifacts", is_flag=True, hidden=True)
 @click.pass_context
 def update(ctx: click.Context, upgrade_tool: bool, refresh_artifacts: bool) -> None:
-    """Проверить наличие новой версии rag-reviewer на PyPI."""
+    """Обновить package, AI-client integrations, скилы и Compose-файл."""
     if refresh_artifacts:
         _refresh_update_artifacts(ctx)
         return

--- a/reviewer/entrypoints/cli.py
+++ b/reviewer/entrypoints/cli.py
@@ -1039,6 +1039,8 @@ def install(client: str | None, all_clients: bool, list_clients: bool,
         targets = [c for c in inst.detect_installed() if c.key != "claude-code"]
         if _shutil.which("claude"):
             targets.insert(0, inst.CLIENTS["claude-code"])
+        if _shutil.which("codex") and not any(target.key == "codex" for target in targets):
+            targets.append(inst.CLIENTS["codex"])
         if not targets:
             raise click.ClickException(
                 "Не обнаружено установленных клиентов. Укажите явно: reviewer install <client> "
@@ -1491,7 +1493,9 @@ def init(
 def _has_detected_clients() -> bool:
     from reviewer import install as inst
 
-    return bool(inst.detect_installed()) or _shutil.which("claude") is not None
+    return bool(inst.detect_installed()) or any(
+        _shutil.which(executable) is not None for executable in ("claude", "codex")
+    )
 
 
 def _install_detected_clients(ctx: click.Context) -> None:
@@ -1531,7 +1535,10 @@ def _refresh_update_artifacts(ctx: click.Context) -> None:
         try:
             _install_detected_clients(ctx)
         except click.ClickException as exc:
-            errors.append(f"Integrations: {exc.format_message()}")
+            errors.append(
+                f"Integrations: {type(exc).__name__} "
+                "(подробности: reviewer install --all)"
+            )
         except Exception as exc:  # noqa: BLE001 - do not expose profile paths or config content
             errors.append(f"Integrations: {type(exc).__name__}")
     else:
@@ -1566,6 +1573,11 @@ def update(ctx: click.Context, upgrade_tool: bool, refresh_artifacts: bool) -> N
 
     mode = "uv tool (постоянная)" if installation.mode is InstallMode.UV_TOOL else "uvx (временная)"
     click.echo(f"Режим: {mode} | Версия: {installation.current}")
+    if upgrade_tool and installation.mode is InstallMode.UVX:
+        result = upgrade_uv_tool(installation)
+        if result.returncode != 0:
+            raise click.ClickException(f"Ошибка uv tool upgrade: {result.stderr}")
+        click.echo("✓ Persistent uv tool installation обновлена.")
 
     version_check = check_latest(installation)
     if version_check.latest is None:
@@ -1582,11 +1594,6 @@ def update(ctx: click.Context, upgrade_tool: bool, refresh_artifacts: bool) -> N
         click.echo(f"Версия актуальна: {installation.current}.")
         if installation.mode is not InstallMode.UV_TOOL:
             click.echo("MCP-сервер обновляется автоматически — в конфиге клиента прописан @latest.")
-        if upgrade_tool and installation.mode is InstallMode.UVX:
-            result = upgrade_uv_tool(installation)
-            if result.returncode != 0:
-                raise click.ClickException(f"Ошибка uv tool upgrade: {result.stderr}")
-            click.echo("✓ Persistent uv tool installation обновлена.")
         _refresh_update_artifacts(ctx)
         return
 
@@ -1616,11 +1623,6 @@ def update(ctx: click.Context, upgrade_tool: bool, refresh_artifacts: bool) -> N
             "MCP-сервер подхватит обновление автоматически при следующем запуске (@latest в конфиге).\n"
             "Для CLI: uvx --from rag-reviewer@latest reviewer <команда>"
         )
-        if upgrade_tool:
-            result = upgrade_uv_tool(installation)
-            if result.returncode != 0:
-                raise click.ClickException(f"Ошибка uv tool upgrade: {result.stderr}")
-            click.echo("✓ Persistent uv tool installation обновлена.")
         _refresh_update_artifacts(ctx)
 
 

--- a/reviewer/launcher/app.py
+++ b/reviewer/launcher/app.py
@@ -34,7 +34,6 @@ from reviewer.launcher.command import parameter_occurrences, prepare_command
 from reviewer.launcher.controller import LauncherController, Screen
 from reviewer.launcher.models import CommandSpec, LauncherResult, ParameterSpec
 from reviewer.versioning import (
-    InstallMode,
     InstallationInfo,
     VersionCheck,
     check_latest,
@@ -120,7 +119,7 @@ class _LauncherUI:
         """Подтвердить preview или существующий Click update path."""
         if self.controller.screen is Screen.PREVIEW:
             self.controller.confirm()
-        elif self.controller.screen is Screen.UPDATE_RESULT and self._can_update_uv_tool():
+        elif self.controller.screen is Screen.UPDATE_RESULT and self._can_run_update():
             self.controller.result = LauncherResult(("update",), 0)
         if self.controller.result is not None:
             self._revoke_updates()
@@ -300,13 +299,15 @@ class _LauncherUI:
             Label("Проверка обновлений"),
             Label(self._update_message),
         ]
-        if self._can_update_uv_tool():
+        if self._can_run_update():
             preview = prepare_command(self.controller.selected, {}, set()).preview
             children.extend(
                 [
                     Label(f"Команда после подтверждения: {preview}"),
                     Label("Эффект после подтверждения: запись"),
-                    Label("Внимание: будет изменена постоянная uv tool-установка rag-reviewer."),
+                    Label(
+                        "Будут обновлены package, integrations, скилы и управляемый Compose."
+                    ),
                 ]
             )
         children.append(Label(self._update_hint))
@@ -329,32 +330,18 @@ class _LauncherUI:
         if not check.current_valid:
             return (
                 "Не удалось определить корректную текущую версию. "
-                "Сравнение и обновление недоступны."
+                "Package не будет изменён; остальные artifacts можно обновить."
             )
         if check.update_available:
             return f"Доступна новая версия: {info.current} → {check.latest}"
         return f"Версия актуальна: {info.current}."
 
     def _update_hint(self) -> str:
-        if self.update_error is not None or (
-            self.version_check is not None and self.version_check.latest is None
-        ):
-            return "Повторить проверку: Esc — назад, затем Enter"
+        if self._can_run_update():
+            return "Enter — подтвердить и передать команду · Esc — назад"
         if self.version_check is None:
             return "Ctrl+C — выход"
-        info = self.version_check.installation
-        if not self.version_check.current_valid:
-            return "Исправьте установку rag-reviewer · Esc — назад"
-        if self._can_update_uv_tool():
-            return "Enter — подтвердить и передать команду · Esc — назад"
-        if info.mode is InstallMode.EDITABLE:
-            return "Для обновления: git pull && pip install -e . · Esc — назад"
-        if info.mode is InstallMode.UVX:
-            return (
-                "MCP подхватит @latest автоматически; "
-                "CLI: uvx --from rag-reviewer@latest reviewer <команда> · Esc — назад"
-            )
-        return "Обновление не требуется · Esc — назад"
+        return "Повторить проверку: Esc — назад, затем Enter"
 
     def _build_form(self) -> None:
         self._drop_form()
@@ -554,12 +541,9 @@ class _LauncherUI:
         installation = self.installation_detector()
         return self.version_checker(installation, timeout=5)
 
-    def _can_update_uv_tool(self) -> bool:
-        return (
-            self.version_check is not None
-            and self.version_check.current_valid
-            and self.version_check.update_available
-            and self.version_check.installation.mode is InstallMode.UV_TOOL
+    def _can_run_update(self) -> bool:
+        return not self.checking_update and (
+            self.version_check is not None or self.update_error is not None
         )
 
 

--- a/reviewer/launcher/app.py
+++ b/reviewer/launcher/app.py
@@ -174,7 +174,10 @@ class _LauncherUI:
 
     def toggle_advanced(self, event: KeyPressEvent) -> None:
         """Переключить расширенные поля и перестроить форму."""
-        if self.controller.screen is not Screen.DETAILS:
+        if (
+            self.controller.screen is not Screen.DETAILS
+            or self.controller.selected.special_action is not None
+        ):
             return
         self.controller.toggle_advanced()
         self._build_form()

--- a/reviewer/launcher/app.py
+++ b/reviewer/launcher/app.py
@@ -95,6 +95,9 @@ class _LauncherUI:
         self.controller.open_selected()
         if self.controller.screen is not Screen.DETAILS:
             return
+        if self.controller.selected.special_action is not None:
+            event.app.invalidate()
+            return
         self._build_form()
         if self.form_widgets:
             event.app.layout.focus(self.form_widgets[0])

--- a/reviewer/launcher/metadata.py
+++ b/reviewer/launcher/metadata.py
@@ -105,14 +105,14 @@ COMMAND_PRESENTATION = {
         keywords=("drift", "json", "health"),
     ),
     ("update",): CommandPresentation(
-        summary="Проверить обновления",
+        summary="Обновить reviewer и integrations",
         details=(
-            "Сначала только проверяет PyPI; постоянную uv tool-установку изменяет "
-            "только после отдельного подтверждения."
+            "Обновляет persistent uv tool package, обнаруженные AI-client integrations, "
+            "скилы и управляемый Compose; не перезаписывает пользовательские изменения Compose."
         ),
         effects=(Effect.READ, Effect.NETWORK, Effect.WRITE),
-        scenarios=("Обновление глобальной uv tool-установки",),
-        keywords=("pypi", "version", "upgrade"),
+        scenarios=("Полное обновление rag-reviewer",),
+        keywords=("pypi", "version", "upgrade", "skills", "compose"),
         special_action="check_update",
     ),
 }

--- a/reviewer/update_lifecycle.py
+++ b/reviewer/update_lifecycle.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Literal
+
+
+STATE_NAME = ".reviewer-update.json"
+
+
+@dataclass(frozen=True)
+class ComposeSyncResult:
+    action: Literal["created", "adopted", "current", "updated", "preserved"]
+    path: Path
+
+
+def default_config_dir() -> Path:
+    root = os.environ.get("XDG_CONFIG_HOME")
+    return (Path(root).expanduser() if root else Path.home() / ".config") / "rag-reviewer"
+
+
+def _digest(content: bytes) -> str:
+    return "sha256:" + hashlib.sha256(content).hexdigest()
+
+
+def _atomic_write(path: Path, content: bytes) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with tempfile.NamedTemporaryFile(dir=path.parent, delete=False) as tmp:
+        tmp.write(content)
+        temporary = Path(tmp.name)
+    temporary.replace(path)
+
+
+def _write_state(path: Path, digest: str) -> None:
+    content = json.dumps(
+        {"docker_compose_sha256": digest}, indent=2, ensure_ascii=False
+    ).encode("utf-8") + b"\n"
+    _atomic_write(path, content)
+
+
+def _read_recorded_hash(path: Path) -> str | None:
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return None
+    value = payload.get("docker_compose_sha256") if isinstance(payload, dict) else None
+    return value if isinstance(value, str) and value.startswith("sha256:") else None
+
+
+def sync_compose_file(
+    content: bytes,
+    *,
+    config_dir: Path | None = None,
+) -> ComposeSyncResult:
+    directory = config_dir or default_config_dir()
+    target = directory / "docker-compose.yml"
+    state_path = directory / STATE_NAME
+    incoming_hash = _digest(content)
+    if target.exists():
+        existing = target.read_bytes()
+        existing_hash = _digest(existing)
+    else:
+        existing_hash = None
+    if existing_hash == incoming_hash:
+        action = "current" if _read_recorded_hash(state_path) == incoming_hash else "adopted"
+        _write_state(state_path, incoming_hash)
+        return ComposeSyncResult(action, target)
+    if existing_hash is not None and _read_recorded_hash(state_path) == existing_hash:
+        _atomic_write(target, content)
+        _write_state(state_path, incoming_hash)
+        return ComposeSyncResult("updated", target)
+    if existing_hash is not None:
+        return ComposeSyncResult("preserved", target)
+    _atomic_write(target, content)
+    _write_state(state_path, incoming_hash)
+    return ComposeSyncResult("created", target)

--- a/reviewer/update_lifecycle.py
+++ b/reviewer/update_lifecycle.py
@@ -3,19 +3,66 @@ from __future__ import annotations
 import hashlib
 import json
 import os
+import shutil
+import subprocess
 import tempfile
+import urllib.request
+from collections.abc import Callable
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Literal
 
 
 STATE_NAME = ".reviewer-update.json"
+COMPOSE_URL = (
+    "https://raw.githubusercontent.com/mimfort/rag_for_git/main/docker-compose.yml"
+)
 
 
 @dataclass(frozen=True)
 class ComposeSyncResult:
     action: Literal["created", "adopted", "current", "updated", "preserved"]
     path: Path
+
+
+@dataclass(frozen=True)
+class RefreshProcessResult:
+    returncode: int
+    stdout: str
+    stderr: str
+
+
+def download_compose(
+    *,
+    opener: Callable = urllib.request.urlopen,
+    timeout: int = 30,
+) -> bytes:
+    request = urllib.request.Request(
+        COMPOSE_URL,
+        headers={"Cache-Control": "no-cache, no-store", "Pragma": "no-cache"},
+    )
+    with opener(request, timeout=timeout) as response:
+        return response.read()
+
+
+def run_fresh_artifact_refresh(
+    *,
+    which: Callable[[str], str | None] = shutil.which,
+    run: Callable = subprocess.run,
+) -> RefreshProcessResult:
+    executable = which("reviewer")
+    if executable is None:
+        return RefreshProcessResult(127, "", "reviewer не найден в PATH")
+    result = run(
+        [executable, "update", "--refresh-artifacts"],
+        capture_output=True,
+        text=True,
+    )
+    return RefreshProcessResult(
+        result.returncode,
+        result.stdout or "",
+        result.stderr or "",
+    )
 
 
 def default_config_dir() -> Path:

--- a/reviewer/update_lifecycle.py
+++ b/reviewer/update_lifecycle.py
@@ -3,8 +3,8 @@ from __future__ import annotations
 import hashlib
 import json
 import os
-import shutil
 import subprocess
+import sys
 import tempfile
 import urllib.request
 from collections.abc import Callable
@@ -47,14 +47,19 @@ def download_compose(
 
 def run_fresh_artifact_refresh(
     *,
-    which: Callable[[str], str | None] = shutil.which,
+    python_executable: str = sys.executable,
     run: Callable = subprocess.run,
 ) -> RefreshProcessResult:
-    executable = which("reviewer")
-    if executable is None:
-        return RefreshProcessResult(127, "", "reviewer не найден в PATH")
+    if not python_executable:
+        return RefreshProcessResult(127, "", "Python executable не найден")
     result = run(
-        [executable, "update", "--refresh-artifacts"],
+        [
+            python_executable,
+            "-c",
+            "from reviewer.entrypoints.launcher import main; main()",
+            "update",
+            "--refresh-artifacts",
+        ],
         capture_output=True,
         text=True,
     )
@@ -107,6 +112,8 @@ def sync_compose_file(
     target = directory / "docker-compose.yml"
     state_path = directory / STATE_NAME
     incoming_hash = _digest(content)
+    if target.is_symlink():
+        return ComposeSyncResult("preserved", target)
     if target.exists():
         existing = target.read_bytes()
         existing_hash = _digest(existing)
@@ -116,7 +123,14 @@ def sync_compose_file(
         action = "current" if _read_recorded_hash(state_path) == incoming_hash else "adopted"
         _write_state(state_path, incoming_hash)
         return ComposeSyncResult(action, target)
-    if existing_hash is not None and _read_recorded_hash(state_path) == existing_hash:
+    recorded_hash = _read_recorded_hash(state_path)
+    if existing_hash is not None and recorded_hash == existing_hash:
+        latest = target.read_bytes()
+        if latest != existing:
+            if latest == content:
+                _write_state(state_path, incoming_hash)
+                return ComposeSyncResult("current", target)
+            return ComposeSyncResult("preserved", target)
         _atomic_write(target, content)
         _write_state(state_path, incoming_hash)
         return ComposeSyncResult("updated", target)

--- a/reviewer/update_lifecycle.py
+++ b/reviewer/update_lifecycle.py
@@ -3,11 +3,13 @@ from __future__ import annotations
 import hashlib
 import json
 import os
+import platform
 import subprocess
 import sys
 import tempfile
 import urllib.request
 from collections.abc import Callable
+from contextlib import contextmanager
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Literal
@@ -30,6 +32,32 @@ class RefreshProcessResult:
     returncode: int
     stdout: str
     stderr: str
+
+
+def find_uv_tool_python(
+    uv_executable: str | None,
+    *,
+    run: Callable = subprocess.run,
+    system: str | None = None,
+) -> str | None:
+    if uv_executable is None:
+        return None
+    try:
+        result = run(
+            [uv_executable, "tool", "dir"],
+            capture_output=True,
+            text=True,
+        )
+    except OSError:
+        return None
+    if result.returncode != 0 or not result.stdout.strip():
+        return None
+    environment = Path(result.stdout.strip()) / "rag-reviewer"
+    if (system or platform.system()) == "Windows":
+        python = environment / "Scripts" / "python.exe"
+    else:
+        python = environment / "bin" / "python"
+    return str(python) if python.is_file() else None
 
 
 def download_compose(
@@ -55,6 +83,7 @@ def run_fresh_artifact_refresh(
     result = run(
         [
             python_executable,
+            "-I",
             "-c",
             "from reviewer.entrypoints.launcher import main; main()",
             "update",
@@ -87,6 +116,50 @@ def _atomic_write(path: Path, content: bytes) -> None:
     temporary.replace(path)
 
 
+def _atomic_create(path: Path, content: bytes) -> bool:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with tempfile.NamedTemporaryFile(dir=path.parent, delete=False) as tmp:
+        tmp.write(content)
+        tmp.flush()
+        os.fsync(tmp.fileno())
+        temporary = Path(tmp.name)
+    try:
+        os.link(temporary, path)
+    except FileExistsError:
+        return False
+    finally:
+        temporary.unlink(missing_ok=True)
+    return True
+
+
+@contextmanager
+def _update_lock(directory: Path):
+    directory.mkdir(parents=True, exist_ok=True)
+    lock_path = directory / ".reviewer-update.lock"
+    with lock_path.open("a+b") as lock_file:
+        lock_file.seek(0, os.SEEK_END)
+        if lock_file.tell() == 0:
+            lock_file.write(b"\0")
+            lock_file.flush()
+        lock_file.seek(0)
+        if os.name == "nt":
+            import msvcrt
+
+            msvcrt.locking(lock_file.fileno(), msvcrt.LK_LOCK, 1)
+        else:
+            import fcntl
+
+            fcntl.flock(lock_file.fileno(), fcntl.LOCK_EX)
+        try:
+            yield
+        finally:
+            lock_file.seek(0)
+            if os.name == "nt":
+                msvcrt.locking(lock_file.fileno(), msvcrt.LK_UNLCK, 1)
+            else:
+                fcntl.flock(lock_file.fileno(), fcntl.LOCK_UN)
+
+
 def _write_state(path: Path, digest: str) -> None:
     content = json.dumps(
         {"docker_compose_sha256": digest}, indent=2, ensure_ascii=False
@@ -109,6 +182,11 @@ def sync_compose_file(
     config_dir: Path | None = None,
 ) -> ComposeSyncResult:
     directory = config_dir or default_config_dir()
+    with _update_lock(directory):
+        return _sync_compose_file_unlocked(content, directory)
+
+
+def _sync_compose_file_unlocked(content: bytes, directory: Path) -> ComposeSyncResult:
     target = directory / "docker-compose.yml"
     state_path = directory / STATE_NAME
     incoming_hash = _digest(content)
@@ -136,6 +214,7 @@ def sync_compose_file(
         return ComposeSyncResult("updated", target)
     if existing_hash is not None:
         return ComposeSyncResult("preserved", target)
-    _atomic_write(target, content)
+    if not _atomic_create(target, content):
+        return ComposeSyncResult("preserved", target)
     _write_state(state_path, incoming_hash)
     return ComposeSyncResult("created", target)

--- a/tests/docs/test_readme_onboarding.py
+++ b/tests/docs/test_readme_onboarding.py
@@ -36,6 +36,7 @@ PARITY_MARKERS = (
     "docker compose -f ~/.config/rag-reviewer/docker-compose.yml up -d",
     "reviewer init",
     "reviewer install",
+    "reviewer update",
     "reviewer check",
     "reviewer index",
     "reviewer status",
@@ -190,16 +191,18 @@ def test_readmes_share_critical_commands_and_contract_markers():
         assert marker in russian, ("README.ru.md", marker)
 
 
-def test_quick_start_downloads_compose_and_indexes_before_checking():
+def test_quick_start_uses_unified_update_and_indexes_before_checking():
     for filename, heading in (
         ("README.md", "## Try reviewer"),
         ("README.ru.md", "## Попробовать reviewer"),
     ):
         section = _section(_read(filename), heading)
+        assert "curl -o ~/.config/rag-reviewer/docker-compose.yml" not in section
         _assert_in_order(
             section,
             (
-                "curl -o ~/.config/rag-reviewer/docker-compose.yml",
+                "uv tool install rag-reviewer",
+                "reviewer update",
                 "docker compose -f ~/.config/rag-reviewer/docker-compose.yml up -d",
                 "reviewer init",
                 "reviewer index /path/to/repo --ref main",
@@ -207,6 +210,19 @@ def test_quick_start_downloads_compose_and_indexes_before_checking():
                 "reviewer status /path/to/repo --branch main --json",
             ),
         )
+
+
+def test_readmes_document_unified_update_contract():
+    markers = (
+        "uvx --refresh --from rag-reviewer@latest reviewer update --upgrade-tool",
+        ".reviewer-update.json",
+        "New Chat",
+        "Reload Window",
+    )
+    for filename in ("README.md", "README.ru.md"):
+        text = _read(filename)
+        for marker in markers:
+            assert marker in text, (filename, marker)
 
 
 def test_team_route_describes_per_client_stdio_processes():

--- a/tests/entrypoints/test_update_command.py
+++ b/tests/entrypoints/test_update_command.py
@@ -562,3 +562,13 @@ def test_has_detected_clients_includes_native_claude_cli(monkeypatch):
     )
 
     assert cli_mod._has_detected_clients() is True
+
+
+def test_update_help_describes_unified_lifecycle_and_hides_internal_phase():
+    result = CliRunner().invoke(cli_mod.cli, ["update", "--help"])
+
+    assert result.exit_code == 0, result.output
+    assert "AI-client integrations" in result.output
+    assert "Compose" in result.output
+    assert "--upgrade-tool" in result.output
+    assert "--refresh-artifacts" not in result.output

--- a/tests/entrypoints/test_update_command.py
+++ b/tests/entrypoints/test_update_command.py
@@ -292,6 +292,7 @@ def test_update_uvx_upgrade_tool_is_explicit(monkeypatch):
     info = InstallationInfo(InstallMode.UVX, "0.4.4", "/usr/bin/uv")
     upgrade = Mock(return_value=UpgradeResult(0, ""))
     refresh = Mock()
+    fresh = Mock(return_value=SimpleNamespace(returncode=0, stdout="", stderr=""))
     monkeypatch.setattr(cli_mod, "detect_installation", lambda: info)
     monkeypatch.setattr(
         cli_mod,
@@ -300,6 +301,8 @@ def test_update_uvx_upgrade_tool_is_explicit(monkeypatch):
     )
     monkeypatch.setattr(cli_mod, "upgrade_uv_tool", upgrade)
     monkeypatch.setattr(cli_mod, "_refresh_update_artifacts", refresh)
+    monkeypatch.setattr(cli_mod, "find_uv_tool_python", lambda uv: "/tools/python")
+    monkeypatch.setattr(cli_mod, "run_fresh_artifact_refresh", fresh)
 
     regular = CliRunner().invoke(cli_mod.cli, ["update"])
     bootstrap = CliRunner().invoke(cli_mod.cli, ["update", "--upgrade-tool"])
@@ -307,7 +310,8 @@ def test_update_uvx_upgrade_tool_is_explicit(monkeypatch):
     assert regular.exit_code == 0, regular.output
     assert bootstrap.exit_code == 0, bootstrap.output
     upgrade.assert_called_once_with(info)
-    assert refresh.call_count == 2
+    refresh.assert_called_once()
+    fresh.assert_called_once_with(python_executable="/tools/python")
 
 
 def test_update_editable_refreshes_artifacts_without_touching_source(monkeypatch):
@@ -348,12 +352,18 @@ def test_update_uvx_bootstrap_with_newer_version_upgrades_tool_once(monkeypatch)
     )
     monkeypatch.setattr(cli_mod, "upgrade_uv_tool", upgrade)
     monkeypatch.setattr(cli_mod, "_refresh_update_artifacts", refresh)
+    monkeypatch.setattr(cli_mod, "find_uv_tool_python", lambda uv: "/tools/python")
+    monkeypatch.setattr(
+        cli_mod,
+        "run_fresh_artifact_refresh",
+        lambda **kwargs: SimpleNamespace(returncode=0, stdout="", stderr=""),
+    )
 
     result = CliRunner().invoke(cli_mod.cli, ["update", "--upgrade-tool"])
 
     assert result.exit_code == 0, result.output
     upgrade.assert_called_once_with(info)
-    refresh.assert_called_once()
+    refresh.assert_not_called()
 
 
 def test_update_pypi_failure_still_refreshes_independent_artifacts(monkeypatch):
@@ -418,12 +428,48 @@ def test_update_explicit_bootstrap_is_not_skipped_by_version_check_failure(
     monkeypatch.setattr(cli_mod, "check_latest", lambda value: version_check)
     monkeypatch.setattr(cli_mod, "upgrade_uv_tool", upgrade)
     monkeypatch.setattr(cli_mod, "_refresh_update_artifacts", refresh)
+    monkeypatch.setattr(cli_mod, "find_uv_tool_python", lambda uv: "/tools/python")
+    monkeypatch.setattr(
+        cli_mod,
+        "run_fresh_artifact_refresh",
+        lambda **kwargs: SimpleNamespace(returncode=0, stdout="", stderr=""),
+    )
 
     result = CliRunner().invoke(cli_mod.cli, ["update", "--upgrade-tool"])
 
     assert result.exit_code == 0, result.output
     upgrade.assert_called_once_with(info)
-    refresh.assert_called_once()
+    refresh.assert_not_called()
+
+
+def test_update_uvx_bootstrap_refreshes_from_persistent_tool_python(monkeypatch):
+    info = InstallationInfo(InstallMode.UVX, "0.4.4", "/usr/bin/uv")
+    in_process_refresh = Mock()
+    fresh_refresh = Mock(
+        return_value=SimpleNamespace(returncode=0, stdout="persistent artifacts\n", stderr="")
+    )
+    check = Mock()
+    monkeypatch.setattr(cli_mod, "detect_installation", lambda: info)
+    monkeypatch.setattr(cli_mod, "upgrade_uv_tool", lambda value: UpgradeResult(0, ""))
+    monkeypatch.setattr(
+        cli_mod,
+        "find_uv_tool_python",
+        lambda uv: "/uv-tools/rag-reviewer/bin/python",
+        raising=False,
+    )
+    monkeypatch.setattr(cli_mod, "run_fresh_artifact_refresh", fresh_refresh)
+    monkeypatch.setattr(cli_mod, "_refresh_update_artifacts", in_process_refresh)
+    monkeypatch.setattr(cli_mod, "check_latest", check)
+
+    result = CliRunner().invoke(cli_mod.cli, ["update", "--upgrade-tool"])
+
+    assert result.exit_code == 0, result.output
+    assert "persistent artifacts" in result.output
+    fresh_refresh.assert_called_once_with(
+        python_executable="/uv-tools/rag-reviewer/bin/python"
+    )
+    in_process_refresh.assert_not_called()
+    check.assert_not_called()
 
 
 def test_refresh_artifacts_updates_compose_and_skips_absent_clients(monkeypatch, tmp_path):

--- a/tests/entrypoints/test_update_command.py
+++ b/tests/entrypoints/test_update_command.py
@@ -392,6 +392,40 @@ def test_update_invalid_package_version_still_refreshes_artifacts(monkeypatch):
     refresh.assert_called_once()
 
 
+@pytest.mark.parametrize(
+    "version_check",
+    [
+        VersionCheck(
+            InstallationInfo(InstallMode.UVX, "0.4.4", "/usr/bin/uv"),
+            None,
+            False,
+        ),
+        VersionCheck(
+            InstallationInfo(InstallMode.UVX, "local", "/usr/bin/uv"),
+            "0.4.4",
+            False,
+            current_valid=False,
+        ),
+    ],
+)
+def test_update_explicit_bootstrap_is_not_skipped_by_version_check_failure(
+    monkeypatch, version_check
+):
+    info = version_check.installation
+    upgrade = Mock(return_value=UpgradeResult(0, ""))
+    refresh = Mock()
+    monkeypatch.setattr(cli_mod, "detect_installation", lambda: info)
+    monkeypatch.setattr(cli_mod, "check_latest", lambda value: version_check)
+    monkeypatch.setattr(cli_mod, "upgrade_uv_tool", upgrade)
+    monkeypatch.setattr(cli_mod, "_refresh_update_artifacts", refresh)
+
+    result = CliRunner().invoke(cli_mod.cli, ["update", "--upgrade-tool"])
+
+    assert result.exit_code == 0, result.output
+    upgrade.assert_called_once_with(info)
+    refresh.assert_called_once()
+
+
 def test_refresh_artifacts_updates_compose_and_skips_absent_clients(monkeypatch, tmp_path):
     target = tmp_path / "docker-compose.yml"
     install_call = Mock()
@@ -502,13 +536,17 @@ def test_refresh_artifacts_aggregates_integration_failure(monkeypatch, tmp_path)
     monkeypatch.setattr(
         cli_mod,
         "_install_detected_clients",
-        lambda ctx: (_ for _ in ()).throw(click.ClickException("Codex failed")),
+        lambda ctx: (_ for _ in ()).throw(
+            click.ClickException("Codex failed at /secret/profile")
+        ),
     )
 
     result = CliRunner().invoke(cli_mod.cli, ["update", "--refresh-artifacts"])
 
     assert result.exit_code != 0
-    assert "Integrations: Codex failed" in result.output
+    assert "Integrations: ClickException" in result.output
+    assert "reviewer install --all" in result.output
+    assert "/secret/profile" not in result.output
 
 
 def test_refresh_artifacts_sanitizes_unexpected_integration_failure(monkeypatch, tmp_path):
@@ -559,6 +597,19 @@ def test_has_detected_clients_includes_native_claude_cli(monkeypatch):
         cli_mod._shutil,
         "which",
         lambda name: "/usr/bin/claude" if name == "claude" else None,
+    )
+
+    assert cli_mod._has_detected_clients() is True
+
+
+def test_has_detected_clients_includes_native_codex_cli(monkeypatch):
+    from reviewer import install as inst
+
+    monkeypatch.setattr(inst, "detect_installed", lambda: [])
+    monkeypatch.setattr(
+        cli_mod._shutil,
+        "which",
+        lambda name: "/usr/bin/codex" if name == "codex" else None,
     )
 
     assert cli_mod._has_detected_clients() is True

--- a/tests/entrypoints/test_update_command.py
+++ b/tests/entrypoints/test_update_command.py
@@ -2,7 +2,9 @@ from contextlib import nullcontext
 from types import SimpleNamespace
 from unittest.mock import Mock
 
+import click
 from click.testing import CliRunner
+import pytest
 
 import reviewer.entrypoints.cli as cli_mod
 from reviewer.versioning import (
@@ -13,9 +15,15 @@ from reviewer.versioning import (
     check_latest,
     detect_installation,
 )
+from reviewer.update_lifecycle import ComposeSyncResult
 
 
-def test_update_editable_preserves_output(monkeypatch):
+@pytest.fixture
+def no_artifact_refresh(monkeypatch):
+    monkeypatch.setattr(cli_mod, "_refresh_update_artifacts", lambda ctx: None)
+
+
+def test_update_editable_preserves_output(monkeypatch, no_artifact_refresh):
     monkeypatch.setattr(
         cli_mod,
         "detect_installation",
@@ -30,7 +38,7 @@ def test_update_editable_preserves_output(monkeypatch):
     )
 
 
-def test_update_uvx_current_preserves_output(monkeypatch):
+def test_update_uvx_current_preserves_output(monkeypatch, no_artifact_refresh):
     monkeypatch.setattr(
         cli_mod,
         "detect_installation",
@@ -52,7 +60,7 @@ def test_update_uvx_current_preserves_output(monkeypatch):
     )
 
 
-def test_update_network_failure_preserves_output(monkeypatch):
+def test_update_network_failure_preserves_output(monkeypatch, no_artifact_refresh):
     info = InstallationInfo(InstallMode.UVX, "0.4.0", "/usr/bin/uv")
     monkeypatch.setattr(cli_mod, "detect_installation", lambda: info)
     monkeypatch.setattr(cli_mod, "check_latest", lambda info: VersionCheck(info, None, False))
@@ -98,7 +106,9 @@ def test_update_uv_tool_upgrade_failure_is_nonzero(monkeypatch):
     assert "Ошибка uv tool upgrade: не удалось обновить" in result.output
 
 
-def test_update_uv_tool_does_not_upgrade_when_latest_version_is_unknown(monkeypatch):
+def test_update_uv_tool_does_not_upgrade_when_latest_version_is_unknown(
+    monkeypatch, no_artifact_refresh
+):
     info = InstallationInfo(InstallMode.UV_TOOL, "0.4.0", "/usr/bin/uv")
     upgrade = Mock()
     monkeypatch.setattr(cli_mod, "detect_installation", lambda: info)
@@ -112,7 +122,9 @@ def test_update_uv_tool_does_not_upgrade_when_latest_version_is_unknown(monkeypa
     upgrade.assert_not_called()
 
 
-def test_update_does_not_claim_invalid_current_version_is_current_or_upgrade(monkeypatch):
+def test_update_does_not_claim_invalid_current_version_is_current_or_upgrade(
+    monkeypatch, no_artifact_refresh
+):
     info = InstallationInfo(InstallMode.UV_TOOL, "не-версия", "/usr/bin/uv")
     upgrade = Mock()
     response = SimpleNamespace(read=lambda: b'{"info": {"version": "1.0"}}')
@@ -136,7 +148,7 @@ def test_update_does_not_claim_invalid_current_version_is_current_or_upgrade(mon
     upgrade.assert_not_called()
 
 
-def test_update_uvx_new_version_preserves_output(monkeypatch):
+def test_update_uvx_new_version_preserves_output(monkeypatch, no_artifact_refresh):
     info = InstallationInfo(InstallMode.UVX, "0.4.0", "/usr/bin/uv")
     monkeypatch.setattr(cli_mod, "detect_installation", lambda: info)
     monkeypatch.setattr(cli_mod, "check_latest", lambda info: VersionCheck(info, "0.5.0", True))
@@ -152,7 +164,9 @@ def test_update_uvx_new_version_preserves_output(monkeypatch):
     )
 
 
-def test_update_uvx_does_not_upgrade_unrelated_persistent_tool(monkeypatch, tmp_path):
+def test_update_uvx_does_not_upgrade_unrelated_persistent_tool(
+    monkeypatch, tmp_path, no_artifact_refresh
+):
     tool_dir = tmp_path / "uv-tools"
     (tool_dir / "rag-reviewer").mkdir(parents=True)
     uvx_prefix = tmp_path / "uv-cache" / "archive-v0" / "current"
@@ -376,3 +390,175 @@ def test_update_invalid_package_version_still_refreshes_artifacts(monkeypatch):
     assert result.exit_code == 0, result.output
     assert "Не удалось определить корректную текущую версию" in result.output
     refresh.assert_called_once()
+
+
+def test_refresh_artifacts_updates_compose_and_skips_absent_clients(monkeypatch, tmp_path):
+    target = tmp_path / "docker-compose.yml"
+    install_call = Mock()
+    monkeypatch.setattr(
+        cli_mod,
+        "download_compose",
+        lambda: b"services: {}\n",
+        raising=False,
+    )
+    monkeypatch.setattr(
+        cli_mod,
+        "sync_compose_file",
+        lambda content: ComposeSyncResult("created", target),
+        raising=False,
+    )
+    monkeypatch.setattr(
+        cli_mod,
+        "_has_detected_clients",
+        lambda: False,
+        raising=False,
+    )
+    monkeypatch.setattr(
+        cli_mod,
+        "_install_detected_clients",
+        install_call,
+        raising=False,
+    )
+
+    result = CliRunner().invoke(cli_mod.cli, ["update", "--refresh-artifacts"])
+
+    assert result.exit_code == 0, result.output
+    assert f"Compose создан: {target}" in result.output
+    assert "AI-клиенты не обнаружены" in result.output
+    assert "New Chat/new CLI session" in result.output
+    assert "Reload Window" in result.output
+    install_call.assert_not_called()
+
+
+def test_refresh_artifacts_preserves_modified_compose_and_updates_clients(monkeypatch, tmp_path):
+    target = tmp_path / "docker-compose.yml"
+    install_call = Mock()
+    monkeypatch.setattr(cli_mod, "download_compose", lambda: b"services: {}\n")
+    monkeypatch.setattr(
+        cli_mod,
+        "sync_compose_file",
+        lambda content: ComposeSyncResult("preserved", target),
+    )
+    monkeypatch.setattr(cli_mod, "_has_detected_clients", lambda: True)
+    monkeypatch.setattr(cli_mod, "_install_detected_clients", install_call)
+
+    result = CliRunner().invoke(cli_mod.cli, ["update", "--refresh-artifacts"])
+
+    assert result.exit_code == 0, result.output
+    assert "не перезаписан" in result.output
+    install_call.assert_called_once()
+
+
+@pytest.mark.parametrize(
+    ("action", "status"),
+    [
+        ("adopted", "принят под управление"),
+        ("current", "актуален"),
+        ("updated", "обновлён"),
+    ],
+)
+def test_refresh_artifacts_reports_compose_status(monkeypatch, tmp_path, action, status):
+    target = tmp_path / "docker-compose.yml"
+    monkeypatch.setattr(cli_mod, "download_compose", lambda: b"services: {}\n")
+    monkeypatch.setattr(
+        cli_mod,
+        "sync_compose_file",
+        lambda content: ComposeSyncResult(action, target),
+    )
+    monkeypatch.setattr(cli_mod, "_has_detected_clients", lambda: False)
+
+    result = CliRunner().invoke(cli_mod.cli, ["update", "--refresh-artifacts"])
+
+    assert result.exit_code == 0, result.output
+    assert f"Compose {status}: {target}" in result.output
+
+
+def test_refresh_artifacts_attempts_clients_after_compose_download_failure(monkeypatch):
+    install_call = Mock()
+    monkeypatch.setattr(
+        cli_mod,
+        "download_compose",
+        lambda: (_ for _ in ()).throw(OSError("offline")),
+    )
+    monkeypatch.setattr(cli_mod, "_has_detected_clients", lambda: True)
+    monkeypatch.setattr(cli_mod, "_install_detected_clients", install_call)
+
+    result = CliRunner().invoke(cli_mod.cli, ["update", "--refresh-artifacts"])
+
+    assert result.exit_code != 0
+    assert "Compose: OSError" in result.output
+    install_call.assert_called_once()
+
+
+def test_refresh_artifacts_aggregates_integration_failure(monkeypatch, tmp_path):
+    target = tmp_path / "docker-compose.yml"
+    monkeypatch.setattr(cli_mod, "download_compose", lambda: b"services: {}\n")
+    monkeypatch.setattr(
+        cli_mod,
+        "sync_compose_file",
+        lambda content: ComposeSyncResult("current", target),
+    )
+    monkeypatch.setattr(cli_mod, "_has_detected_clients", lambda: True)
+    monkeypatch.setattr(
+        cli_mod,
+        "_install_detected_clients",
+        lambda ctx: (_ for _ in ()).throw(click.ClickException("Codex failed")),
+    )
+
+    result = CliRunner().invoke(cli_mod.cli, ["update", "--refresh-artifacts"])
+
+    assert result.exit_code != 0
+    assert "Integrations: Codex failed" in result.output
+
+
+def test_refresh_artifacts_sanitizes_unexpected_integration_failure(monkeypatch, tmp_path):
+    target = tmp_path / "docker-compose.yml"
+    monkeypatch.setattr(cli_mod, "download_compose", lambda: b"services: {}\n")
+    monkeypatch.setattr(
+        cli_mod,
+        "sync_compose_file",
+        lambda content: ComposeSyncResult("current", target),
+    )
+    monkeypatch.setattr(cli_mod, "_has_detected_clients", lambda: True)
+    monkeypatch.setattr(
+        cli_mod,
+        "_install_detected_clients",
+        lambda ctx: (_ for _ in ()).throw(OSError("/secret/profile")),
+    )
+
+    result = CliRunner().invoke(cli_mod.cli, ["update", "--refresh-artifacts"])
+
+    assert result.exit_code != 0
+    assert "Integrations: OSError" in result.output
+    assert "/secret/profile" not in result.output
+
+
+def test_install_detected_clients_reuses_install_all_contract():
+    ctx = Mock()
+
+    cli_mod._install_detected_clients(ctx)
+
+    ctx.invoke.assert_called_once_with(
+        cli_mod.install,
+        client=None,
+        all_clients=True,
+        list_clients=False,
+        path_opt=None,
+        pin=None,
+        no_latest=False,
+        no_skills=False,
+        dry_run=False,
+    )
+
+
+def test_has_detected_clients_includes_native_claude_cli(monkeypatch):
+    from reviewer import install as inst
+
+    monkeypatch.setattr(inst, "detect_installed", lambda: [])
+    monkeypatch.setattr(
+        cli_mod._shutil,
+        "which",
+        lambda name: "/usr/bin/claude" if name == "claude" else None,
+    )
+
+    assert cli_mod._has_detected_clients() is True

--- a/tests/entrypoints/test_update_command.py
+++ b/tests/entrypoints/test_update_command.py
@@ -66,23 +66,25 @@ def test_update_network_failure_preserves_output(monkeypatch):
     )
 
 
-def test_update_uv_tool_upgrade_success_preserves_output(monkeypatch):
+def test_update_uv_tool_upgrade_success_reports_package_and_artifacts(monkeypatch):
     info = InstallationInfo(InstallMode.UV_TOOL, "0.4.0", "/usr/bin/uv")
     monkeypatch.setattr(cli_mod, "detect_installation", lambda: info)
     monkeypatch.setattr(cli_mod, "check_latest", lambda info: VersionCheck(info, "0.5.0", True))
     monkeypatch.setattr(cli_mod, "upgrade_uv_tool", lambda info: UpgradeResult(0, ""))
+    monkeypatch.setattr(
+        cli_mod,
+        "run_fresh_artifact_refresh",
+        lambda: SimpleNamespace(returncode=0, stdout="artifacts refreshed\n", stderr=""),
+    )
 
     result = CliRunner().invoke(cli_mod.cli, ["update"])
 
     assert result.exit_code == 0
-    assert result.output == (
-        "Режим: uv tool (постоянная) | Версия: 0.4.0\n"
-        "Доступна новая версия: 0.4.0 → 0.5.0\n"
-        "Обновлено. Перезапустите MCP-сервер.\n"
-    )
+    assert "✓ Python package обновлён." in result.output
+    assert "artifacts refreshed" in result.output
 
 
-def test_update_uv_tool_upgrade_failure_preserves_output(monkeypatch):
+def test_update_uv_tool_upgrade_failure_is_nonzero(monkeypatch):
     info = InstallationInfo(InstallMode.UV_TOOL, "0.4.0", "/usr/bin/uv")
     monkeypatch.setattr(cli_mod, "detect_installation", lambda: info)
     monkeypatch.setattr(cli_mod, "check_latest", lambda info: VersionCheck(info, "0.5.0", True))
@@ -92,12 +94,8 @@ def test_update_uv_tool_upgrade_failure_preserves_output(monkeypatch):
 
     result = CliRunner().invoke(cli_mod.cli, ["update"])
 
-    assert result.exit_code == 0
-    assert result.output == (
-        "Режим: uv tool (постоянная) | Версия: 0.4.0\n"
-        "Доступна новая версия: 0.4.0 → 0.5.0\n"
-        "Ошибка uv tool upgrade: не удалось обновить\n"
-    )
+    assert result.exit_code != 0
+    assert "Ошибка uv tool upgrade: не удалось обновить" in result.output
 
 
 def test_update_uv_tool_does_not_upgrade_when_latest_version_is_unknown(monkeypatch):
@@ -194,3 +192,187 @@ def test_update_uvx_does_not_upgrade_unrelated_persistent_tool(monkeypatch, tmp_
         "Для CLI: uvx --from rag-reviewer@latest reviewer <команда>\n"
     )
     upgrade.assert_not_called()
+
+
+def test_update_uv_tool_upgrade_runs_artifacts_in_fresh_process(monkeypatch):
+    info = InstallationInfo(InstallMode.UV_TOOL, "0.4.3", "/usr/bin/uv")
+    refreshed = Mock(
+        return_value=SimpleNamespace(
+            returncode=0,
+            stdout="artifacts ok\n",
+            stderr="",
+        )
+    )
+    monkeypatch.setattr(cli_mod, "detect_installation", lambda: info)
+    monkeypatch.setattr(
+        cli_mod,
+        "check_latest",
+        lambda value: VersionCheck(value, "0.4.4", True),
+    )
+    monkeypatch.setattr(
+        cli_mod,
+        "upgrade_uv_tool",
+        lambda value: UpgradeResult(0, ""),
+    )
+    monkeypatch.setattr(
+        cli_mod,
+        "run_fresh_artifact_refresh",
+        refreshed,
+        raising=False,
+    )
+
+    result = CliRunner().invoke(cli_mod.cli, ["update"])
+
+    assert result.exit_code == 0, result.output
+    assert "Доступна новая версия: 0.4.3 → 0.4.4" in result.output
+    assert "artifacts ok" in result.output
+    refreshed.assert_called_once_with()
+
+
+def test_update_uv_tool_stops_before_artifacts_when_upgrade_fails(monkeypatch):
+    info = InstallationInfo(InstallMode.UV_TOOL, "0.4.3", "/usr/bin/uv")
+    refreshed = Mock()
+    monkeypatch.setattr(cli_mod, "detect_installation", lambda: info)
+    monkeypatch.setattr(
+        cli_mod,
+        "check_latest",
+        lambda value: VersionCheck(value, "0.4.4", True),
+    )
+    monkeypatch.setattr(
+        cli_mod,
+        "upgrade_uv_tool",
+        lambda value: UpgradeResult(1, "registry unavailable"),
+    )
+    monkeypatch.setattr(cli_mod, "run_fresh_artifact_refresh", refreshed)
+
+    result = CliRunner().invoke(cli_mod.cli, ["update"])
+
+    assert result.exit_code != 0
+    assert "registry unavailable" in result.output
+    refreshed.assert_not_called()
+
+
+def test_update_current_version_refreshes_artifacts_in_process(monkeypatch):
+    info = InstallationInfo(InstallMode.UV_TOOL, "0.4.4", "/usr/bin/uv")
+    refresh = Mock()
+    monkeypatch.setattr(cli_mod, "detect_installation", lambda: info)
+    monkeypatch.setattr(
+        cli_mod,
+        "check_latest",
+        lambda value: VersionCheck(value, "0.4.4", False),
+    )
+    monkeypatch.setattr(
+        cli_mod,
+        "_refresh_update_artifacts",
+        refresh,
+        raising=False,
+    )
+
+    result = CliRunner().invoke(cli_mod.cli, ["update"])
+
+    assert result.exit_code == 0, result.output
+    refresh.assert_called_once()
+
+
+def test_update_uvx_upgrade_tool_is_explicit(monkeypatch):
+    info = InstallationInfo(InstallMode.UVX, "0.4.4", "/usr/bin/uv")
+    upgrade = Mock(return_value=UpgradeResult(0, ""))
+    refresh = Mock()
+    monkeypatch.setattr(cli_mod, "detect_installation", lambda: info)
+    monkeypatch.setattr(
+        cli_mod,
+        "check_latest",
+        lambda value: VersionCheck(value, "0.4.4", False),
+    )
+    monkeypatch.setattr(cli_mod, "upgrade_uv_tool", upgrade)
+    monkeypatch.setattr(cli_mod, "_refresh_update_artifacts", refresh)
+
+    regular = CliRunner().invoke(cli_mod.cli, ["update"])
+    bootstrap = CliRunner().invoke(cli_mod.cli, ["update", "--upgrade-tool"])
+
+    assert regular.exit_code == 0, regular.output
+    assert bootstrap.exit_code == 0, bootstrap.output
+    upgrade.assert_called_once_with(info)
+    assert refresh.call_count == 2
+
+
+def test_update_editable_refreshes_artifacts_without_touching_source(monkeypatch):
+    info = InstallationInfo(InstallMode.EDITABLE, "0.4.4", "/usr/bin/uv")
+    refresh = Mock()
+    monkeypatch.setattr(cli_mod, "detect_installation", lambda: info)
+    monkeypatch.setattr(cli_mod, "_refresh_update_artifacts", refresh)
+
+    result = CliRunner().invoke(cli_mod.cli, ["update"])
+
+    assert result.exit_code == 0, result.output
+    assert "git pull && pip install -e ." in result.output
+    refresh.assert_called_once()
+
+
+def test_update_hidden_artifact_phase_skips_installation_detection(monkeypatch):
+    detect = Mock()
+    refresh = Mock()
+    monkeypatch.setattr(cli_mod, "detect_installation", detect)
+    monkeypatch.setattr(cli_mod, "_refresh_update_artifacts", refresh)
+
+    result = CliRunner().invoke(cli_mod.cli, ["update", "--refresh-artifacts"])
+
+    assert result.exit_code == 0, result.output
+    detect.assert_not_called()
+    refresh.assert_called_once()
+
+
+def test_update_uvx_bootstrap_with_newer_version_upgrades_tool_once(monkeypatch):
+    info = InstallationInfo(InstallMode.UVX, "0.4.3", "/usr/bin/uv")
+    upgrade = Mock(return_value=UpgradeResult(0, ""))
+    refresh = Mock()
+    monkeypatch.setattr(cli_mod, "detect_installation", lambda: info)
+    monkeypatch.setattr(
+        cli_mod,
+        "check_latest",
+        lambda value: VersionCheck(value, "0.4.4", True),
+    )
+    monkeypatch.setattr(cli_mod, "upgrade_uv_tool", upgrade)
+    monkeypatch.setattr(cli_mod, "_refresh_update_artifacts", refresh)
+
+    result = CliRunner().invoke(cli_mod.cli, ["update", "--upgrade-tool"])
+
+    assert result.exit_code == 0, result.output
+    upgrade.assert_called_once_with(info)
+    refresh.assert_called_once()
+
+
+def test_update_pypi_failure_still_refreshes_independent_artifacts(monkeypatch):
+    info = InstallationInfo(InstallMode.UVX, "0.4.4", "/usr/bin/uv")
+    refresh = Mock()
+    monkeypatch.setattr(cli_mod, "detect_installation", lambda: info)
+    monkeypatch.setattr(
+        cli_mod,
+        "check_latest",
+        lambda value: VersionCheck(value, None, False),
+    )
+    monkeypatch.setattr(cli_mod, "_refresh_update_artifacts", refresh)
+
+    result = CliRunner().invoke(cli_mod.cli, ["update"])
+
+    assert result.exit_code == 0, result.output
+    assert "Не удалось получить информацию с PyPI" in result.output
+    refresh.assert_called_once()
+
+
+def test_update_invalid_package_version_still_refreshes_artifacts(monkeypatch):
+    info = InstallationInfo(InstallMode.UV_TOOL, "local", "/usr/bin/uv")
+    refresh = Mock()
+    monkeypatch.setattr(cli_mod, "detect_installation", lambda: info)
+    monkeypatch.setattr(
+        cli_mod,
+        "check_latest",
+        lambda value: VersionCheck(value, "0.4.4", False, current_valid=False),
+    )
+    monkeypatch.setattr(cli_mod, "_refresh_update_artifacts", refresh)
+
+    result = CliRunner().invoke(cli_mod.cli, ["update"])
+
+    assert result.exit_code == 0, result.output
+    assert "Не удалось определить корректную текущую версию" in result.output
+    refresh.assert_called_once()

--- a/tests/install/test_codex_cli.py
+++ b/tests/install/test_codex_cli.py
@@ -2,6 +2,7 @@ from pathlib import Path
 
 from click.testing import CliRunner
 
+import reviewer.entrypoints.cli as cli_module
 from reviewer import install as generic_install
 from reviewer.entrypoints.cli import cli
 from reviewer.install_codex import (
@@ -129,3 +130,31 @@ def test_install_all_reports_codex_failure_after_other_targets(monkeypatch, tmp_
     assert result.exit_code != 0
     assert "plugin failed" in result.output
     assert (home / ".cursor/mcp.json").is_file()
+
+
+def test_install_all_detects_codex_from_executable_without_config_dir(monkeypatch, tmp_path):
+    captured = []
+    monkeypatch.setattr(generic_install, "_home", lambda: tmp_path / "home")
+    monkeypatch.setattr(generic_install, "detect_installed", lambda: [])
+
+    def which(name):
+        if name == "codex":
+            return "/opt/codex"
+        if name == "uvx":
+            return "/opt/uvx"
+        return None
+
+    monkeypatch.setattr(cli_module._shutil, "which", which)
+    monkeypatch.setattr(
+        cli_module,
+        "_run_codex_target",
+        lambda **kwargs: captured.append(kwargs) or object(),
+    )
+    monkeypatch.setattr(cli_module, "_print_codex_result", lambda result: None)
+
+    result = CliRunner().invoke(cli, ["install", "--all"])
+
+    assert result.exit_code == 0, result.output
+    assert captured == [
+        {"include_mcp": True, "dry_run": False, "version": "latest", "path_opt": None}
+    ]

--- a/tests/launcher/test_app.py
+++ b/tests/launcher/test_app.py
@@ -227,12 +227,12 @@ class _TrackingOutput(PlainTextOutput):
         if (
             "reviewer update" in rendered
             and "Эффект после подтверждения: запись" in rendered
-            and "будет изменена постоянная uv tool-установка rag-reviewer" in rendered
+            and "Будут обновлены package, integrations, скилы и управляемый Compose" in rendered
         ):
             self.update_confirmation_rendered.set()
         if (
             "Не удалось получить информацию с PyPI. Проверьте сеть." in rendered
-            and "Повторить проверку: Esc — назад, затем Enter" in rendered
+            and "Команда после подтверждения: reviewer update" in rendered
         ):
             self.update_failure_rendered.set()
         if (
@@ -839,7 +839,7 @@ def test_update_check_runs_once_and_does_not_return_upgrade_without_confirm():
     assert calls == [(info, 5)]
 
 
-def test_uv_tool_update_result_renders_command_write_effect_and_persistent_warning():
+def test_uv_tool_update_result_renders_unified_write_effect():
     checked = threading.Event()
     info = InstallationInfo(InstallMode.UV_TOOL, "0.4.0", "/usr/bin/uv")
     output = _TrackingOutput()
@@ -1145,7 +1145,51 @@ def test_update_confirm_returns_existing_click_argv_for_uv_tool():
     assert result == LauncherResult(("update",), 0)
 
 
-def test_uvx_update_result_only_shows_instructions_without_upgrade_argv():
+@pytest.mark.parametrize(
+    "check",
+    [
+        VersionCheck(
+            InstallationInfo(InstallMode.UV_TOOL, "0.4.4", "/usr/bin/uv"),
+            "0.4.4",
+            False,
+        ),
+        VersionCheck(
+            InstallationInfo(InstallMode.UVX, "0.4.4", "/usr/bin/uv"),
+            "0.4.4",
+            False,
+        ),
+        VersionCheck(
+            InstallationInfo(InstallMode.EDITABLE, "0.4.4", "/usr/bin/uv"),
+            "0.4.4",
+            False,
+        ),
+        VersionCheck(
+            InstallationInfo(InstallMode.UV_TOOL, "local", "/usr/bin/uv"),
+            "0.4.4",
+            False,
+            current_valid=False,
+        ),
+        VersionCheck(
+            InstallationInfo(InstallMode.UV_TOOL, "0.4.4", "/usr/bin/uv"),
+            None,
+            False,
+        ),
+    ],
+)
+def test_completed_check_allows_unified_update_for_every_install_mode(check):
+    controller = LauncherController((_spec("update"),))
+    controller.screen = Screen.UPDATE_RESULT
+    ui = _LauncherUI(
+        controller,
+        installation_detector=lambda: check.installation,
+        version_checker=lambda installation, timeout: check,
+    )
+    ui.version_check = check
+
+    assert ui._can_run_update() is True
+
+
+def test_uvx_update_result_can_confirm_unified_update():
     checked = threading.Event()
     info = InstallationInfo(InstallMode.UVX, "0.4.0", "/usr/bin/uv")
 
@@ -1156,7 +1200,7 @@ def test_uvx_update_result_only_shows_instructions_without_upgrade_argv():
     output = _TrackingOutput()
 
     with create_pipe_input() as pipe:
-        sender = _send_after(pipe, output.update_result_rendered, b"\r\x03")
+        sender = _send_after(pipe, checked, b"\r")
         pipe.send_bytes(b"\r\r")
         result = run_launcher(
             commands=(_spec("update"),),
@@ -1169,22 +1213,23 @@ def test_uvx_update_result_only_shows_instructions_without_upgrade_argv():
 
     rendered = output.stream.getvalue()
     assert checked.is_set()
-    assert "Команда после подтверждения: reviewer update" not in rendered
-    assert "Эффект после подтверждения: запись" not in rendered
+    assert "Команда после подтверждения: reviewer update" in rendered
+    assert "Эффект после подтверждения: запись" in rendered
     assert "будет изменена постоянная uv tool-установка" not in rendered
-    assert result == LauncherResult(None, 130)
+    assert result == LauncherResult(("update",), 0)
 
 
-def test_editable_update_result_has_no_mutation_preview_or_button():
+def test_editable_update_result_offers_artifact_refresh():
     info = InstallationInfo(InstallMode.EDITABLE, "0.4.0", "/usr/bin/uv")
     output = _TrackingOutput()
+    checked = threading.Event()
 
     def checker(installation: InstallationInfo, *, timeout: int) -> VersionCheck:
+        checked.set()
         return VersionCheck(installation, "0.5.0", True)
 
     with create_pipe_input() as pipe:
-        stop = threading.Timer(0.5, lambda: pipe.send_bytes(b"\x03"))
-        stop.start()
+        sender = _send_after(pipe, checked, b"\r")
         pipe.send_bytes(b"\r\r")
         result = run_launcher(
             commands=(_spec("update"),),
@@ -1193,29 +1238,29 @@ def test_editable_update_result_has_no_mutation_preview_or_button():
             installation_detector=lambda: info,
             version_checker=checker,
         )
-        stop.join()
+        sender.join()
 
     rendered = output.stream.getvalue()
-    assert "Для обновления: git pull && pip install -e ." in rendered
-    assert "Команда после подтверждения: reviewer update" not in rendered
-    assert "Эффект после подтверждения: запись" not in rendered
+    assert "Команда после подтверждения: reviewer update" in rendered
+    assert "Эффект после подтверждения: запись" in rendered
     assert "будет изменена постоянная uv tool-установка" not in rendered
-    assert result == LauncherResult(None, 130)
+    assert result == LauncherResult(("update",), 0)
 
 
-def test_invalid_current_version_disables_tui_update_confirmation():
+def test_invalid_current_version_still_allows_artifact_refresh():
     info = InstallationInfo(InstallMode.UV_TOOL, "не-версия", "/usr/bin/uv")
     output = _TrackingOutput()
+    checked = threading.Event()
 
     def checker(installation: InstallationInfo, *, timeout: int) -> VersionCheck:
+        checked.set()
         return launcher_app.check_latest(
             installation,
             opener=lambda request, timeout: _VersionResponse("1.0"),
         )
 
     with create_pipe_input() as pipe:
-        stop = threading.Timer(0.5, lambda: pipe.send_bytes(b"\x03"))
-        stop.start()
+        sender = _send_after(pipe, checked, b"\r")
         pipe.send_bytes(b"\r\r")
         result = run_launcher(
             commands=(_spec("update"),),
@@ -1224,17 +1269,17 @@ def test_invalid_current_version_disables_tui_update_confirmation():
             installation_detector=lambda: info,
             version_checker=checker,
         )
-        stop.join()
+        sender.join()
 
     rendered = output.stream.getvalue()
     assert "Не удалось определить корректную текущую версию." in rendered
     assert "Версия актуальна" not in rendered
-    assert "Команда после подтверждения: reviewer update" not in rendered
-    assert "Enter — подтвердить" not in rendered
-    assert result == LauncherResult(None, 130)
+    assert "Команда после подтверждения: reviewer update" in rendered
+    assert "Enter — подтвердить" in rendered
+    assert result == LauncherResult(("update",), 0)
 
 
-def test_offline_update_result_shows_failure_retry_and_no_currency_or_confirmation():
+def test_offline_update_result_allows_attempting_independent_artifacts():
     info = InstallationInfo(InstallMode.UV_TOOL, "0.4.0", "/usr/bin/uv")
     output = _TrackingOutput()
 
@@ -1262,8 +1307,8 @@ def test_offline_update_result_shows_failure_retry_and_no_currency_or_confirmati
     assert output.update_failure_rendered.is_set(), rendered
     assert "Обновление не требуется" not in rendered
     assert "Версия актуальна" not in rendered
-    assert "Команда после подтверждения: reviewer update" not in rendered
-    assert "Enter — подтвердить" not in rendered
+    assert "Команда после подтверждения: reviewer update" in rendered
+    assert "Enter — подтвердить" in rendered
     assert result == LauncherResult(None, 130)
 
 

--- a/tests/launcher/test_app.py
+++ b/tests/launcher/test_app.py
@@ -813,6 +813,21 @@ def test_update_details_explicitly_keep_startup_and_check_read_only():
     assert calls == []
 
 
+def test_update_special_action_ignores_f2_without_detached_focus_crash():
+    with create_pipe_input() as pipe:
+        stop = threading.Timer(0.2, lambda: pipe.send_bytes(b"\x03"))
+        stop.start()
+        pipe.send_bytes(b"\r\x1bOQ")
+        result = run_launcher(
+            commands=(_spec("update"),),
+            input=pipe,
+            output=DummyOutput(),
+        )
+        stop.join()
+
+    assert result == LauncherResult(None, 130)
+
+
 def test_update_check_runs_once_and_does_not_return_upgrade_without_confirm():
     checked = threading.Event()
     info = InstallationInfo(InstallMode.UV_TOOL, "0.4.0", "/usr/bin/uv")

--- a/tests/launcher/test_catalog.py
+++ b/tests/launcher/test_catalog.py
@@ -149,9 +149,10 @@ def test_current_commands_have_rich_metadata_without_orphans():
     assert set(COMMAND_PRESENTATION) == paths
 
 
-def test_update_metadata_discloses_conditional_persistent_write():
+def test_update_metadata_discloses_complete_mutating_lifecycle():
     update = next(item for item in build_catalog(cli) if item.path == ("update",))
 
     assert update.effects == (Effect.READ, Effect.NETWORK, Effect.WRITE)
-    assert "постоянную uv tool-установку" in update.details
-    assert "только после отдельного подтверждения" in update.details
+    assert "AI-client integrations" in update.details
+    assert "Compose" in update.details
+    assert "не перезаписывает пользовательские изменения" in update.details

--- a/tests/test_update_lifecycle.py
+++ b/tests/test_update_lifecycle.py
@@ -1,11 +1,14 @@
 import hashlib
 import json
+import threading
 from contextlib import nullcontext
+from contextlib import contextmanager
 from types import SimpleNamespace
 
 import reviewer.update_lifecycle as lifecycle
 from reviewer.update_lifecycle import (
     download_compose,
+    find_uv_tool_python,
     run_fresh_artifact_refresh,
     sync_compose_file,
 )
@@ -120,6 +123,7 @@ def test_run_fresh_artifact_refresh_uses_same_python_environment():
         (
             [
                 "/tools/rag-reviewer/bin/python",
+                "-I",
                 "-c",
                 "from reviewer.entrypoints.launcher import main; main()",
                 "update",
@@ -173,3 +177,83 @@ def test_sync_compose_preserves_edit_that_races_managed_update(monkeypatch, tmp_
 
     assert result.action == "preserved"
     assert target.read_bytes() == custom
+
+
+def test_find_uv_tool_python_resolves_persistent_environment(tmp_path):
+    tools = tmp_path / "uv-tools"
+    python = tools / "rag-reviewer" / "bin" / "python"
+    python.parent.mkdir(parents=True)
+    python.write_bytes(b"")
+    calls = []
+
+    def run(argv, **kwargs):
+        calls.append((argv, kwargs))
+        return SimpleNamespace(returncode=0, stdout=f"{tools}\n")
+
+    result = find_uv_tool_python("/opt/uv", run=run, system="Linux")
+
+    assert result == str(python)
+    assert calls == [
+        (["/opt/uv", "tool", "dir"], {"capture_output": True, "text": True})
+    ]
+
+
+def test_find_uv_tool_python_returns_none_for_missing_environment(tmp_path):
+    result = find_uv_tool_python(
+        "/opt/uv",
+        run=lambda argv, **kwargs: SimpleNamespace(
+            returncode=0,
+            stdout=f"{tmp_path / 'uv-tools'}\n",
+        ),
+        system="Windows",
+    )
+
+    assert result is None
+
+
+def test_update_lock_serializes_parallel_syncs(tmp_path):
+    acquired = threading.Event()
+
+    def contender():
+        with lifecycle._update_lock(tmp_path):
+            acquired.set()
+
+    with lifecycle._update_lock(tmp_path):
+        thread = threading.Thread(target=contender)
+        thread.start()
+        assert acquired.wait(0.1) is False
+
+    assert acquired.wait(1) is True
+    thread.join()
+
+
+def test_sync_compose_holds_update_lock(monkeypatch, tmp_path):
+    entered = []
+
+    @contextmanager
+    def lock(directory):
+        entered.append(directory)
+        yield
+
+    monkeypatch.setattr(lifecycle, "_update_lock", lock)
+
+    sync_compose_file(b"services: {}\n", config_dir=tmp_path)
+
+    assert entered == [tmp_path]
+
+
+def test_sync_compose_preserves_file_created_during_missing_target_race(monkeypatch, tmp_path):
+    target = tmp_path / "docker-compose.yml"
+    custom = b"custom\n"
+
+    def collide(path, content):
+        path.write_bytes(custom)
+        return False
+
+    monkeypatch.setattr(lifecycle, "_atomic_create", collide, raising=False)
+
+    result = sync_compose_file(b"canonical\n", config_dir=tmp_path)
+
+    assert result.action == "preserved"
+    assert target.read_bytes() == custom
+    assert not (tmp_path / ".reviewer-update.json").exists()

--- a/tests/test_update_lifecycle.py
+++ b/tests/test_update_lifecycle.py
@@ -1,7 +1,13 @@
 import hashlib
 import json
+from contextlib import nullcontext
+from types import SimpleNamespace
 
-from reviewer.update_lifecycle import sync_compose_file
+from reviewer.update_lifecycle import (
+    download_compose,
+    run_fresh_artifact_refresh,
+    sync_compose_file,
+)
 
 
 def _digest(content: bytes) -> str:
@@ -75,3 +81,52 @@ def test_sync_compose_preserves_unmanaged_nonmatching_file(tmp_path):
     assert result.action == "preserved"
     assert target.read_bytes() == b"custom\n"
     assert not (tmp_path / ".reviewer-update.json").exists()
+
+
+def test_download_compose_uses_canonical_url_and_no_cache_headers():
+    seen = {}
+
+    def opener(request, timeout):
+        seen["url"] = request.full_url
+        seen["cache"] = request.headers["Cache-control"]
+        seen["timeout"] = timeout
+        return nullcontext(SimpleNamespace(read=lambda: b"services: {}\n"))
+
+    assert download_compose(opener=opener, timeout=7) == b"services: {}\n"
+    assert seen == {
+        "url": (
+            "https://raw.githubusercontent.com/mimfort/rag_for_git/"
+            "main/docker-compose.yml"
+        ),
+        "cache": "no-cache, no-store",
+        "timeout": 7,
+    }
+
+
+def test_run_fresh_artifact_refresh_invokes_reviewer_hidden_phase():
+    calls = []
+
+    def run(argv, **kwargs):
+        calls.append((argv, kwargs))
+        return SimpleNamespace(returncode=0, stdout="compose current\n", stderr="")
+
+    result = run_fresh_artifact_refresh(
+        which=lambda name: "/tools/reviewer" if name == "reviewer" else None,
+        run=run,
+    )
+
+    assert calls == [
+        (
+            ["/tools/reviewer", "update", "--refresh-artifacts"],
+            {"capture_output": True, "text": True},
+        )
+    ]
+    assert result.returncode == 0
+    assert result.stdout == "compose current\n"
+
+
+def test_run_fresh_artifact_refresh_reports_missing_executable():
+    result = run_fresh_artifact_refresh(which=lambda name: None)
+
+    assert result.returncode == 127
+    assert "reviewer не найден" in result.stderr

--- a/tests/test_update_lifecycle.py
+++ b/tests/test_update_lifecycle.py
@@ -3,6 +3,7 @@ import json
 from contextlib import nullcontext
 from types import SimpleNamespace
 
+import reviewer.update_lifecycle as lifecycle
 from reviewer.update_lifecycle import (
     download_compose,
     run_fresh_artifact_refresh,
@@ -103,7 +104,7 @@ def test_download_compose_uses_canonical_url_and_no_cache_headers():
     }
 
 
-def test_run_fresh_artifact_refresh_invokes_reviewer_hidden_phase():
+def test_run_fresh_artifact_refresh_uses_same_python_environment():
     calls = []
 
     def run(argv, **kwargs):
@@ -111,13 +112,19 @@ def test_run_fresh_artifact_refresh_invokes_reviewer_hidden_phase():
         return SimpleNamespace(returncode=0, stdout="compose current\n", stderr="")
 
     result = run_fresh_artifact_refresh(
-        which=lambda name: "/tools/reviewer" if name == "reviewer" else None,
+        python_executable="/tools/rag-reviewer/bin/python",
         run=run,
     )
 
     assert calls == [
         (
-            ["/tools/reviewer", "update", "--refresh-artifacts"],
+            [
+                "/tools/rag-reviewer/bin/python",
+                "-c",
+                "from reviewer.entrypoints.launcher import main; main()",
+                "update",
+                "--refresh-artifacts",
+            ],
             {"capture_output": True, "text": True},
         )
     ]
@@ -126,7 +133,43 @@ def test_run_fresh_artifact_refresh_invokes_reviewer_hidden_phase():
 
 
 def test_run_fresh_artifact_refresh_reports_missing_executable():
-    result = run_fresh_artifact_refresh(which=lambda name: None)
+    result = run_fresh_artifact_refresh(python_executable="")
 
     assert result.returncode == 127
-    assert "reviewer не найден" in result.stderr
+    assert "Python executable не найден" in result.stderr
+
+
+def test_sync_compose_preserves_symlink_even_when_content_matches(tmp_path):
+    source = tmp_path / "custom-compose.yml"
+    content = b"services:\n  db: {}\n"
+    source.write_bytes(content)
+    target = tmp_path / "docker-compose.yml"
+    target.symlink_to(source)
+
+    result = sync_compose_file(content, config_dir=tmp_path)
+
+    assert result.action == "preserved"
+    assert target.is_symlink()
+    assert source.read_bytes() == content
+    assert not (tmp_path / ".reviewer-update.json").exists()
+
+
+def test_sync_compose_preserves_edit_that_races_managed_update(monkeypatch, tmp_path):
+    old = b"services:\n  db: {image: old}\n"
+    new = b"services:\n  db: {image: new}\n"
+    custom = b"services:\n  db: {ports: [custom]}\n"
+    sync_compose_file(old, config_dir=tmp_path)
+    target = tmp_path / "docker-compose.yml"
+    original_read = lifecycle._read_recorded_hash
+
+    def read_then_edit(path):
+        recorded = original_read(path)
+        target.write_bytes(custom)
+        return recorded
+
+    monkeypatch.setattr(lifecycle, "_read_recorded_hash", read_then_edit)
+
+    result = sync_compose_file(new, config_dir=tmp_path)
+
+    assert result.action == "preserved"
+    assert target.read_bytes() == custom

--- a/tests/test_update_lifecycle.py
+++ b/tests/test_update_lifecycle.py
@@ -1,0 +1,77 @@
+import hashlib
+import json
+
+from reviewer.update_lifecycle import sync_compose_file
+
+
+def _digest(content: bytes) -> str:
+    return "sha256:" + hashlib.sha256(content).hexdigest()
+
+
+def test_sync_compose_creates_missing_target_and_state(tmp_path):
+    content = b"services:\n  db: {}\n"
+
+    result = sync_compose_file(content, config_dir=tmp_path)
+
+    assert result.action == "created"
+    assert result.path.read_bytes() == content
+    state = json.loads((tmp_path / ".reviewer-update.json").read_text())
+    assert state == {"docker_compose_sha256": _digest(content)}
+
+
+def test_sync_compose_adopts_exact_unmanaged_download(tmp_path):
+    content = b"services:\n  db: {}\n"
+    (tmp_path / "docker-compose.yml").write_bytes(content)
+
+    result = sync_compose_file(content, config_dir=tmp_path)
+
+    assert result.action == "adopted"
+    assert json.loads((tmp_path / ".reviewer-update.json").read_text()) == {
+        "docker_compose_sha256": _digest(content)
+    }
+
+
+def test_sync_compose_reports_current_managed_file(tmp_path):
+    content = b"services:\n  db: {}\n"
+    sync_compose_file(content, config_dir=tmp_path)
+
+    result = sync_compose_file(content, config_dir=tmp_path)
+
+    assert result.action == "current"
+
+
+def test_sync_compose_updates_only_file_matching_recorded_hash(tmp_path):
+    old = b"services:\n  db: {image: old}\n"
+    new = b"services:\n  db: {image: new}\n"
+    sync_compose_file(old, config_dir=tmp_path)
+
+    result = sync_compose_file(new, config_dir=tmp_path)
+
+    assert result.action == "updated"
+    assert result.path.read_bytes() == new
+
+
+def test_sync_compose_preserves_modified_managed_file_and_old_state(tmp_path):
+    old = b"services:\n  db: {image: old}\n"
+    new = b"services:\n  db: {image: new}\n"
+    sync_compose_file(old, config_dir=tmp_path)
+    target = tmp_path / "docker-compose.yml"
+    target.write_bytes(b"services:\n  db: {ports: [custom]}\n")
+    state_before = (tmp_path / ".reviewer-update.json").read_bytes()
+
+    result = sync_compose_file(new, config_dir=tmp_path)
+
+    assert result.action == "preserved"
+    assert target.read_bytes() == b"services:\n  db: {ports: [custom]}\n"
+    assert (tmp_path / ".reviewer-update.json").read_bytes() == state_before
+
+
+def test_sync_compose_preserves_unmanaged_nonmatching_file(tmp_path):
+    target = tmp_path / "docker-compose.yml"
+    target.write_bytes(b"custom\n")
+
+    result = sync_compose_file(b"canonical\n", config_dir=tmp_path)
+
+    assert result.action == "preserved"
+    assert target.read_bytes() == b"custom\n"
+    assert not (tmp_path / ".reviewer-update.json").exists()

--- a/uv.lock
+++ b/uv.lock
@@ -1647,7 +1647,7 @@ wheels = [
 
 [[package]]
 name = "rag-reviewer"
-version = "0.4.3"
+version = "0.4.4"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary
- release unified reviewer update lifecycle from dev
- update package, detected integrations/plugins/skills and managed Compose with one command
- publish bilingual onboarding and version 0.4.4 metadata

## Verification
- PR #164 checks passed on Linux, macOS and Windows
- dev post-merge Tests run 31323798488 passed
- local full suite: 3645 passed, 1 skipped
- wheel build and update --help smoke passed