### PR TITLE
release: 0.4.9

### DIFF
--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "rag-reviewer",
-  "version": "0.4.8+codex.cd87ba463358",
+  "version": "0.4.9+codex.36315cceb7fb",
   "description": "Agentic PR review: hybrid RAG + code graph via MCP, review skills for Codex",
   "repository": "https://github.com/mimfort/rag_for_git",
   "license": "MIT",

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "rag-reviewer",
-  "version": "0.4.8",
+  "version": "0.4.9",
   "description": "Agentic PR review: hybrid RAG + code graph via MCP, review skills for Claude Code"
 }

--- a/plugin/.codex-plugin/plugin.json
+++ b/plugin/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "rag-reviewer",
-  "version": "0.4.8+codex.cd87ba463358",
+  "version": "0.4.9+codex.36315cceb7fb",
   "description": "Agentic PR review: hybrid RAG + code graph via MCP, review skills for Codex",
   "repository": "https://github.com/mimfort/rag_for_git",
   "license": "MIT",

--- a/plugin/skills/_common/bug-reporting.md
+++ b/plugin/skills/_common/bug-reporting.md
@@ -1,13 +1,6 @@
-**Noticed a defect of reviewer itself?** If a reviewer MCP tool broke its own documented
-contract, a skill step was impossible with the available tools, a stated invariant failed
-(idempotency, dedup, overlay cleanup, outcome counts), or a reviewer frame appeared in a
-traceback — do not fix it silently and move on. Tell the user in one line and offer the
-`report-bug` skill, which assembles an anonymized issue for `mimfort/rag_for_git`.
-
-Stay silent about everything that is not the tool's defect: unavailable Postgres/Neo4j, missing
-keys, a stale index, board or Voyage rate limits, GitHub/GitLab errors, the user's own failing
-tests or git conflicts, permission denials. The channel is only worth having while it is quiet
-on other people's problems.
-
-Never publish anything yourself: publication happens only through `report_bug` with an explicit
-human approval, and never at all in headless, cron or background runs.
+**Defect of reviewer itself?** A tool breaking its documented contract, an impossible skill step,
+a failed stated invariant, or a `reviewer/*` frame in a traceback — tell the user in one line and
+offer the `report-bug` skill. Stay silent about everything else: unavailable Postgres/Neo4j,
+missing keys, a stale index, rate limits, VCS errors, the user's own tests or git conflicts,
+permission denials. Never publish yourself — only `report_bug`, with an explicit human approval,
+never in headless or background runs.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "rag-reviewer"
-version = "0.4.8"
+version = "0.4.9"
 description = "AI pull-request reviewer: hybrid RAG + a code graph + Claude Code. Whole-repo context, inline GitHub comments grounded on exact code."
 readme = "README.md"
 license = { text = "MIT" }

--- a/uv.lock
+++ b/uv.lock
@@ -1647,7 +1647,7 @@ wheels = [
 
 [[package]]
 name = "rag-reviewer"
-version = "0.4.8"
+version = "0.4.9"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
Релиз 0.4.9.

- сжатый include `_common/bug-reporting.md` (922 → 517 символов, ~230 → ~130 токенов на вызов review-pr / solve-task / summarize-subsystems)
- пересобраны codex-манифесты и uv.lock

Тесты: 3859 passed.