### PR TITLE
chore(release): версия 0.4.7

### DIFF
--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "rag-reviewer",
-  "version": "0.4.6+codex.813f150267e3",
+  "version": "0.4.7+codex.24f5ca1e34a0",
   "description": "Agentic PR review: hybrid RAG + code graph via MCP, review skills for Codex",
   "repository": "https://github.com/mimfort/rag_for_git",
   "license": "MIT",

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "rag-reviewer",
-  "version": "0.4.6",
+  "version": "0.4.7",
   "description": "Agentic PR review: hybrid RAG + code graph via MCP, review skills for Claude Code"
 }

--- a/plugin/.codex-plugin/plugin.json
+++ b/plugin/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "rag-reviewer",
-  "version": "0.4.6+codex.813f150267e3",
+  "version": "0.4.7+codex.24f5ca1e34a0",
   "description": "Agentic PR review: hybrid RAG + code graph via MCP, review skills for Codex",
   "repository": "https://github.com/mimfort/rag_for_git",
   "license": "MIT",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "rag-reviewer"
-version = "0.4.6"
+version = "0.4.7"
 description = "AI pull-request reviewer: hybrid RAG + a code graph + Claude Code. Whole-repo context, inline GitHub comments grounded on exact code."
 readme = "README.md"
 license = { text = "MIT" }

--- a/uv.lock
+++ b/uv.lock
@@ -1647,7 +1647,7 @@ wheels = [
 
 [[package]]
 name = "rag-reviewer"
-version = "0.4.6"
+version = "0.4.7"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
Подготовка релиза 0.4.7.

Содержимое версии — #174: `reviewer check` проверяет, что вектор из pgvector читается в `list[float]`. Приёмка 0.4.5 (PRI-236) показала, что `check` был зелёным ровно тогда, когда `prepare_review` падал на каждом PR: проверялось подключение к Postgres, но не совместимость типа вектора.

`uv.lock` пересобран вместе с версией — в бампе 0.4.6 он остался на 0.4.5, из-за чего джоба `test` падала на `uv lock --check` ещё до запуска pytest. Манифесты codex пересобраны как обычно.

`.venv/bin/pytest -q` — 3720 passed, 122 deselected.