### PR TITLE
release: 0.4.7

### DIFF
--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "rag-reviewer",
-  "version": "0.4.6+codex.813f150267e3",
+  "version": "0.4.7+codex.24f5ca1e34a0",
   "description": "Agentic PR review: hybrid RAG + code graph via MCP, review skills for Codex",
   "repository": "https://github.com/mimfort/rag_for_git",
   "license": "MIT",

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "rag-reviewer",
-  "version": "0.4.6",
+  "version": "0.4.7",
   "description": "Agentic PR review: hybrid RAG + code graph via MCP, review skills for Claude Code"
 }

--- a/plugin/.codex-plugin/plugin.json
+++ b/plugin/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "rag-reviewer",
-  "version": "0.4.6+codex.813f150267e3",
+  "version": "0.4.7+codex.24f5ca1e34a0",
   "description": "Agentic PR review: hybrid RAG + code graph via MCP, review skills for Codex",
   "repository": "https://github.com/mimfort/rag_for_git",
   "license": "MIT",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "rag-reviewer"
-version = "0.4.6"
+version = "0.4.7"
 description = "AI pull-request reviewer: hybrid RAG + a code graph + Claude Code. Whole-repo context, inline GitHub comments grounded on exact code."
 readme = "README.md"
 license = { text = "MIT" }

--- a/reviewer/entrypoints/cli.py
+++ b/reviewer/entrypoints/cli.py
@@ -777,6 +777,18 @@ def check(board_project_values: tuple[str, ...]) -> None:
         with store._connect() as conn:
             conn.execute("SELECT 1 FROM chunks LIMIT 1")
         click.echo(f"✓ Postgres ({s.pg_dsn}): подключение и таблица chunks — OK")
+        try:
+            store.check_vector_roundtrip()
+            click.echo("✓ pgvector: вектор читается из БД в list[float] — OK")
+        except Exception as e:
+            # Отдельная ветка, а не общий except Postgres: подключение здесь
+            # исправно, сломана совместимость типа вектора — это бьёт только по
+            # ревью PR, и подсказка должна вести к версии pgvector (PRI-236).
+            click.echo(
+                f"✗ pgvector: вектор из БД не читается в list[float] ({e}) — "
+                "ревью PR работать не будет; проверьте версию пакета pgvector"
+            )
+            failed = True
     except Exception as e:
         err = str(e)
         if "chunks" in err or "does not exist" in err:

--- a/reviewer/index/store.py
+++ b/reviewer/index/store.py
@@ -124,8 +124,10 @@ class ChunkStore:
             ).fetchall()
         return {r[0] for r in rows}
 
-    # Проба для check_vector_roundtrip: знаки и дробная часть подобраны так,
-    # чтобы искажение типа или потеря точности не совпали с ней случайно.
+    # Проба для check_vector_roundtrip: значения обязаны быть точно представимы
+    # в float32 (pgvector хранит vector как float4) — сравнение ниже строгое.
+    # Знаки и дробная часть при этом подобраны так, чтобы искажение типа не
+    # совпало с пробой случайно.
     _PROBE_VECTOR = [0.25, -0.5, 1.0]
 
     def check_vector_roundtrip(self) -> None:

--- a/reviewer/index/store.py
+++ b/reviewer/index/store.py
@@ -124,6 +124,26 @@ class ChunkStore:
             ).fetchall()
         return {r[0] for r in rows}
 
+    # Проба для check_vector_roundtrip: знаки и дробная часть подобраны так,
+    # чтобы искажение типа или потеря точности не совпали с ней случайно.
+    _PROBE_VECTOR = [0.25, -0.5, 1.0]
+
+    def check_vector_roundtrip(self) -> None:
+        """Убедиться, что вектор доезжает из БД обратно в list[float].
+
+        Проверка не полагается на наличие строк в chunks: тип вектора задаёт
+        связка драйвера и pgvector-python, а не данные. Приёмка 0.4.5 (PRI-236)
+        показала, зачем это в `check`: подключение к Postgres было исправным
+        ровно тогда, когда `prepare_review` падал на каждом PR.
+        """
+        with self._connect() as conn:
+            row = conn.execute(
+                "SELECT %s::vector", (Vector(self._PROBE_VECTOR),)
+            ).fetchone()
+        got = self._vector_to_list(row[0])
+        if got != self._PROBE_VECTOR:
+            raise RuntimeError(f"вектор вернулся искажённым: {got!r}")
+
     @staticmethod
     def _vector_to_list(value) -> list[float]:
         """Привести вектор из БД к list[float] независимо от версии pgvector.

--- a/tests/entrypoints/test_cli.py
+++ b/tests/entrypoints/test_cli.py
@@ -512,3 +512,55 @@ def test_config_show_help_does_not_promise_clone_path_from_index(runner):
 
     assert result.exit_code == 0
     assert "из индекса" not in result.output
+
+
+@patch("reviewer.entrypoints.cli._shutil")
+@patch("reviewer.entrypoints.cli.httpx.get")
+@patch("reviewer.entrypoints.cli.GraphStore")
+@patch("reviewer.entrypoints.cli.ChunkStore")
+@patch("reviewer.entrypoints.cli.Settings")
+def test_check_fails_when_vector_roundtrip_broken(
+    mock_settings_cls,
+    mock_chunk_cls,
+    mock_graph_cls,
+    mock_httpx,
+    mock_shutil,
+    runner,
+):
+    """Несовместимость типа pgvector краснит check, а не всплывает в ревью.
+
+    Приёмка 0.4.5 (PRI-236) поймала обратный случай: check был зелёным ровно
+    тогда, когда prepare_review падал на каждом PR — подключение к Postgres
+    проверялось, а совместимость типа вектора нет.
+    """
+    s = MagicMock()
+    s.voyage_api_key = "key"
+    s.github_token = "key"
+    s.gitlab_token = ""
+    s.pg_dsn = "pg://test"
+    s.pg_pool_min_size = 1
+    s.pg_pool_max_size = 4
+    s.neo4j_uri = "neo4j://test"
+    s.neo4j_user = "u"
+    s.neo4j_password = "p"
+    mock_settings_cls.return_value = s
+
+    store = MagicMock()
+    store._connect.return_value.__enter__.return_value.execute.return_value = None
+    store.check_vector_roundtrip.side_effect = TypeError(
+        "'Vector' object is not iterable"
+    )
+    mock_chunk_cls.return_value = store
+
+    mock_graph_cls.return_value = MagicMock()
+    resp = MagicMock()
+    resp.status_code = 200
+    resp.json.return_value = {"login": "testuser"}
+    mock_httpx.return_value = resp
+    mock_shutil.which.return_value = "/usr/bin/scip-python"
+
+    result = runner.invoke(cli, ["check"])
+
+    assert result.exit_code == 1
+    assert "pgvector" in result.output
+    store.close.assert_called_once()

--- a/tests/index/test_store_embedding_reuse.py
+++ b/tests/index/test_store_embedding_reuse.py
@@ -70,3 +70,36 @@ def test_find_embeddings_short_circuits_without_hashes():
     store._connect = MagicMock(side_effect=AssertionError("не должно быть запроса"))
 
     assert store.find_embeddings_by_hashes("owner/name", []) == {}
+
+
+def test_vector_roundtrip_accepts_faithful_driver():
+    """Драйвер, вернувший вектор без искажений, проверку проходит."""
+    store = ChunkStore("postgresql://unused/unused")
+    conn = MagicMock()
+    conn.execute.return_value.fetchone.return_value = (
+        Vector(ChunkStore._PROBE_VECTOR),
+    )
+
+    @contextmanager
+    def _connect():
+        yield conn
+
+    store._connect = _connect  # type: ignore[method-assign]
+
+    store.check_vector_roundtrip()  # не поднимает
+
+
+def test_vector_roundtrip_rejects_distorted_value():
+    """Искажённый вектор — отказ, а не молчаливое согласие."""
+    store = ChunkStore("postgresql://unused/unused")
+    conn = MagicMock()
+    conn.execute.return_value.fetchone.return_value = ([0.0, 0.0, 0.0],)
+
+    @contextmanager
+    def _connect():
+        yield conn
+
+    store._connect = _connect  # type: ignore[method-assign]
+
+    with pytest.raises(RuntimeError, match="искажённ"):
+        store.check_vector_roundtrip()

--- a/uv.lock
+++ b/uv.lock
@@ -1647,7 +1647,7 @@ wheels = [
 
 [[package]]
 name = "rag-reviewer"
-version = "0.4.5"
+version = "0.4.6"
 source = { editable = "." }
 dependencies = [
     { name = "click" },

--- a/uv.lock
+++ b/uv.lock
@@ -1647,7 +1647,7 @@ wheels = [
 
 [[package]]
 name = "rag-reviewer"
-version = "0.4.6"
+version = "0.4.7"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
Задача: [PRI-236](https://ru.yougile.com/team/686c049c8af8/#PRI-236)
<!-- reviewer:task-link -->

Релиз 0.4.7 — закрывает дыру в диагностике, найденную приёмкой 0.4.5 (PRI-236).

## Что вошло

`reviewer check` теперь проверяет, что вектор из pgvector читается в `list[float]` (#174). Приёмка показала, что `check` был зелёным ровно в тот момент, когда `prepare_review` падал на каждом PR: проверялись подключение к Postgres и наличие таблицы `chunks`, но не совместимость типа вектора — а её задаёт связка драйвера и версии `pgvector-python`, а не данные. Именно поэтому дефект 0.4.6 дожил до живого деплоя, не замеченный ни unit-тестами, ни `check`, ни `reviewer index`.

`ChunkStore.check_vector_roundtrip()` прогоняет пробный вектор через `SELECT %s::vector` и сверяет прочитанное с отправленным. Проба не зависит от наличия строк в `chunks` — на чистом деплое проверка работает так же. В `check` это отдельная ветка вывода: подключение в этот момент исправно, и подсказка ведёт к версии пакета `pgvector`, а не к «выполните reviewer index».

`uv.lock` пересобран вместе с версией — в бампе 0.4.6 он остался на 0.4.5, из-за чего джоба `test` падала на `uv lock --check` ещё до запуска pytest.

## Приёмка

Полный цикл ревью PR прогнан на 0.4.6 через этот же пайплайн (PR #174, run_id 77): inline-замечание и сводка опубликованы, overlay `pr:174` удалён. Замечание собственного ревью — про критерий выбора пробного вектора — принято и исправлено в этом же PR.

`.venv/bin/pytest -q` — 3720 passed, 122 deselected.