### PR TITLE
chore(release): версия 0.4.6 и пересборка манифестов

### DIFF
--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "rag-reviewer",
-  "version": "0.4.5+codex.1aba543ef50d",
+  "version": "0.4.6+codex.813f150267e3",
   "description": "Agentic PR review: hybrid RAG + code graph via MCP, review skills for Codex",
   "repository": "https://github.com/mimfort/rag_for_git",
   "license": "MIT",

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "rag-reviewer",
-  "version": "0.4.5",
+  "version": "0.4.6",
   "description": "Agentic PR review: hybrid RAG + code graph via MCP, review skills for Claude Code"
 }

--- a/plugin/.codex-plugin/plugin.json
+++ b/plugin/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "rag-reviewer",
-  "version": "0.4.5+codex.1aba543ef50d",
+  "version": "0.4.6+codex.813f150267e3",
   "description": "Agentic PR review: hybrid RAG + code graph via MCP, review skills for Codex",
   "repository": "https://github.com/mimfort/rag_for_git",
   "license": "MIT",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "rag-reviewer"
-version = "0.4.5"
+version = "0.4.6"
 description = "AI pull-request reviewer: hybrid RAG + a code graph + Claude Code. Whole-repo context, inline GitHub comments grounded on exact code."
 readme = "README.md"
 license = { text = "MIT" }


### PR DESCRIPTION
Подготовка релиза 0.4.6.

Содержимое версии — два фикса из приёмки 0.4.5 (PRI-236), уже смерженных в `dev` (#171):

- **`prepare_review` не работал вообще** — `TypeError: 'Vector' object is not iterable`. `find_embeddings_by_hashes` приводила вектор из БД через `list(v)`, а `register_vector` с pgvector-python 0.4+ отдаёт `pgvector.vector.Vector` без `__iter__` вместо numpy-массива. Зависимость закреплена только снизу, апгрейд до 0.5.0 сломал рантайм. Ломалось ровно ревью: индексация на почти неизменной ветке до запроса не доходит, а overlay PR попадал в cross-branch reuse всегда.
- **`reviewer --version`** — опции не было вовсе; версию можно было узнать лишь косвенно через `uv tool list`.
- **Help-строка `--path` у `config show`** обещала «путь из индекса», хотя `_resolve_clone_path` в `repo_clone` намеренно не ходит.

Манифесты пересобраны `scripts/update_codex_plugin_manifest.py`: бамп версии меняет codex payload-digest, без пересборки install-тесты краснеют.

`.venv/bin/pytest -q` — 3717 passed, 122 deselected.