### PR TITLE
feat(mcp): finish_task различает «ссылка уже была» и «не удалось добавить» (PRI-238)

### DIFF
--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "rag-reviewer",
-  "version": "0.4.7+codex.24f5ca1e34a0",
+  "version": "0.4.7+codex.3ecf05d6ff56",
   "description": "Agentic PR review: hybrid RAG + code graph via MCP, review skills for Codex",
   "repository": "https://github.com/mimfort/rag_for_git",
   "license": "MIT",

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -183,7 +183,10 @@ MCP-сессия (PreparedReview + ToolContext) живёт в процессе `
   Связь двусторонняя: тот же слой fail-soft дописывает кликабельную ссылку на задачу
   (markdown, из `url_template`) в начало тела PR — маркер `<!-- reviewer:task-link -->`
   даёт идемпотентность, платформа резолвится по форме ссылки (`/pull/N` → GitHub,
-  `/-/merge_requests/N` → GitLab), результат — в поле `task_link_added`. Любая правка двигает last-modified, поэтому следующий
+  `/-/merge_requests/N` → GitLab), результат — в поле `task_link_status`
+  (`added` | `already_present` | `failed`; `already_present` — идемпотентный no-op, ссылка уже была
+  в теле PR, это норма, а не сбой), а legacy-`task_link_added` остаётся истинным только для `added`.
+  Любая правка двигает last-modified, поэтому следующий
   `sync_board` сохраняет обновлённую задачу. Python пишет в доску и при болк-синке, и при
   `finish_task`; креды остаются в env. Добавлять type разрешено только полным путём: adapter →
   immutable spec → explicit registry line → full contract fixture → provider-specific tests →

--- a/README.md
+++ b/README.md
@@ -623,7 +623,9 @@ namespaced skills with `$rag-reviewer:...`.
 - **Needs:** task key, PR URL, registered board config, and discovered done target/options.
 - **Reads/writes:** after explicit confirmation, appends the PR idempotently, updates the task,
   prepends a task backlink to the PR body, and re-syncs.
-- **Result:** done state plus `already_closed`/`task_link_added` reporting without duplicate links.
+- **Result:** done state plus `already_closed`/`task_link_status` (`added` | `already_present` |
+  `failed`) reporting without duplicate links; `task_link_added` keeps its old meaning
+  ("written just now").
 
 ### `sync-codebase` — build or update the base index
 

--- a/README.ru.md
+++ b/README.ru.md
@@ -627,7 +627,8 @@ threshold, graph backend и retrieval ceilings меняют cost/recall; сна�
 - **Нужно:** task key, PR URL, registered board config и обнаруженный done target/options.
 - **Чтение/запись:** после подтверждения идемпотентно добавляет PR, обновляет задачу, добавляет
   task backlink в PR body и запускает sync.
-- **Результат:** done state и отчёт `already_closed`/`task_link_added` без duplicate links.
+- **Результат:** done state и отчёт `already_closed`/`task_link_status` (`added` | `already_present`
+  | `failed`) без duplicate links; `task_link_added` сохраняет прежнюю семантику («записали сейчас»).
 
 ### `sync-codebase` — построить или обновить base index
 

--- a/docs/superpowers/briefs/2026-08-11-PRI-238-task-link-status.md
+++ b/docs/superpowers/briefs/2026-08-11-PRI-238-task-link-status.md
@@ -1,0 +1,35 @@
+# Brief — PRI-238 finish_task: отличать «ссылка на задачу уже в PR» от «не удалось добавить»
+https://ru.yougile.com/team/686c049c8af8/#PRI-238
+
+## Task
+`finish_task` возвращает `task_link_added: false` в двух разных случаях — идемпотентный no-op
+(ссылка уже в теле PR) и реальный сбой. Клиент их не различает, скилл finish-task рапортует
+пользователю о проблеме, которой не было. Нужно: различать три исхода в payload, обновить
+докстринг тула и шаг 6 скилла, покрыть юнит-тестами, сохранить обратную совместимость
+`task_link_added` (семантика «мы записали сейчас») и идемпотентность.
+
+## Relevant code
+- `reviewer/tasks/pr_backlink.py:57` — `apply_backlink` возвращает `None` при двойной
+  идемпотентности (маркер ИЛИ URL задачи в теле); чистая функция, менять не требуется.
+- `reviewer/mcp/service.py:819` — `_backlink_pr` → `(bool, warnings)`; три ранних выхода
+  (пустой task_url / неразобранный pr_url / исключение VCS) и no-op `return False, []`.
+- `reviewer/mcp/service.py:1151` — вызов из `finish_task`, сборка payload `task_link_added`.
+- `reviewer/entrypoints/mcp_server.py:146` — докстринг MCP-тула `finish_task`.
+- `plugin/skills/finish-task/SKILL.md:32` — шаг 6, правило отчёта.
+
+## Test exemplars
+- `tests/mcp/test_finish_task.py:213-280` — оркестрация на фейках `_FakeVCS`/`_Provider`:
+  добавлено / идемпотентно / сбой VCS / нет url задачи / неразобранный pr_url.
+- `tests/skills/test_finish_task_skill.py:54` — guard на упоминание `task_link_added` и `PR body`.
+
+## Constraints
+- Правка `plugin/` → пересобрать codex-манифесты (`scripts/update_codex_plugin_manifest.py` + `--check`).
+- Обратная совместимость: `task_link_added` остаётся bool со старой семантикой.
+- Никаких миграций БД/схемы.
+
+Собран на: session model (Opus 5), режим: inline
+
+## Токены (этап solve-task)
+Модель: claude-opus-5
+fresh-in 40 · out 7.7K · cache-write 178K · cache-read 1.4M
+Всего: 1.6M токенов

--- a/plugin/.codex-plugin/plugin.json
+++ b/plugin/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "rag-reviewer",
-  "version": "0.4.7+codex.24f5ca1e34a0",
+  "version": "0.4.7+codex.3ecf05d6ff56",
   "description": "Agentic PR review: hybrid RAG + code graph via MCP, review skills for Codex",
   "repository": "https://github.com/mimfort/rag_for_git",
   "license": "MIT",

--- a/plugin/skills/finish-task/SKILL.md
+++ b/plugin/skills/finish-task/SKILL.md
@@ -29,7 +29,11 @@ target, and adds a clickable task link to the PR body; clients never send creden
    On `status == "error"`, report the reason in Russian and stop.
 6. **Re-index.** Call `sync_board(board=<project or null>, board_type=<type>,
    provider_options=<task_board.options or {}>)`, then report the write and sync result. When
-   `already_closed` is true, state that no duplicate PR link was added. Report `task_link_added`:
-   when false, relay the warning verbatim — the board write still succeeded.
+   `already_closed` is true, state that no duplicate PR link was added. Report the task link from
+   `task_link_status`, not from `task_link_added` alone: `added` — the link was written now;
+   `already_present` — it was already in the PR body, so report it as normal (an idempotent no-op,
+   never as a problem); `failed` — only then relay the warning verbatim, and the board write still
+   succeeded. `task_link_added` stays `true` only for `added` (older deploys may omit
+   `task_link_status`: treat a missing field as `added`/`failed` by whether warnings mention the link).
 
 All reads are fail-open; the explicitly confirmed `finish_task` call is the only write.

--- a/reviewer/entrypoints/mcp_server.py
+++ b/reviewer/entrypoints/mcp_server.py
@@ -143,8 +143,10 @@ def create_server(service: MCPReviewService) -> FastMCP:
         task's last-modified bumps and the next sync_board re-indexes the updated task.
         board_type is a registered provider type, target is the selected generic done
         target, and provider_options is a non-secret JSON object. It also appends a
-        clickable task link to the PR body (task_link_added; fail-soft, reasons land in
-        warnings). Credentials remain server-side; failures are returned safely."""
+        clickable task link to the PR body: task_link_status is "added", "already_present"
+        (the link was already there — an idempotent no-op, not a problem) or "failed"
+        (reason in warnings); task_link_added keeps its old meaning "written just now".
+        Fail-soft. Credentials remain server-side; failures are returned safely."""
         return service.finish_task(
             key,
             pr_url,

--- a/reviewer/mcp/service.py
+++ b/reviewer/mcp/service.py
@@ -816,20 +816,25 @@ class MCPReviewService:
         )
         return request, registry, credentials
 
-    def _backlink_pr(self, pr_url: str, key: str, task_url: str) -> tuple[bool, list[str]]:
-        """Дописать ссылку на задачу в начало тела PR. Возвращает (added, warnings).
+    def _backlink_pr(self, pr_url: str, key: str, task_url: str) -> tuple[str, list[str]]:
+        """Дописать ссылку на задачу в начало тела PR. Возвращает (status, warnings).
+
+        status — один из трёх исходов: "added" (записали сейчас), "already_present"
+        (ссылка уже была в теле — идемпотентный no-op, это норма) и "failed"
+        (записать не удалось; причина — в warnings). Один bool их не различал, и
+        клиент рапортовал о проблеме, которой не было (PRI-238).
 
         Обратная сторона связи: finish пишет PR-ссылку в задачу, здесь — ссылку
         на задачу в PR. Полностью fail-soft: доска к этому моменту уже записана,
         поэтому ни одна ошибка правки PR не отменяет успех finish_task."""
         from reviewer.tasks.pr_backlink import apply_backlink, parse_pr_url
         if not task_url:
-            return False, ["ссылка на задачу не добавлена в PR: url задачи не резолвится "
-                           "(task_board.url_template не задан)"]
+            return "failed", ["ссылка на задачу не добавлена в PR: url задачи не резолвится "
+                              "(task_board.url_template не задан)"]
         target = parse_pr_url(pr_url)
         if target is None:
-            return False, ["ссылка на задачу не добавлена в PR: "
-                           f"{pr_url!r} не распознан как ссылка на PR/MR"]
+            return "failed", ["ссылка на задачу не добавлена в PR: "
+                              f"{pr_url!r} не распознан как ссылка на PR/MR"]
         vcs = None
         try:
             vcs = (self._vcs_factory(target.owner, target.repo) if self._vcs_factory
@@ -838,12 +843,12 @@ class MCPReviewService:
                        platform=target.platform, base_url=target.base_url))
             body = apply_backlink(vcs.get_pull_request(target.number).body, key, task_url)
             if body is None:
-                return False, []       # ссылка уже на месте — идемпотентный no-op
+                return "already_present", []   # ссылка уже на месте — идемпотентный no-op
             vcs.update_pull_request_body(target.number, body)
-            return True, []
+            return "added", []
         except Exception as exc:
             log.warning("бэклинк задачи в PR не удался", exc_info=True)
-            return False, [f"ссылка на задачу не добавлена в PR: {exc}"]
+            return "failed", [f"ссылка на задачу не добавлена в PR: {exc}"]
         finally:
             if vcs is not None and self._vcs_factory is None:
                 try:
@@ -1148,7 +1153,7 @@ class MCPReviewService:
                     target=target,
                 )
                 brief = self._write_through(resolved.provider, key)
-                link_added, link_warnings = self._backlink_pr(
+                link_status, link_warnings = self._backlink_pr(
                     pr_url, key, (brief or {}).get("url") or "")
                 result.setdefault("warnings", []).extend(migration_warnings)
                 result["warnings"].extend(link_warnings)
@@ -1157,7 +1162,10 @@ class MCPReviewService:
                         "status": "ok",
                         "board_type": resolved.board_type,
                         "reindexed": brief is not None,
-                        "task_link_added": link_added,
+                        # task_link_added — прежняя семантика («записали сейчас»),
+                        # task_link_status — три различимых исхода (PRI-238).
+                        "task_link_added": link_status == "added",
+                        "task_link_status": link_status,
                         **result,
                     },
                     resolved.secrets,

--- a/tests/mcp/test_finish_task.py
+++ b/tests/mcp/test_finish_task.py
@@ -216,6 +216,7 @@ def test_finish_task_backlinks_task_into_pr_body():
     out = _Svc(["fake"], vcs=vcs).finish_task("PRI-10", PR_URL)
     assert out["status"] == "ok"
     assert out["task_link_added"] is True
+    assert out["task_link_status"] == "added"
     assert len(vcs.updated) == 1
     number, body = vcs.updated[0]
     assert number == 7
@@ -230,6 +231,18 @@ def test_finish_task_backlink_idempotent_on_second_run():
     out = _Svc(["fake"], vcs=vcs).finish_task("PRI-10", PR_URL)
     assert out["status"] == "ok"
     assert out["task_link_added"] is False
+    # Ссылка уже на месте — это норма, а не сбой: отдельный статус отличает её от неудачи.
+    assert out["task_link_status"] == "already_present"
+    assert vcs.updated == []
+    assert out["warnings"] == []
+
+
+def test_finish_task_backlink_already_present_when_author_linked_manually():
+    # Ручная ссылка автора PR (без нашего маркера) — тоже идемпотентный no-op.
+    vcs = _FakeVCS(body="см. [PRI-10](https://board.example/#PRI-10)\n\nтекст")
+    out = _Svc(["fake"], vcs=vcs).finish_task("PRI-10", PR_URL)
+    assert out["task_link_added"] is False
+    assert out["task_link_status"] == "already_present"
     assert vcs.updated == []
     assert out["warnings"] == []
 
@@ -241,6 +254,7 @@ def test_finish_task_backlink_failsoft_on_vcs_error():
     assert out["status"] == "ok"
     assert out["done_set"] is True
     assert out["task_link_added"] is False
+    assert out["task_link_status"] == "failed"
     assert any("403" in w for w in out["warnings"])
 
 
@@ -254,6 +268,7 @@ def test_finish_task_backlink_skipped_without_task_url():
     out = _Svc(["fake"], _NoUrl(), vcs=vcs).finish_task("PRI-10", PR_URL)
     assert out["status"] == "ok"
     assert out["task_link_added"] is False
+    assert out["task_link_status"] == "failed"
     assert vcs.updated == []
     assert any("url_template" in w for w in out["warnings"])
 
@@ -263,6 +278,8 @@ def test_finish_task_backlink_skipped_on_unparsable_pr_url():
     out = _Svc(["fake"], vcs=vcs).finish_task("PRI-10", "не ссылка")
     assert out["status"] == "ok"
     assert out["task_link_added"] is False
+    assert out["task_link_status"] == "failed"
+    assert any("не распознан" in w for w in out["warnings"])
     assert vcs.updated == []
 
 
@@ -277,4 +294,14 @@ def test_finish_task_backlink_skipped_when_writethrough_failed():
     assert out["status"] == "ok"
     assert out["reindexed"] is False
     assert out["task_link_added"] is False
+    assert out["task_link_status"] == "failed"
     assert vcs.updated == []
+
+
+def test_finish_task_link_status_matches_warnings_contract():
+    # Контракт: 'failed' ⇔ есть warning про ссылку; норма ('added'/'already_present') — без него.
+    vcs = _FakeVCS()
+    out = _Svc(["fake"], vcs=vcs).finish_task("PRI-10", PR_URL)
+    assert out["task_link_status"] in {"added", "already_present", "failed"}
+    assert out["task_link_added"] is (out["task_link_status"] == "added")
+    assert not [w for w in out["warnings"] if "ссылка на задачу" in w]

--- a/tests/skills/test_finish_task_skill.py
+++ b/tests/skills/test_finish_task_skill.py
@@ -55,3 +55,12 @@ def test_finish_task_mentions_pr_backlink():
     t = SKILL.read_text(encoding="utf-8")
     assert "task_link_added" in t     # отчёт озвучивает результат обратного линка
     assert "PR body" in t             # offer предупреждает о правке тела PR
+
+
+def test_finish_task_reports_link_status_three_outcomes():
+    # Шаг 6 читает task_link_status: 'уже была' — норма, а не проблема (PRI-238).
+    t = SKILL.read_text(encoding="utf-8")
+    assert "task_link_status" in t
+    for outcome in ("added", "already_present", "failed"):
+        assert outcome in t
+    assert "only" in t and "failed" in t   # о проблеме сообщаем только при failed


### PR DESCRIPTION
Задача: [PRI-238](https://ru.yougile.com/team/686c049c8af8/#PRI-238)

## Проблема

`finish_task` возвращал `task_link_added: false` в двух разных случаях: идемпотентный no-op (ссылка на задачу уже была в теле PR) и реальный сбой. Клиент их не различал, и скилл finish-task рапортовал пользователю о проблеме, которой не было (воспроизведено на PRI-237 / PR #177).

## Что сделано

- `reviewer/mcp/service.py::_backlink_pr` возвращает статус вместо bool: `added` | `already_present` | `failed`.
- В payload `finish_task` добавлено поле `task_link_status`; `task_link_added` сохраняет прежнюю семантику («записали сейчас») — обратная совместимость.
- Докстринг MCP-тула `finish_task` обновлён под новый контракт.
- `plugin/skills/finish-task/SKILL.md`, шаг 6: о проблеме сообщаем только при `failed`; `already_present` — норма. Есть фолбэк для старых деплоев без нового поля.
- Тесты: `tests/mcp/test_finish_task.py` — три исхода + ручная ссылка автора PR + контракт «failed ⇔ warning»; `tests/skills` — guard на новую формулировку шага 6.
- Доки: README.md / README.ru.md / CLAUDE.md; codex-манифесты пересобраны (`--check` exit 0).

## Проверка

- `.venv/bin/pytest -q` → 3723 passed
- `ruff` чист по затронутым файлам
- `scripts/update_codex_plugin_manifest.py --check` → exit 0