### PR TITLE
chore(release): версия 0.4.8

### DIFF
--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "rag-reviewer",
-  "version": "0.4.7+codex.67c0abe7fe53",
+  "version": "0.4.8+codex.cd87ba463358",
   "description": "Agentic PR review: hybrid RAG + code graph via MCP, review skills for Codex",
   "repository": "https://github.com/mimfort/rag_for_git",
   "license": "MIT",

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "rag-reviewer",
-  "version": "0.4.7",
+  "version": "0.4.8",
   "description": "Agentic PR review: hybrid RAG + code graph via MCP, review skills for Claude Code"
 }

--- a/plugin/.codex-plugin/plugin.json
+++ b/plugin/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "rag-reviewer",
-  "version": "0.4.7+codex.67c0abe7fe53",
+  "version": "0.4.8+codex.cd87ba463358",
   "description": "Agentic PR review: hybrid RAG + code graph via MCP, review skills for Codex",
   "repository": "https://github.com/mimfort/rag_for_git",
   "license": "MIT",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "rag-reviewer"
-version = "0.4.7"
+version = "0.4.8"
 description = "AI pull-request reviewer: hybrid RAG + a code graph + Claude Code. Whole-repo context, inline GitHub comments grounded on exact code."
 readme = "README.md"
 license = { text = "MIT" }

--- a/uv.lock
+++ b/uv.lock
@@ -1647,7 +1647,7 @@ wheels = [
 
 [[package]]
 name = "rag-reviewer"
-version = "0.4.7"
+version = "0.4.8"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
Бамп версии под релиз в main.

Содержимое релиза:
- **PRI-239** — канал репорта багов самого reviewer: server-side `report_bug` с детерминированной анонимизацией, скилл `report-bug`, публикация только по явному апруву и никогда в headless.
- **PRI-240** — автотриггер к нему: `PostToolUse`-хук, распознающий дефект инструмента по форме ответа; штатные сбои (недоступные хранилища, ключи, лимиты, 4xx, таймауты, состояние индекса) проходят молча.

`uv.lock` и codex-манифесты бампаются тем же коммитом: рассинхрон lock ронял джобу test на `uv lock --check` ещё до pytest, а payload-digest манифестов завязан на version.

Проверки: `pytest -q` → 3859 passed; `uv lock --check` → ok; `update_codex_plugin_manifest.py --check` → exit 0. Editable-установка переставлена локально, иначе tests/install/test_codex_install.py сверялся бы со старой версией дистрибутива.