### PR TITLE
fix(skills): summarize-subsystems — убрать эхо fingerprint из промпта file-job'а (PRI-237)

### DIFF
--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "rag-reviewer",
-  "version": "0.4.7+codex.7f05ce6ac996",
+  "version": "0.4.7+codex.5216034553cb",
   "description": "Agentic PR review: hybrid RAG + code graph via MCP, review skills for Codex",
   "repository": "https://github.com/mimfort/rag_for_git",
   "license": "MIT",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "rag-reviewer",
-  "version": "0.4.7+codex.24f5ca1e34a0",
+  "version": "0.4.7+codex.7f05ce6ac996",
   "description": "Agentic PR review: hybrid RAG + code graph via MCP, review skills for Codex",
   "repository": "https://github.com/mimfort/rag_for_git",
   "license": "MIT",

--- a/docs/superpowers/briefs/2026-08-11-PRI-237-drop-fingerprint-echo-from-file-job.md
+++ b/docs/superpowers/briefs/2026-08-11-PRI-237-drop-fingerprint-echo-from-file-job.md
@@ -1,0 +1,52 @@
+# Brief — PRI-237 summarize-subsystems: убрать эхо fingerprint из промпта file-job'а
+https://ru.yougile.com/team/686c049c8af8/#PRI-237
+
+## Task
+- Скилл `summarize-subsystems` (шаг 5.2) требует передавать fingerprint файла в промпт субагента и получать его обратно в `{path, fingerprint, summary, provenance}`.
+- Субагент не может вычислить это значение (skeleton-fingerprint считает сервер и отдаёт в `get_subsystem_summary_work`) → для LLM это генерация 64 hex-символов, а не копирование. Прогон 11.08.2026 (Haiku, dev, depth=2, 9 кластеров, 82 файла): ≥8 неверных fingerprint, один — неверной длины.
+- Авторитетные пары `path → fingerprint` уже у оркестратора (ответ `get_subsystem_summary_work`); значение делает петлю в ненадёжное место и возвращается хуже. Job'у оно не нужно.
+- Риск: выдуманный fingerprint уходит в `index_subsystem_summary` → в лучшем случае бандл отвергается и проход теряется, в худшем — фиксируется неверная свежесть и сводка файла перестаёт обновляться.
+- Критерии: (1) шаг 5.2 не упоминает fingerprint ни во входе, ни в результате file-job'а; (2) SKILL.md явно предписывает оркестратору брать fingerprint только из `get_subsystem_summary_work`; (3) guard-тест краснеет при возврате старой формулировки; (4) `update_codex_plugin_manifest.py --check` → exit 0 и `pytest -q` зелёный; (5) серверный контракт `index_subsystem_summary` не меняется — правка чисто промптовая, без миграций.
+
+## Related work
+- ID-287 — «перевести summarize-subsystems на сжатое перечисление, проверить цикл на крупном репо»: предыдущая правка того же SKILL.md + его guard-тестов, задаёт образец, как менять скилл вместе с контрактными тестами.
+- ID-280 — «сделать subsystem summaries инкрементальными на уровне файлов»: ввела сам протокол fragments/fingerprint, который сейчас правится (источник формулировки шага 5.2).
+- ID-165 — «freshness по структуре, а не по содержимому»: определила skeleton-fingerprint как серверную величину — прямое обоснование, почему job не может её вычислить.
+(dropped 5: ID-291 — сама задача; ID-166/173/283/167 — про depth, поле `stale`, пагинацию listing и векторизацию сводок: соседняя область, другой механизм, промпта file-job'а не касаются.)
+
+## Subsystems
+- `reviewer/index` — `chunker.symbol_skeleton_hash` (скелет-хэш = «сигнатура + docstring») и `summary_store` (идемпотентный upsert, атомарный `commit_summary_bundle`): подтверждает, что fingerprint вычисляется и валидируется серверно.
+- `plugin/hooks` — хуки brief (fail-open, изоляция ошибок): соседняя plugin-подсистема, правкой не затрагивается.
+- `reviewer/entrypoints` — `mcp_server.py` регистрирует `list_subsystem_clusters` / `index_subsystem_summary`; контракт этих тулов по задаче остаётся неизменным.
+(остальные вернувшиеся сводки — про ревью PR/поиск, к задаче не относятся)
+
+## Relevant code
+- `plugin/skills/summarize-subsystems/SKILL.md:86-87` — «Each file prompt must name only its own path (plus that entry's fingerprint) … require one Russian result: `{path, fingerprint, summary, provenance}`» — правится: убрать скобку и `fingerprint` из требуемого результата, добавить явный запрет job'у выдумывать/возвращать fingerprint.
+- `plugin/skills/summarize-subsystems/SKILL.md:88-96` (шаг 5.3, «ordered reused/moved/new fragment texts») — место, где оркестратор мержит `reused_fragments` + `moved_files` + новые результаты; здесь закрепить подстановку authoritative `path → fingerprint` из ответа `get_subsystem_summary_work`.
+- `plugin/skills/summarize-subsystems/SKILL.md:97-103` (шаг 5.4, `index_subsystem_summary(..., fragments=[new file results])`) — потребитель fingerprint'ов; формулировка о персисте должна остаться совместимой с существующим guard-тестом (точное совпадение строки вызова).
+- `plugin/skills/summarize-subsystems/SKILL.md:45` и `:144` — прочие упоминания fingerprint (сжатый listing без fingerprint'ов; «fingerprint granularity» в описании инвариантов): менять не требуется, но проверить, что новый guard-грep не ловит их ложно.
+- `tests/skills/test_summarize_subsystems.py:108-126` — `test_skill_uses_incremental_file_summary_protocol` и `test_skill_composes_only_from_ordered_fragment_texts` (последний уже ассертит `"file prompt must name only its own path"`): ближайшее место для нового guard-теста; грепов по `fingerprint` в файле сейчас нет — контракт не закреплён.
+- `scripts/update_codex_plugin_manifest.py` — обязательный прогон после правки контента под `plugin/` (payload-digest), затем `--check` (exit 0).
+- Греп `fingerprint|source_hash|layout_token` по `plugin/skills/**/*.md` вне summarize-subsystems: единственный хит — `sync-tasks/SKILL.md:42` (`filter_fingerprint` в списке полей отчёта, не эхо через субагента). Прямых аналогов анти-паттерна в `review-pr`/`pr-walkthrough` по этим ключам нет.
+(dropped 0)
+
+## Test exemplars
+- `tests/skills/test_summarize_subsystems.py:108` `test_skill_uses_incremental_file_summary_protocol` — паттерн guard-теста: `_assembled_skill()` (сборка SKILL.md с развёрнутыми `_common`-инклюдами) + набор `assert "<точная фраза>" in text`.
+- `tests/skills/test_summarize_subsystems.py:119` `test_skill_composes_only_from_ordered_fragment_texts` — уже ассертит фразу, которую задача правит («file prompt must name only its own path»); при переформулировке шага 5.2 фразу надо либо сохранить дословно, либо обновить тест синхронно.
+- `tests/skills/test_summarize_subsystems.py:127` `test_skill_persists_new_fragments_and_defers_races` — пример ассерта по нормализованному тексту (`" ".join(text.split())`) для многострочной сигнатуры вызова.
+(dropped 0)
+
+## Constraints / open questions
+- Правка **только промптовая**: серверный контракт `index_subsystem_summary`/`get_subsystem_summary_work` не меняется, миграций и изменений схемы нет.
+- Открытый вопрос (шаг 4 задачи): полная проверка остальных скиллов на анти-паттерн «эхо server-side идентификатора через субагента» — греп по `fingerprint|source_hash|layout_token` чист, но другие идентификаторы (например, id/хэши в `review-pr`) не проверялись; решить в брейншторме — чинить здесь или выносить отдельной задачей.
+- Открытый вопрос: нужен ли негативный guard (грeп, что в шаге 5.2 fingerprint отсутствует) в дополнение к позитивному, и как не поймать легитимные упоминания на строках 45/144.
+- Не забыть: `python scripts/update_codex_plugin_manifest.py` + `--check`, иначе install-тесты краснеют.
+- Индекс свеж (drift 0 на `dev`, 6474 чанка, 40 сводок); корпус задач прогрет (`sync_board`: 94 задачи, 1 обновлена).
+- Родственная ловушка того же класса (из контекста задачи): дешёвые модели не вызывают deferred MCP-тул `index_subsystem_summary`, а печатают вызов текстом — персист обязан делать оркестратор; скилл это уже требует, отдельной правки не нужно.
+
+Собран на: session-модель (Opus 5), режим: inline
+
+## Токены (этап solve-task)
+Модель: claude-opus-5
+fresh-in 35 · out 9.5K · cache-write 165.9K · cache-read 1.2M
+Всего: 1.4M токенов

--- a/docs/superpowers/plans/2026-08-11-pri-237-drop-fingerprint-echo.md
+++ b/docs/superpowers/plans/2026-08-11-pri-237-drop-fingerprint-echo.md
@@ -1,0 +1,228 @@
+# PRI-237 — убрать эхо fingerprint из промпта file-job'а: Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Убрать fingerprint из входа и результата file-job'а в скилле `summarize-subsystems` и закрепить guard-тестами, что авторитетные значения подставляет оркестратор из ответа `get_subsystem_summary_work`.
+
+**Architecture:** Правка чисто промптовая: два абзаца в `plugin/skills/summarize-subsystems/SKILL.md` (шаги 5.2 и 5.3) плюс три guard-теста поверх существующего хелпера `_assembled_skill()`. Серверный контракт `index_subsystem_summary` (fragments с полем `fingerprint`, строгая optimistic-проверка) не меняется — меняется только источник значения при сборке fragments.
+
+**Tech Stack:** Markdown (промпты скилла), pytest (guard-тесты по тексту скилла), `scripts/update_codex_plugin_manifest.py` (пересборка codex payload-digest).
+
+Спека: `docs/superpowers/specs/2026-08-11-pri-237-drop-fingerprint-echo-from-file-job-design.md`
+Бриф: `docs/superpowers/briefs/2026-08-11-PRI-237-drop-fingerprint-echo-from-file-job.md`
+
+## Global Constraints
+
+- Ветка работы: `feat/pri-237-drop-fingerprint-echo` (уже создана, спека и бриф в ней закоммичены).
+- Правка **только промптовая**: питоновский код `reviewer/` не трогать, миграций и изменений схемы нет.
+- Серверный контракт `index_subsystem_summary(repo, branch, cluster_key, title, summary, source_hash, fragments=[…])` не меняется; шаг 5.4 SKILL.md остаётся дословно прежним (его строка вызова закреплена существующим тестом `test_skill_persists_new_fragments_and_defers_races`).
+- Фраза `file prompt must name only its own path` должна сохраниться в шаге 5.2 дословно — её ассертит существующий `test_skill_composes_only_from_ordered_fragment_texts`.
+- Легитимные упоминания fingerprint в SKILL.md на строках 45 (`no fingerprints` про сжатый listing) и 144 (`fingerprint granularity`) не трогать.
+- Язык проекта — русский: комментарии и докстринги тестов по-русски, тело SKILL.md остаётся английским (так устроены все скиллы плагина).
+- Коммиты: Conventional Commits на русском, **без self-attribution** (никаких `Co-Authored-By`, упоминаний Claude).
+- Тесты гонять через `.venv/bin/pytest` (unit, без Postgres/Neo4j/сети).
+
+---
+
+### Task 1: Guard-тесты и правка промптов шагов 5.2/5.3
+
+**Files:**
+- Modify: `tests/skills/test_summarize_subsystems.py` (добавить хелпер и три теста в конец файла)
+- Modify: `plugin/skills/summarize-subsystems/SKILL.md:84-96` (шаги 5.2 и 5.3)
+
+**Interfaces:**
+- Consumes: существующий хелпер `_assembled_skill() -> str` из `tests/skills/test_summarize_subsystems.py:9` (читает SKILL.md и разворачивает `<!-- include: _common/*.md -->` inline).
+- Produces: новый хелпер `_file_job_step() -> str` — срез текста шага 5.2; используется только внутри этого файла тестов.
+
+- [ ] **Step 1: Написать падающие guard-тесты**
+
+Добавить в КОНЕЦ файла `tests/skills/test_summarize_subsystems.py`:
+
+```python
+_STEP_52_START = "Let pending work be exactly"
+_STEP_53_START = "Build the **ordered reused/moved/new fragment texts**"
+
+
+def _file_job_step() -> str:
+    """Срез шага 5.2 (диспатч file-job'ов) — без соседних пунктов 5.1 и 5.3."""
+    text = _assembled_skill()
+    start = text.index(_STEP_52_START)
+    end = text.index(_STEP_53_START, start)
+    return " ".join(text[start:end].split())
+
+
+def test_skill_file_job_does_not_echo_fingerprint():
+    """PRI-237: job не получает и не возвращает fingerprint — это серверное значение."""
+    step = _file_job_step()
+    assert "`{path, summary, provenance}`" in step, (
+        "шаг 5.2 не требует от job'а результат {path, summary, provenance}"
+    )
+    assert "never compute, guess, or return a `fingerprint`" in step, (
+        "шаг 5.2 не запрещает job'у выдумывать fingerprint"
+    )
+    assert "plus that entry's fingerprint" not in step, (
+        "шаг 5.2 снова передаёт fingerprint во вход job'а"
+    )
+    assert "{path, fingerprint" not in step, (
+        "шаг 5.2 снова требует fingerprint в результате job'а"
+    )
+
+
+def test_skill_orchestrator_supplies_fingerprints():
+    """PRI-237: fingerprint берётся только из ответа get_subsystem_summary_work."""
+    normalized = " ".join(_assembled_skill().split())
+    assert (
+        "The orchestrator attaches each new fragment's `fingerprint` by joining on `path`"
+        in normalized
+    ), "шаг 5.3 не предписывает оркестратору подстановку fingerprint по path"
+    assert (
+        "authoritative `added_files` / `changed_files` entries of the "
+        "`get_subsystem_summary_work` response"
+        in normalized
+    ), "шаг 5.3 не называет авторитетный источник fingerprint"
+    assert "never from a job's answer" in normalized, (
+        "шаг 5.3 не запрещает брать fingerprint из ответа субагента"
+    )
+
+
+def test_skill_rejects_file_job_path_mismatch():
+    """PRI-237: path — единственное поле job'а, участвующее в join; рассинхрон не персистится."""
+    step = _file_job_step()
+    assert "returns a `path` outside the pending list" in step, (
+        "шаг 5.2 не описывает рассинхрон path"
+    )
+    assert "discard that result and re-dispatch the job" in step, (
+        "шаг 5.2 не предписывает отбросить результат и перевызвать job"
+    )
+    assert "on a second mismatch count the cluster as deferred" in step, (
+        "шаг 5.2 не переводит кластер в deferred при повторном рассинхроне"
+    )
+```
+
+- [ ] **Step 2: Прогнать тесты — убедиться, что они падают**
+
+Run: `.venv/bin/pytest tests/skills/test_summarize_subsystems.py -q -k "fingerprint or path_mismatch"`
+Expected: FAIL — `test_skill_file_job_does_not_echo_fingerprint` (нет `{path, summary, provenance}`), `test_skill_orchestrator_supplies_fingerprints` (нет фразы про join), `test_skill_rejects_file_job_path_mismatch` (нет описания рассинхрона).
+
+- [ ] **Step 3: Правка шага 5.2 в SKILL.md**
+
+В `plugin/skills/summarize-subsystems/SKILL.md` заменить блок (строки 84-89):
+
+```
+   2. Let pending work be exactly `added_files + changed_files`. Dispatch exactly one file-summary job
+      on the chosen model for each pending entry, and no other source-reading jobs. Each file prompt must name only its own path
+      (plus that entry's fingerprint), tell the job to `Read` exactly that path, and require one Russian result:
+      `{path, fingerprint, summary, provenance}`. The orchestrator and every job must not read unchanged
+      source files. If per-subagent model override is unavailable, generate the same
+      per-file result inline and note that fallback in the report.
+```
+
+на:
+
+```
+   2. Let pending work be exactly `added_files + changed_files`. Dispatch exactly one file-summary job
+      on the chosen model for each pending entry, and no other source-reading jobs. Each file prompt must name only its own path,
+      tell the job to `Read` exactly that path, and require one Russian result:
+      `{path, summary, provenance}`. A job must never compute, guess, or return a `fingerprint`: that
+      value is server-side and the orchestrator supplies it. If a job returns a `path` outside the
+      pending list, discard that result and re-dispatch the job for that pending entry once; on a
+      second mismatch count the cluster as deferred and persist nothing for it. The orchestrator and
+      every job must not read unchanged source files. If per-subagent model override is unavailable,
+      generate the same per-file result inline and note that fallback in the report.
+```
+
+- [ ] **Step 4: Правка шага 5.3 в SKILL.md**
+
+В том же файле заменить первое предложение пункта 3 (строки 90-91):
+
+```
+   3. Build the **ordered reused/moved/new fragment texts** by merging `reused_fragments`,
+      `moved_files`, and the new file results, then sorting by `path`. Dispatch exactly one cluster
+```
+
+на:
+
+```
+   3. Build the **ordered reused/moved/new fragment texts** by merging `reused_fragments`,
+      `moved_files`, and the new file results, then sorting by `path`. The orchestrator attaches each
+      new fragment's `fingerprint` by joining on `path` with the authoritative `added_files` /
+      `changed_files` entries of the `get_subsystem_summary_work` response — never from a job's
+      answer. Dispatch exactly one cluster
+```
+
+Остаток пункта 3 (начиная с `composer on the chosen model with only those ordered fragment records;`) не менять.
+
+- [ ] **Step 5: Прогнать весь файл тестов скилла**
+
+Run: `.venv/bin/pytest tests/skills/test_summarize_subsystems.py -q`
+Expected: PASS — и три новых теста, и все существующие (в частности `test_skill_composes_only_from_ordered_fragment_texts`, ассертящий `file prompt must name only its own path`, и `test_skill_persists_new_fragments_and_defers_races`).
+
+Если `test_skill_composes_only_from_ordered_fragment_texts` покраснел — значит фраза `file prompt must name only its own path` при правке шага 5.2 была изменена; восстановить её дословно, тест не трогать.
+
+- [ ] **Step 6: Коммит**
+
+```bash
+git add tests/skills/test_summarize_subsystems.py plugin/skills/summarize-subsystems/SKILL.md
+git commit -m "fix(skills): summarize-subsystems — fingerprint подставляет оркестратор, а не file-job"
+```
+
+---
+
+### Task 2: Пересборка манифестов плагина и полный прогон
+
+**Files:**
+- Modify: артефакты, которые перезапишет `scripts/update_codex_plugin_manifest.py` (манифесты codex-плагина; конкретные пути определяет сам скрипт)
+
+**Interfaces:**
+- Consumes: изменённый `plugin/skills/summarize-subsystems/SKILL.md` из Task 1 — его контент входит в codex payload-digest.
+- Produces: обновлённые манифесты, на которых `--check` возвращает exit 0 (это же гоняет CI: `.github/workflows/tests.yml:30` и `.github/workflows/codex-plugin.yml:32`).
+
+- [ ] **Step 1: Убедиться, что проверка манифестов краснеет до пересборки**
+
+Run: `python scripts/update_codex_plugin_manifest.py --check; echo "exit=$?"`
+Expected: ненулевой exit — digest не совпадает, потому что контент под `plugin/` изменён в Task 1.
+
+Если exit уже 0 — пересборка не нужна (контент digest не затронул); зафиксировать это в отчёте и перейти к Step 3.
+
+- [ ] **Step 2: Пересобрать манифесты**
+
+Run: `python scripts/update_codex_plugin_manifest.py`
+Expected: скрипт отработал без ошибок и перезаписал манифесты.
+
+- [ ] **Step 3: Проверить, что digest сошёлся**
+
+Run: `python scripts/update_codex_plugin_manifest.py --check; echo "exit=$?"`
+Expected: `exit=0`.
+
+- [ ] **Step 4: Полный unit-прогон**
+
+Run: `.venv/bin/pytest -q`
+Expected: PASS (integration-тесты исключены по умолчанию через `addopts = -m 'not integration'`).
+
+- [ ] **Step 5: Линт изменённых python-файлов**
+
+Run: `.venv/bin/ruff check tests/skills/test_summarize_subsystems.py`
+Expected: `All checks passed!`
+
+Замечание: repo-wide `ruff` на этом репозитории не чист — проверять только изменённый файл.
+
+- [ ] **Step 6: Коммит**
+
+```bash
+git add -A
+git commit -m "chore(plugin): пересобрать манифесты codex после правки summarize-subsystems"
+```
+
+Если Step 1 показал exit=0 и `git status` пуст — коммит пропустить и отметить это в отчёте.
+
+---
+
+## Проверка критериев приёмки
+
+После Task 2 сверить со спекой:
+
+1. `grep -n fingerprint plugin/skills/summarize-subsystems/SKILL.md` → упоминания остались только на строках сжатого listing (`no fingerprints`), в новых фразах шага 5.2 (запрет) и 5.3 (подстановка оркестратором) и в описании гранулярности инвариантов.
+2. Шаг 5.3 называет `get_subsystem_summary_work` единственным источником fingerprint.
+3. `.venv/bin/pytest tests/skills/ -q` зелёный; откат любой из правок Task 1 краснит новые тесты.
+4. `python scripts/update_codex_plugin_manifest.py --check` → exit 0; `.venv/bin/pytest -q` зелёный.
+5. `git diff --stat dev...HEAD` не содержит файлов из `reviewer/` — серверный контракт не тронут.

--- a/docs/superpowers/specs/2026-08-11-pri-237-drop-fingerprint-echo-from-file-job-design.md
+++ b/docs/superpowers/specs/2026-08-11-pri-237-drop-fingerprint-echo-from-file-job-design.md
@@ -1,0 +1,102 @@
+# PRI-237 — summarize-subsystems: убрать эхо fingerprint из промпта file-job'а
+
+Источник: `docs/superpowers/briefs/2026-08-11-PRI-237-drop-fingerprint-echo-from-file-job.md`
+Задача: https://ru.yougile.com/team/686c049c8af8/#PRI-237
+
+## Проблема
+
+Шаг 5.2 скилла `summarize-subsystems` предписывает передавать file-job'у fingerprint файла и требовать
+его обратно в результате `{path, fingerprint, summary, provenance}`. Субагент не может вычислить это
+значение: skeleton-fingerprint считает сервер и отдаёт в ответе `get_subsystem_summary_work`. Для LLM
+дословный перенос 64 hex-символов — не копирование, а генерация: у случайной hex-строки нет семантики,
+модель уверенно порождает строку правильной формы вместо исходной. Прогон 11.08.2026 (Haiku, ветка dev,
+depth=2, 9 кластеров `reviewer/*`, 82 файла) дал ≥8 неверных fingerprint, один — неверной длины.
+
+Авторитетные пары `path → fingerprint` всё это время лежат у оркестратора — он сам вызывает
+`get_subsystem_summary_work`. Значение делает петлю из надёжного места в ненадёжное и возвращается хуже;
+job'у для его работы (написать сводку файла) оно не нужно вовсе.
+
+Риск: выдуманный fingerprint уходит в `index_subsystem_summary`. В лучшем случае строгая optimistic-проверка
+отвергает бандл и проход теряется; в худшем фиксируется неверная свежесть файла, и его сводка перестаёт
+обновляться при последующих правках.
+
+## Границы
+
+Правка **чисто промптовая**. Серверный контракт не меняется: `index_subsystem_summary` по-прежнему
+принимает `fragments: list[SummaryFragmentIn]` с полем `fingerprint` и выполняет строгую
+optimistic-проверку (`reviewer/entrypoints/mcp_server.py:374-380`), а `get_subsystem_summary_work`
+по-прежнему отдаёт авторитетные пары `{path, fingerprint}` (`reviewer/mcp/service.py:1733`). Меняется
+только то, **откуда** оркестратор берёт fingerprint при сборке fragments: из ответа сервера, а не из
+ответа субагента. Миграций и изменений схемы нет.
+
+## Дизайн
+
+### 1. `plugin/skills/summarize-subsystems/SKILL.md`, шаг 5.2
+
+- Убрать вставку `(plus that entry's fingerprint)`.
+- Требуемый от job'а результат: `{path, summary, provenance}`.
+- Добавить явный запрет: job никогда не вычисляет, не угадывает и не возвращает `fingerprint` —
+  значение серверное, его подставляет оркестратор.
+- Рассинхрон `path` (единственное поле, которое job теперь может исказить): результат с `path` вне
+  pending-списка отбрасывается, job перевызывается для этой pending-записи один раз; при повторном
+  несовпадении кластер считается `deferred` и для него ничего не персистится.
+- Фраза `file prompt must name only its own path` сохраняется дословно — её уже ассертит существующий
+  `test_skill_composes_only_from_ordered_fragment_texts`.
+
+### 2. Там же, шаг 5.3
+
+Добавить одно предложение: собирая новые file results, оркестратор проставляет каждому фрагменту
+`fingerprint` join'ом по `path` с авторитетными записями `added_files` / `changed_files` из ответа
+`get_subsystem_summary_work` — и никогда из ответа субагента.
+
+### 3. Шаг 5.4 — не меняется
+
+Строка вызова `index_subsystem_summary(repo, branch, cluster_key, title, summary, source_hash,
+fragments=[new file results])` дословно закреплена тестом `test_skill_persists_new_fragments_and_defers_races`;
+семантика персиста прежняя.
+
+### 4. `tests/skills/test_summarize_subsystems.py` — guard-тесты
+
+Хелпер вырезает срез шага 5.2 (от `Let pending work be exactly` до начала пункта 5.3) поверх
+существующего `_assembled_skill()`.
+
+- `test_skill_file_job_does_not_echo_fingerprint`:
+  - позитив — в срезе есть `{path, summary, provenance}` и фраза запрета job'у;
+  - негатив — в срезе нет старых конструкций `plus that entry's fingerprint` и `{path, fingerprint`.
+
+  Негатив точечный, по старым формулировкам, а не `"fingerprint" not in срез`: сама фраза запрета
+  содержит это слово. Легитимные упоминания fingerprint на строках 45 и 144 (сжатый listing без
+  fingerprint'ов; описание гранулярности инвариантов) при этом не затрагиваются.
+- `test_skill_orchestrator_supplies_fingerprints`: подстановка приписана оркестратору, источником
+  назван `get_subsystem_summary_work`.
+
+### 5. Ревизия прочих скиллов (шаг 4 задачи) — выполнена, кода не порождает
+
+- Греп `fingerprint|source_hash|layout_token` по `plugin/skills/**/*.md` вне summarize-subsystems даёт
+  единственный хит `sync-tasks/SKILL.md:42` (`filter_fingerprint` в списке полей отчёта) — не эхо через
+  субагента.
+- `pr-walkthrough` субагентов не диспатчит вовсе → анти-паттерна нет.
+- `review-pr`: единственное эхо server-side идентификатора — id находки в
+  `submit_verdicts(repo, pr, verdicts=[{id, is_real}])`. Риск качественно другой: id короткий и
+  семантичный (`f1`, `f2`, … — `reviewer/mcp/service.py:2411`), сервер игнорирует неизвестный id с
+  warning, а отсутствие вердикта трактуется как keep (`reviewer/mcp/service.py:2429-2446`), то есть
+  безопасный дефолт. Правки не требует; отдельная задача не заводится.
+
+### 6. Манифесты и прогон
+
+Правка контента под `plugin/` меняет codex payload-digest: `python scripts/update_codex_plugin_manifest.py`,
+затем `--check` (exit 0). Финально `.venv/bin/pytest -q`.
+
+## Критерии приёмки
+
+1. Шаг 5.2 SKILL.md не упоминает fingerprint ни во входе file-job'а, ни в требуемом от него результате.
+2. SKILL.md явно предписывает оркестратору брать fingerprint только из `get_subsystem_summary_work`.
+3. Новые guard-тесты краснеют при возврате старой формулировки; существующие тесты
+   `tests/skills/test_summarize_subsystems.py` остаются зелёными.
+4. `python scripts/update_codex_plugin_manifest.py --check` → exit 0; `.venv/bin/pytest -q` зелёный.
+5. Серверный контракт `index_subsystem_summary` не меняется — миграций и изменений схемы нет.
+
+## Тестирование
+
+Только unit: guard-тесты по тексту скилла (`tests/skills/`) + существующий набор. Инфраструктура
+(Postgres/Neo4j/Voyage) не нужна, integration-тесты не затрагиваются.

--- a/plugin/.codex-plugin/plugin.json
+++ b/plugin/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "rag-reviewer",
-  "version": "0.4.7+codex.7f05ce6ac996",
+  "version": "0.4.7+codex.5216034553cb",
   "description": "Agentic PR review: hybrid RAG + code graph via MCP, review skills for Codex",
   "repository": "https://github.com/mimfort/rag_for_git",
   "license": "MIT",

--- a/plugin/.codex-plugin/plugin.json
+++ b/plugin/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "rag-reviewer",
-  "version": "0.4.7+codex.24f5ca1e34a0",
+  "version": "0.4.7+codex.7f05ce6ac996",
   "description": "Agentic PR review: hybrid RAG + code graph via MCP, review skills for Codex",
   "repository": "https://github.com/mimfort/rag_for_git",
   "license": "MIT",

--- a/plugin/skills/summarize-subsystems/SKILL.md
+++ b/plugin/skills/summarize-subsystems/SKILL.md
@@ -87,7 +87,8 @@ Plus `list_subsystem_clusters`, `get_subsystem_summary_work`, `index_subsystem_s
       `{path, summary, provenance}`. A job must never compute, guess, or return a `fingerprint`: that
       value is server-side and the orchestrator supplies it. If a job returns a `path` outside the
       pending list, discard that result and re-dispatch the job for that pending entry once; on a
-      second mismatch count the cluster as deferred and persist nothing for it. The orchestrator and
+      second mismatch count the cluster as deferred, increment `raced`, and persist nothing for it.
+      The orchestrator and
       every job must not read unchanged source files. If per-subagent model override is unavailable,
       generate the same per-file result inline and note that fallback in the report.
    3. Build the **ordered reused/moved/new fragment texts** by merging `reused_fragments`,
@@ -102,7 +103,8 @@ Plus `list_subsystem_clusters`, `get_subsystem_summary_work`, `index_subsystem_s
       symbols, and invariants supported by the fragments.
    4. Persist the bundle:
       `index_subsystem_summary(repo, branch, cluster_key, title, summary, source_hash,
-      fragments=[new file results])`. Pass only the newly generated pending-file results in
+      fragments=[new file results])` (the fingerprint-enriched records from 5.3). Pass only the
+      newly generated pending-file results in
       `fragments`; reused and moved fragments are committed server-side. If the response has
       `stored=false`, count the cluster as deferred/raced, increment `raced`, and must not count it as success
       or add its metrics. For `stored=true`, add returned `created`, `reused`, `removed`,

--- a/plugin/skills/summarize-subsystems/SKILL.md
+++ b/plugin/skills/summarize-subsystems/SKILL.md
@@ -82,13 +82,19 @@ Plus `list_subsystem_clusters`, `get_subsystem_summary_work`, `index_subsystem_s
       cluster's listed `source_hash`. If `ready=false`, count the cluster as deferred/raced, increment
       `raced`, and continue without jobs or persistence.
    2. Let pending work be exactly `added_files + changed_files`. Dispatch exactly one file-summary job
-      on the chosen model for each pending entry, and no other source-reading jobs. Each file prompt must name only its own path
-      (plus that entry's fingerprint), tell the job to `Read` exactly that path, and require one Russian result:
-      `{path, fingerprint, summary, provenance}`. The orchestrator and every job must not read unchanged
-      source files. If per-subagent model override is unavailable, generate the same
-      per-file result inline and note that fallback in the report.
+      on the chosen model for each pending entry, and no other source-reading jobs. Each file prompt must name only its own path,
+      tell the job to `Read` exactly that path, and require one Russian result:
+      `{path, summary, provenance}`. A job must never compute, guess, or return a `fingerprint`: that
+      value is server-side and the orchestrator supplies it. If a job returns a `path` outside the
+      pending list, discard that result and re-dispatch the job for that pending entry once; on a
+      second mismatch count the cluster as deferred and persist nothing for it. The orchestrator and
+      every job must not read unchanged source files. If per-subagent model override is unavailable,
+      generate the same per-file result inline and note that fallback in the report.
    3. Build the **ordered reused/moved/new fragment texts** by merging `reused_fragments`,
-      `moved_files`, and the new file results, then sorting by `path`. Dispatch exactly one cluster
+      `moved_files`, and the new file results, then sorting by `path`. The orchestrator attaches each
+      new fragment's `fingerprint` by joining on `path` with the authoritative `added_files` /
+      `changed_files` entries of the `get_subsystem_summary_work` response — never from a job's
+      answer. Dispatch exactly one cluster
       composer on the chosen model with only those ordered fragment records; do not pass `files`,
       `top_symbols`, or source text. Its prompt must say: **composer must not call `Read`** and must
       not make **source-code claims absent from the fragments**. It returns `{title, summary}` in

--- a/tests/skills/test_summarize_subsystems.py
+++ b/tests/skills/test_summarize_subsystems.py
@@ -182,3 +182,63 @@ def test_skill_full_pass_requires_walking_every_page():
     )
     assert "pagination is not an override" in normalized.lower() or \
         "Pagination is not an override" in text
+
+
+_STEP_52_START = "Let pending work be exactly"
+_STEP_53_START = "Build the **ordered reused/moved/new fragment texts**"
+
+
+def _file_job_step() -> str:
+    """Срез шага 5.2 (диспатч file-job'ов) — без соседних пунктов 5.1 и 5.3."""
+    text = _assembled_skill()
+    start = text.index(_STEP_52_START)
+    end = text.index(_STEP_53_START, start)
+    return " ".join(text[start:end].split())
+
+
+def test_skill_file_job_does_not_echo_fingerprint():
+    """PRI-237: job не получает и не возвращает fingerprint — это серверное значение."""
+    step = _file_job_step()
+    assert "`{path, summary, provenance}`" in step, (
+        "шаг 5.2 не требует от job'а результат {path, summary, provenance}"
+    )
+    assert "never compute, guess, or return a `fingerprint`" in step, (
+        "шаг 5.2 не запрещает job'у выдумывать fingerprint"
+    )
+    assert "plus that entry's fingerprint" not in step, (
+        "шаг 5.2 снова передаёт fingerprint во вход job'а"
+    )
+    assert "{path, fingerprint" not in step, (
+        "шаг 5.2 снова требует fingerprint в результате job'а"
+    )
+
+
+def test_skill_orchestrator_supplies_fingerprints():
+    """PRI-237: fingerprint берётся только из ответа get_subsystem_summary_work."""
+    normalized = " ".join(_assembled_skill().split())
+    assert (
+        "The orchestrator attaches each new fragment's `fingerprint` by joining on `path`"
+        in normalized
+    ), "шаг 5.3 не предписывает оркестратору подстановку fingerprint по path"
+    assert (
+        "authoritative `added_files` / `changed_files` entries of the "
+        "`get_subsystem_summary_work` response"
+        in normalized
+    ), "шаг 5.3 не называет авторитетный источник fingerprint"
+    assert "never from a job's answer" in normalized, (
+        "шаг 5.3 не запрещает брать fingerprint из ответа субагента"
+    )
+
+
+def test_skill_rejects_file_job_path_mismatch():
+    """PRI-237: path — единственное поле job'а, участвующее в join; рассинхрон не персистится."""
+    step = _file_job_step()
+    assert "returns a `path` outside the pending list" in step, (
+        "шаг 5.2 не описывает рассинхрон path"
+    )
+    assert "discard that result and re-dispatch the job" in step, (
+        "шаг 5.2 не предписывает отбросить результат и перевызвать job"
+    )
+    assert "on a second mismatch count the cluster as deferred" in step, (
+        "шаг 5.2 не переводит кластер в deferred при повторном рассинхроне"
+    )


### PR DESCRIPTION
## Проблема

Шаг 5.2 скилла `summarize-subsystems` требовал передавать file-job'у skeleton-fingerprint файла и получать его обратно в результате. Субагент не может вычислить это значение — его считает сервер и отдаёт в `get_subsystem_summary_work`. Для LLM перенос 64 hex-символов не копирование, а генерация: на реальном прогоне 11.08.2026 (Haiku, dev, depth=2, 9 кластеров, 82 файла) ≥8 fingerprint пришли неверными, один — неверной длины.

Риск: выдуманный fingerprint уходит в `index_subsystem_summary` — в лучшем случае бандл отвергается и проход теряется, в худшем фиксируется неверная свежесть файла и его сводка перестаёт обновляться.

## Что сделано

Правка чисто промптовая, серверный контракт не меняется (`SummaryFragmentIn` по-прежнему требует `fingerprint`, миграций нет).

- **Шаг 5.2** — fingerprint убран из входа и из требуемого результата job'а (`{path, summary, provenance}`); добавлен явный запрет вычислять/угадывать/возвращать его. `path` — единственное поле, которое job теперь может исказить: результат с path вне pending-списка отбрасывается, job перевызывается один раз, при повторном рассинхроне кластер идёт в `deferred` + `raced` и ничего не персистится.
- **Шаг 5.3** — оркестратор подставляет `fingerprint` join'ом по `path` из авторитетных `added_files`/`changed_files` ответа `get_subsystem_summary_work`, никогда из ответа job'а. Шаг 5.4 уточнён, что персистятся именно обогащённые записи.
- **Guard-тесты** (`tests/skills/test_summarize_subsystems.py`) — срез шага 5.2 между якорными фразами: позитивные ассерты новых формулировок + негативные на старые. Проверено в worktree на `8992284`: при откате краснеют ровно эти три теста.
- Манифесты codex-плагина пересобраны (правка контента под `plugin/` меняет payload-digest).

## Ревизия прочих скиллов

`pr-walkthrough` субагентов не диспатчит. В `review-pr` единственное эхо server-side идентификатора — id находки в `submit_verdicts` (`f1`, `f2`…): короткий семантичный id, неизвестный игнорируется с warning, отсутствие вердикта = keep. Правки не требует.

## Проверки

- `.venv/bin/pytest -q` → 3723 passed, 122 deselected
- `scripts/update_codex_plugin_manifest.py --check` → exit 0
- `ruff` по изменённому тест-файлу → чисто
- В диффе нет ни одного файла из `reviewer/`

Приёмка на живом прогоне: запустить `/rag-reviewer:summarize-subsystems` на дешёвой модели и убедиться, что все кластеры возвращают `stored: true`.

Задача: https://ru.yougile.com/team/686c049c8af8/#PRI-237
Бриф/спека/план: `docs/superpowers/{briefs,specs,plans}/…pri-237…`