### PR TITLE
feat: параметризация публикуемых портов Postgres/Neo4j (PRI-241)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -58,6 +58,11 @@ PG_POOL_MAX_SIZE=4
 NEO4J_URI=neo4j://localhost:7687
 NEO4J_USER=neo4j
 NEO4J_PASSWORD=reviewerpass
+# Публикуемые (хостовые) порты docker compose; контейнерные порты (5432/7687/7474) фиксированы.
+# reviewer init выводит первые два из PG_DSN/NEO4J_URI.
+PARADEDB_PUBLISH_PORT=5433
+NEO4J_BOLT_PUBLISH_PORT=7687
+NEO4J_HTTP_PUBLISH_PORT=7474
 
 # ============================================================================
 # Только для тестов: изолированные сервисы `docker compose --profile test`

--- a/README.md
+++ b/README.md
@@ -322,6 +322,23 @@ Important groups:
   layer takes precedence — see [Repositories and branches](#repositories-and-branches));
 - board credentials: provider-specific env declared in the registry.
 
+Published host ports of the Compose storage services are variables, not literals:
+`PARADEDB_PUBLISH_PORT` (default `5433`), `NEO4J_BOLT_PUBLISH_PORT` (default `7687`) and
+`NEO4J_HTTP_PUBLISH_PORT` (default `7474`). Container ports stay fixed. `reviewer init` asks for
+them in the storage group and derives the first two from `PG_DSN` and `NEO4J_URI`, so the client
+string and the published port cannot drift apart silently; a mismatch on a local host prints a
+warning without blocking.
+
+```bash
+PARADEDB_PUBLISH_PORT=6543 NEO4J_BOLT_PUBLISH_PORT=7999 \
+  docker compose -f ~/.config/rag-reviewer/docker-compose.yml up -d
+```
+
+Prefer variables over editing the Compose file: a hand-edited
+`~/.config/rag-reviewer/docker-compose.yml` no longer matches its recorded hash, so `reviewer
+update` treats it as user-modified (status `preserved`) and stops delivering new Compose
+definitions to it.
+
 Credentials stay server-side. **Credentials are not returned** by board metadata or discovery
 tools and must not be placed in `.review.yml`.
 

--- a/README.ru.md
+++ b/README.ru.md
@@ -327,6 +327,23 @@ New Chat или новую CLI-сессию. В IDE также выполнит�
   слой имеет приоритет — см. [Репозитории и ветки](#репозитории-и-ветки));
 - board credentials: provider-specific env из registry.
 
+Публикуемые хостовые порты storage-сервисов Compose заданы переменными, а не литералами:
+`PARADEDB_PUBLISH_PORT` (дефолт `5433`), `NEO4J_BOLT_PUBLISH_PORT` (дефолт `7687`) и
+`NEO4J_HTTP_PUBLISH_PORT` (дефолт `7474`). Контейнерные порты фиксированы. `reviewer init`
+спрашивает их в группе хранилищ и выводит первые два из `PG_DSN` и `NEO4J_URI`, поэтому строка
+подключения и публикуемый порт не разъезжаются молча; расхождение на локальном хосте печатает
+предупреждение, но не блокирует.
+
+```bash
+PARADEDB_PUBLISH_PORT=6543 NEO4J_BOLT_PUBLISH_PORT=7999 \
+  docker compose -f ~/.config/rag-reviewer/docker-compose.yml up -d
+```
+
+Настраивайте переменными, а не правкой Compose-файла: отредактированный вручную
+`~/.config/rag-reviewer/docker-compose.yml` перестаёт совпадать с записанным hash, поэтому
+`reviewer update` считает его изменённым пользователем (статус `preserved`) и больше не доставляет
+в него новые Compose-описания.
+
 Credentials остаются на сервере. **Credentials are not returned** board metadata/discovery tools
 и не должны попадать в `.review.yml`.
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,13 +6,13 @@ services:
       POSTGRES_PASSWORD: reviewer
       POSTGRES_DB: reviewer
     # loopback-only: локальный dev-стек не должен слушать LAN. Креды — одноразовые dev-дефолты.
-    ports: ["127.0.0.1:5433:5432"]   # 5433 на хосте: 5432 занят локальным Postgres разработчика
+    ports: ["127.0.0.1:${PARADEDB_PUBLISH_PORT:-5433}:5432"]   # 5433 на хосте: 5432 занят локальным Postgres разработчика
     volumes: ["paradedb_data:/var/lib/postgresql/"]
   neo4j:
     image: neo4j:5
     environment:
       NEO4J_AUTH: neo4j/reviewerpass
-    ports: ["127.0.0.1:7474:7474", "127.0.0.1:7687:7687"]
+    ports: ["127.0.0.1:${NEO4J_HTTP_PUBLISH_PORT:-7474}:7474", "127.0.0.1:${NEO4J_BOLT_PUBLISH_PORT:-7687}:7687"]
     volumes: ["neo4j_data:/data"]
   web:
     # Web admin собирается и запускается только через явный `--profile web`.

--- a/docs/superpowers/briefs/2026-08-12-PRI-241-parametrize-storage-publish-ports.md
+++ b/docs/superpowers/briefs/2026-08-12-PRI-241-parametrize-storage-publish-ports.md
@@ -1,0 +1,62 @@
+# Brief — PRI-241 Параметризовать хостовые порты Postgres/Neo4j в compose и задавать их через install-wizard
+https://ru.yougile.com/team/686c049c8af8/#PRI-241
+
+## Task
+- ID-295/PRI-241, статус «Запуск / CI / хуки». Хостовые порты paradedb/neo4j зашиты в `docker-compose.yml` литералами; install-wizard пишет `PG_DSN`/`NEO4J_URI` в `.env`, но не трогает compose → смена порта в мастере тихо ломает подключение.
+- Требования (из описания): параметризовать `docker-compose.yml:9,15` по образцу web (`docker-compose.yml:26-30`) через `PARADEDB_PUBLISH_PORT:-5433`, `NEO4J_BOLT_PUBLISH_PORT:-7687`, `NEO4J_HTTP_PUBLISH_PORT:-7474` (контейнерные порты 5432/7687/7474 фиксированы); добавить ключи в wizard-группу «Хранилища» и в `ENV_TEMPLATE`/`.env.example`; дефолт publish-порта выводить из `PG_DSN`/`NEO4J_URI`, при ручном расхождении — предупреждать, не блокировать; не трогать `paradedb-test`/`neo4j-test`; обновить README.md/README.ru.md.
+- Критерии приёмки: 1) `docker compose config` без переменных даёт прежние порты; 2) с заданными env compose публикует их и `reviewer check` проходит; 3) wizard с нестандартным портом даёт согласованные `.env`; 4) unit-тест на wizard фиксирует новые поля и вывод дефолта из DSN; 5) тестовый профиль не тронут; 6) README синхронны.
+- criteria пусты в сторе — весь текст выше взят из description задачи.
+
+## Related work
+- ID-276/PRI-222 (done, PR mimfort/rag_for_git#162) — прямой прецедент того же паттерна: параметризация publish-порта через `${VAR:-default}` в `docker-compose.yml` для сервиса `web`, синхронная правка README.md/README.ru.md, guard-тест `tests/test_infrastructure_policy.py::test_compose_web_service_is_opt_in_with_separate_runtime_ports`, документационный guard в `tests/docs/test_readme_onboarding.py`. Важно: в этом PR `REVIEWER_WEB_PUBLISH_PORT` задаётся только вручную в shell/README-примерах — wizard его НЕ пишет в `.env`; PRI-241 впервые заводит publish-порт под управление install-wizard.
+- ID-122/PRI-? «reviewer init — мастер онбординга» (done) — исходная реализация wizard-групп (`WIZARD_GROUPS`, `EnvGroup`/`EnvField`, `render_env`, `ENV_TEMPLATE`) в `reviewer/install.py`; новые поля публикуемых портов встраиваются в ту же структуру.
+- ID-169/PRI-? «reviewer init: заполнение новых полей (GitLab, доска, веб-админка) + связка с configure-review» (done) — прецедент добавления новых wizard-полей в существующую группу и синхронизации `ENV_TEMPLATE`.
+- (dropped 4 из 8 найденных похожих задач: ID-268 healthcheck CPU — про интервалы проб, не про порты; ID-121 lite-режим SQLite — другая инфраструктура; ID-95 purge orphaned tasks и ID-124 CI-рецепт — не относятся к теме портов/wizard)
+
+## Subsystems
+- reviewer (корневой кластер) — `install.py` (WIZARD_GROUPS, EnvField/EnvGroup, render_env, ENV_TEMPLATE) и `update_lifecycle.py` (`sync_compose_file`/`_sync_compose_file_unlocked`, `download_compose`, статусы created/adopted/current/updated/preserved) — оба модуля, которые задача требует трогать, лежат в этом кластере.
+- reviewer/config — `settings.py::Settings` держит `pg_dsn`/`neo4j_uri` дефолты и паттерн `.env`-резолва; новые publish-порт переменные не обязаны попадать в Settings (они read только compose/wizard-стороной), но дефолты DSN/URI (`localhost:5433`, `localhost:7687`) должны остаться согласованными источником для вывода дефолта publish-порта.
+- tests — `tests/test_infrastructure_policy.py` уже парсит `docker-compose.yml` через `yaml.safe_load` и содержит прецедент теста `test_compose_web_service_is_opt_in_with_separate_runtime_ports`; новый тест для paradedb/neo4j должен идти рядом.
+- tests/install — `tests/install/test_install_wizard.py` — целевое место для нового unit-теста (критерий приёмки №4).
+- tests/docs — guard-тесты паритета README.md/README.ru.md (см. прецедент PRI-222) — потребуется аналогичная проверка для новых секций про storage publish-порты.
+
+## Relevant code
+- `docker-compose.yml:9` — `ports: ["127.0.0.1:5433:5432"]` у `paradedb`; менять на `"127.0.0.1:${PARADEDB_PUBLISH_PORT:-5433}:5432"`.
+- `docker-compose.yml:15` — `ports: ["127.0.0.1:7474:7474", "127.0.0.1:7687:7687"]` у `neo4j`; менять на `"127.0.0.1:${NEO4J_HTTP_PUBLISH_PORT:-7474}:7474"` и `"127.0.0.1:${NEO4J_BOLT_PUBLISH_PORT:-7687}:7687"`.
+- `docker-compose.yml:26-30` — рабочий образец параметризации у `web`: `ports: ["127.0.0.1:${REVIEWER_WEB_PUBLISH_PORT:-8000}:${REVIEWER_WEB_PORT:-8000}"]`; прямой шаблон для копирования.
+- `docker-compose.yml:49,63` — `paradedb-test`/`neo4j-test` порты (`55433`, `17474`/`17687`) — задача явно требует их не трогать.
+- `reviewer/install.py:252-270` — wizard-группа `EnvGroup(title="Хранилища (Postgres / Neo4j)", ...)` с полями `PG_DSN`, `NEO4J_URI`, `NEO4J_USER`, `NEO4J_PASSWORD`; сюда добавляются новые `EnvField` для трёх publish-портов.
+- `reviewer/install.py:105-124` — `@dataclass class EnvField` (key/prompt_text/default/secret/required) — контракт, которому должны соответствовать новые поля; `default` статичен, поэтому «дефолт из PG_DSN/NEO4J_URI» потребует либо динамического вычисления при построении `WIZARD_GROUPS`/`prompt_groups`, либо отдельной логики в `init` (cli.py), а не просто нового статичного `EnvField.default`.
+- `reviewer/install.py:313-334` — `render_env(values, extra)` — рендерит `.env` по `WIZARD_GROUPS`; новые ключи попадут в вывод автоматически, если добавлены в группу.
+- `reviewer/install.py:48-115` — `_ENV_TEMPLATE_BASE` (Python-строка, встроенный шаблон `.env`) со секцией `# --- Postgres (ParadeDB :5433) / Neo4j (:7687) — дефолты docker-compose ---` (строки 71-77); сюда добавить `PARADEDB_PUBLISH_PORT=5433`, `NEO4J_BOLT_PUBLISH_PORT=7687`, `NEO4J_HTTP_PUBLISH_PORT=7474`.
+- `reviewer/install.py:296-298` — `_GROUP_HEADERS` — заголовок секции для группы «Хранилища» в рендере `.env` (`# --- Postgres (ParadeDB :5433) / Neo4j (:7687) ---`).
+- `.env.example` — по CLAUDE.md должен зеркалить `ENV_TEMPLATE`/settings; требует синхронной правки новыми ключами (файл не процитирован сниппетом, но упомянут в задаче и в докстринге `_ENV_TEMPLATE_BASE:51` как «Полный справочник полей — зеркало .env.example»).
+- `reviewer/entrypoints/cli.py:1218-1486` — команда `init`; интерактивная ветка (`values = inst.prompt_groups(...)`, строки 1271-1293) — здесь естественное место для логики «вывести дефолт publish-порта из PG_DSN/NEO4J_URI, предупредить при расхождении, не блокировать».
+- `reviewer/update_lifecycle.py:189-220` — `_sync_compose_file_unlocked` — апдейтер сравнивает SHA256 всего файла; ручная правка compose (в т.ч. добавление publish-порт переменных вручную пользователем) переводит файл в `preserved` — это ограничение нужно задокументировать в README согласно пункту 5 задачи.
+- `reviewer/update_lifecycle.py:63-73` — `download_compose(...)` тянет канонический `docker-compose.yml` с `COMPOSE_URL` (GitHub raw, main-ветка) — подтверждает, что правка `docker-compose.yml` в репозитории автоматически становится источником для апдейтера у существующих инсталляций.
+- `reviewer/entrypoints/cli.py:1516-1552` — `_refresh_update_artifacts` — вызывает `sync_compose_file(download_compose())` и печатает статус (created/adopted/current/updated/preserved); релевантно для понимания, как обновлённый compose доедет до уже установленных пользователей.
+- `README.md:797`, `README.ru.md:786` — существующие примеры `REVIEWER_WEB_PORT=... REVIEWER_WEB_PUBLISH_PORT=... docker compose --profile web up -d web` — стилевой образец для новой документации по storage-портам.
+- (dropped ~7 из ретрива: сниппеты `Settings` (config/settings.py) и точки входа `mcp_server.py`/`cli.py::serve`/`web/app.py`/`web/serve.py` попали в топ по семантической близости к «портам», но не относятся к paradedb/neo4j publish-портам или install-wizard — тема запроса не про web-порт, а он уже параметризован; не информируют реализацию)
+
+## Test exemplars
+- `tests/test_infrastructure_policy.py:350` (`test_compose_web_service_is_opt_in_with_separate_runtime_ports`) — прямой паттерн: парсит `docker-compose.yml` через `yaml.safe_load`, проверяет `ports == ["127.0.0.1:${VAR:-default}:${VAR2:-default2}"]` без Docker/сети. Тот же приём подходит для нового теста на paradedb/neo4j (проверка литерала-шаблона строки, а не рантайм-подстановки — `docker compose config` для рантайм-подстановки нужен отдельно, integration/ручной).
+- `tests/test_infrastructure_policy.py:261-283` — существующие ассерты на `paradedb-test`/`neo4j-test` ports (`55433`, `17474`/`17687`) — образец, что для dev-сервисов паradedb/neo4j такого явного теста-литерала сейчас НЕТ (только test-профиль покрыт), значит новый тест для критерия приёмки №1 придётся писать с нуля.
+- `tests/install/test_install_wizard.py:62-75` (`test_render_env_contains_wizard_keys`) — паттерн: собрать `values` dict, вызвать `inst.render_env(values, extra={})`, проверить вхождение строк вида `KEY=value`; годится как шаблон unit-теста criteria №4 (новые поля публикуемых портов).
+- `tests/install/test_install_wizard.py:187-191` (`test_env_template_contains_all_wizard_keys`) — гарантирует, что каждый ключ `WIZARD_GROUPS` присутствует в `ENV_TEMPLATE`; новые поля обязаны пройти этот тест без правки (или потребуют явного апдейта, если тест жёстче).
+- `tests/install/test_install_wizard.py:346-401` (`test_init_prompts_only_selected_vcs_provider`) — паттерн monkeypatch `reviewer.install.prompt_groups`, `click.confirm`, вызов `CliRunner().invoke(cli, ["init", "--scope", "global"])` — пригодится для теста «дефолт publish-порта выводится из PG_DSN/NEO4J_URI при интерактивном прогоне init».
+- (dropped 0 отдельно — все найденные тестовые сниппеты по install wizard оказались релевантны; общий cliff обрезал ретрив на 15/71 при скоре 0.42, но непоказанные ниже cliff — низкорелевантные хиты того же файла/кластера, не новая информация)
+
+## Constraints / open questions
+- criteria пусты в сторе — все критерии приёмки взяты из раздела описания задачи, не из отдельного поля.
+- `EnvField.default` — статичное поле dataclass; «дефолт publish-порта из PG_DSN/NEO4J_URI» не укладывается в статичный default напрямую — нужно решить, где именно парсить порт из DSN/URI: во время построения `WIZARD_GROUPS` (модуль-уровень, no access to `current` values) или в `init`/`prompt_groups` в момент интерактивного прогона (есть доступ к текущим значениям `.env`). Второе больше соответствует «предупреждать, не блокировать» при расхождении.
+- Не найдено готовой функции парсинга порта из `PG_DSN`/`NEO4J_URI` — придётся написать (или переиспользовать существующий urlparse, если такой есть в `reviewer/config/settings.py`/`gitutil.py` — не подтверждено ретривом, требует отдельной проверки при реализации).
+- `_sync_compose_file_unlocked` инвариант preserved: если пользователь уже вручную правил `docker-compose.yml` (например, добавил кастомный порт руками до этой задачи), апдейтер после релиза PRI-241 обнаружит расхождение хэша и оставит файл в `preserved` — новый шаблон не долетит автоматически; это ограничение явно требуется задокументировать (пункт 5 задачи), а не чинить.
+- `.env.example` не был процитирован ни одним сниппетом ретрива (Python-only индекс не покрывает `.env`-файлы) — его текущее содержимое нужно прочитать напрямую перед правкой, не полагаясь на этот бриф.
+- README.md/README.ru.md: существующие фрагменты про порты найдены только для web-контейнера (строки ~786-797); секция про paradedb/neo4j publish-порты, вероятно, потребует нового блока рядом с существующим onboarding-текстом про `docker compose up -d` (README.md:37,103) — точные номера строк для вставки не подтверждены, требуют прямого чтения файла при реализации.
+
+Собран на: mid (Sonnet), режим: subagent
+
+## Токены (этап solve-task)
+Модель: claude-opus-5
+fresh-in 43 · out 16.3K · cache-write 149.6K · cache-read 1.5M
+Всего: 1.6M токенов

--- a/docs/superpowers/plans/2026-08-12-pri-241-storage-publish-ports.md
+++ b/docs/superpowers/plans/2026-08-12-pri-241-storage-publish-ports.md
@@ -1,0 +1,753 @@
+# PRI-241 — Параметризация publish-портов Postgres/Neo4j: план реализации
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development
+> (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use
+> checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Публикуемые хостовые порты `paradedb` и `neo4j` задаются переменными окружения, которые
+записывает `reviewer init`, а не литералами в `docker-compose.yml`.
+
+**Architecture:** Три новые переменные (`PARADEDB_PUBLISH_PORT`, `NEO4J_BOLT_PUBLISH_PORT`,
+`NEO4J_HTTP_PUBLISH_PORT`) владеют хостовой стороной port mapping по образцу уже
+параметризованного сервиса `web`. `EnvField` получает опциональный callable `derive_default`,
+чтобы дефолт publish-порта выводился из уже введённого `PG_DSN`/`NEO4J_URI`; чистая функция
+`publish_port_warnings` в конце `reviewer init` предупреждает о расхождении, не блокируя запись.
+
+**Tech Stack:** Python 3, Click, dataclasses, `urllib.parse.urlsplit`, PyYAML (в тестах), pytest,
+Docker Compose.
+
+Спека: `docs/superpowers/specs/2026-08-12-pri-241-storage-publish-ports-design.md`
+Бриф: `docs/superpowers/briefs/2026-08-12-PRI-241-parametrize-storage-publish-ports.md`
+
+## Global Constraints
+
+- Ветка работы — `feat/pri-241-storage-publish-ports` (спека и бриф уже в ней, коммит `483fa76`).
+- Язык проекта русский: комментарии, докстринги, сообщения CLI — на русском.
+- Коммиты — Conventional Commits на русском, **без self-attribution** (никаких `Co-Authored-By`,
+  упоминаний Claude/AI).
+- Дефолты неизменны и обязаны совпадать везде (compose, `ENV_TEMPLATE`, `.env.example`, поля
+  wizard): `PARADEDB_PUBLISH_PORT=5433`, `NEO4J_BOLT_PUBLISH_PORT=7687`,
+  `NEO4J_HTTP_PUBLISH_PORT=7474`.
+- Контейнерные порты (`5432`, `7687`, `7474`) и loopback-биндинг `127.0.0.1` не параметризуются.
+- Сервисы `paradedb-test` / `neo4j-test` не изменяются ни одной задачей.
+- Новые переменные **не** добавляются в `reviewer/config/settings.py` — их читает только compose.
+- `reviewer check` не расширяется; поведение `preserved` у апдейтера не меняется.
+- Каталог `plugin/` не трогается, версия в `pyproject.toml` не бампается → пересборка манифестов
+  (`update_codex_plugin_manifest.py`) не требуется.
+- Тесты запускаются интерпретатором venv: `.venv/bin/pytest`. Все тесты плана — unit (без
+  Postgres, Neo4j, Docker и сети), маркер `integration` не ставится.
+- Перед коммитом прогонять `.venv/bin/ruff check <изменённые .py>` (pre-commit hook делает то же
+  по staged-файлам). Repo-wide чистоты ruff не добиваться — на `dev` он не чист.
+
+---
+
+### Task 1: Параметризовать публикуемые порты storage-сервисов в compose
+
+**Files:**
+- Modify: `docker-compose.yml:9`, `docker-compose.yml:15`
+- Test: `tests/test_infrastructure_policy.py` (новый тест рядом с
+  `test_compose_web_service_is_opt_in_with_separate_runtime_ports`, строка 350)
+
+**Interfaces:**
+- Consumes: ничего.
+- Produces: переменные окружения `PARADEDB_PUBLISH_PORT`, `NEO4J_BOLT_PUBLISH_PORT`,
+  `NEO4J_HTTP_PUBLISH_PORT` с дефолтами `5433`/`7687`/`7474` — их именами пользуются задачи 2-5.
+
+- [ ] **Step 1: Написать падающий тест**
+
+Добавить в `tests/test_infrastructure_policy.py` сразу после
+`test_compose_web_service_is_opt_in_with_separate_runtime_ports` (файл уже импортирует `yaml` и
+`Path`, новых импортов не нужно):
+
+```python
+def test_compose_publishes_storage_ports_through_overridable_variables() -> None:
+    """Хостовые порты dev-хранилищ параметризованы, контейнерные — фиксированы."""
+    root = Path(__file__).parents[1]
+    compose = yaml.safe_load((root / "docker-compose.yml").read_text(encoding="utf-8"))
+
+    assert compose["services"]["paradedb"]["ports"] == [
+        "127.0.0.1:${PARADEDB_PUBLISH_PORT:-5433}:5432"
+    ]
+    assert compose["services"]["neo4j"]["ports"] == [
+        "127.0.0.1:${NEO4J_HTTP_PUBLISH_PORT:-7474}:7474",
+        "127.0.0.1:${NEO4J_BOLT_PUBLISH_PORT:-7687}:7687",
+    ]
+```
+
+- [ ] **Step 2: Запустить тест и убедиться, что он падает**
+
+Run: `.venv/bin/pytest tests/test_infrastructure_policy.py::test_compose_publishes_storage_ports_through_overridable_variables -q`
+Expected: FAIL — фактические значения `['127.0.0.1:5433:5432']` и
+`['127.0.0.1:7474:7474', '127.0.0.1:7687:7687']` не равны ожидаемым шаблонам.
+
+- [ ] **Step 3: Внести правку в compose**
+
+В `docker-compose.yml` заменить строку 9:
+
+```yaml
+    ports: ["127.0.0.1:${PARADEDB_PUBLISH_PORT:-5433}:5432"]   # 5433 на хосте: 5432 занят локальным Postgres разработчика
+```
+
+и строку 15:
+
+```yaml
+    ports: ["127.0.0.1:${NEO4J_HTTP_PUBLISH_PORT:-7474}:7474", "127.0.0.1:${NEO4J_BOLT_PUBLISH_PORT:-7687}:7687"]
+```
+
+Комментарий над `paradedb.ports` (loopback-only, строки 7-8) сохранить как есть. Блок
+`paradedb-test`/`neo4j-test` не трогать.
+
+- [ ] **Step 4: Запустить тесты и убедиться, что они проходят**
+
+Run: `.venv/bin/pytest tests/test_infrastructure_policy.py -q -k "compose"`
+Expected: PASS, включая существующий `test_compose_defines_isolated_test_profile_services` —
+он фиксирует неизменность портов test-профиля (критерий приёмки 5).
+
+- [ ] **Step 5: Проверить обратную совместимость вручную**
+
+Run: `docker compose config | grep -A2 "published"`
+Expected: без заданных переменных публикуются `5433`, `7474`, `7687` — прежние значения.
+Если Docker недоступен, шаг пропустить и отметить это в отчёте по задаче.
+
+- [ ] **Step 6: Коммит**
+
+```bash
+git add docker-compose.yml tests/test_infrastructure_policy.py
+git commit -m "feat(compose): публикуемые порты paradedb/neo4j через переменные окружения"
+```
+
+---
+
+### Task 2: Производный дефолт поля wizard (`derive_default` + `_port_from_url`)
+
+**Files:**
+- Modify: `reviewer/install.py:119-124` (dataclass `EnvField`), `reviewer/install.py:385-434`
+  (`prompt_groups`), импорты в шапке файла
+- Test: `tests/install/test_install_wizard.py`
+
+**Interfaces:**
+- Consumes: имена переменных из задачи 1.
+- Produces:
+  - `EnvField.derive_default: Callable[[dict[str, str]], str] | None = None` — новое опциональное
+    поле dataclass;
+  - `install._port_from_url(value: str, fallback: str) -> str` — порт из URL строкой;
+  - `install._effective_default(field: EnvField, values: dict[str, str], current: dict[str, str]) -> str`
+    — единая точка вычисления дефолта.
+  Задача 3 использует `_port_from_url` и `derive_default`.
+
+- [ ] **Step 1: Написать падающие тесты**
+
+Добавить в конец `tests/install/test_install_wizard.py` (файл уже импортирует
+`from reviewer import install as inst`):
+
+```python
+def test_port_from_url_reads_explicit_port():
+    dsn = "postgresql://reviewer:reviewer@localhost:6543/reviewer"
+    assert inst._port_from_url(dsn, "5433") == "6543"
+    assert inst._port_from_url("neo4j://localhost:7999", "7687") == "7999"
+
+
+def test_port_from_url_falls_back_when_port_missing_or_broken():
+    assert inst._port_from_url("postgresql://reviewer@localhost/reviewer", "5433") == "5433"
+    assert inst._port_from_url("neo4j://localhost:not-a-port", "7687") == "7687"
+    assert inst._port_from_url("", "5433") == "5433"
+    assert inst._port_from_url("   ", "5433") == "5433"
+
+
+def _derived_probe_group(optional: bool) -> "inst.EnvGroup":
+    """Группа из источника и производного от него поля — для проверки derive_default."""
+    return inst.EnvGroup(
+        title="Проба",
+        optional=optional,
+        fields=[
+            inst.EnvField(
+                key="PROBE_URI",
+                prompt_text="PROBE_URI",
+                default="neo4j://localhost:7687",
+            ),
+            inst.EnvField(
+                key="PROBE_PORT",
+                prompt_text="PROBE_PORT",
+                default="7687",
+                derive_default=lambda values: inst._port_from_url(
+                    values.get("PROBE_URI", ""), "7687"
+                ),
+            ),
+        ],
+    )
+
+
+def test_prompt_groups_derives_default_from_earlier_field():
+    result = inst.prompt_groups(
+        [_derived_probe_group(optional=False)],
+        current={"PROBE_URI": "neo4j://localhost:7999"},
+        yes=True,
+    )
+    assert result["PROBE_PORT"] == "7999"
+
+
+def test_prompt_groups_derives_default_in_optional_group():
+    # Опциональная группа при yes=True идёт коротким путём — derive_default обязан работать и там
+    result = inst.prompt_groups(
+        [_derived_probe_group(optional=True)],
+        current={"PROBE_URI": "neo4j://localhost:7999"},
+        yes=True,
+    )
+    assert result["PROBE_PORT"] == "7999"
+
+
+def test_prompt_groups_existing_value_beats_derived_default():
+    result = inst.prompt_groups(
+        [_derived_probe_group(optional=False)],
+        current={"PROBE_URI": "neo4j://localhost:7999", "PROBE_PORT": "7000"},
+        yes=True,
+    )
+    assert result["PROBE_PORT"] == "7000"
+
+
+def test_prompt_groups_derive_default_falls_back_to_static_default():
+    result = inst.prompt_groups(
+        [_derived_probe_group(optional=False)],
+        current={"PROBE_URI": "neo4j://localhost"},
+        yes=True,
+    )
+    assert result["PROBE_PORT"] == "7687"
+```
+
+- [ ] **Step 2: Запустить тесты и убедиться, что они падают**
+
+Run: `.venv/bin/pytest tests/install/test_install_wizard.py -q -k "port_from_url or derive"`
+Expected: FAIL — `AttributeError: module 'reviewer.install' has no attribute '_port_from_url'` и
+`TypeError: EnvField.__init__() got an unexpected keyword argument 'derive_default'`.
+
+- [ ] **Step 3: Реализовать минимально**
+
+В `reviewer/install.py` в шапке добавить импорт (рядом с существующими `from ... import`):
+
+```python
+from collections.abc import Callable
+```
+
+Расширить dataclass `EnvField` (строки 118-124):
+
+```python
+@dataclass
+class EnvField:
+    key: str
+    prompt_text: str
+    default: str = ""
+    secret: bool = False
+    required: bool = False
+    # Дефолт, выводимый из уже собранных значений (напр. порт из PG_DSN). None — статичный default.
+    derive_default: Callable[[dict[str, str]], str] | None = None
+```
+
+Добавить перед `prompt_groups` две функции:
+
+```python
+def _port_from_url(value: str, fallback: str) -> str:
+    """Порт из URL (DSN/URI) строкой; fallback при пустом/кривом URL или URL без порта."""
+    try:
+        port = urlsplit((value or "").strip()).port
+    except ValueError:
+        return fallback
+    return str(port) if port else fallback
+
+
+def _effective_default(
+    field: EnvField,
+    values: dict[str, str],
+    current: dict[str, str],
+) -> str:
+    """Дефолт поля: значение из .env → производный (derive_default) → статичный."""
+    cur = current.get(field.key, "")
+    if cur:
+        return cur
+    if field.derive_default is not None:
+        return field.derive_default(values)
+    return field.default
+```
+
+В `prompt_groups` заменить **все три** места, где сейчас вычисляется `current.get(...) or f.default`
+/ `cur or field.default`:
+
+```python
+    for group in groups:
+        # Опциональную группу предваряем вопросом (в интерактивном режиме)
+        if group.optional:
+            if yes:
+                # CI: сохраняем текущее или дефолт, не спрашиваем
+                for f in group.fields:
+                    values[f.key] = _effective_default(f, values, current)
+                continue
+            if not click.confirm(f"\nНастроить {group.title}?", default=False):
+                for f in group.fields:
+                    values[f.key] = _effective_default(f, values, current)
+                continue
+        elif not yes:
+            click.echo(f"\n[{group.title}]")
+
+        for field in group.fields:
+            cur = current.get(field.key, "")
+            effective_default = _effective_default(field, values, current)
+```
+
+Остальное тело цикла (ветки `yes`, `field.secret`, финальный `click.prompt`) не меняется — оно уже
+использует `cur` и `effective_default`.
+
+- [ ] **Step 4: Запустить тесты и убедиться, что они проходят**
+
+Run: `.venv/bin/pytest tests/install/test_install_wizard.py -q`
+Expected: PASS — новые тесты зелёные, существующие (`test_prompt_groups_yes_uses_current_values`,
+`test_prompt_groups_yes_uses_field_default_when_no_current`,
+`test_prompt_groups_yes_skips_optional_groups`) не сломались.
+
+- [ ] **Step 5: Линт и коммит**
+
+```bash
+.venv/bin/ruff check reviewer/install.py tests/install/test_install_wizard.py
+git add reviewer/install.py tests/install/test_install_wizard.py
+git commit -m "feat(install): производный дефолт поля wizard (derive_default) и разбор порта из URL"
+```
+
+---
+
+### Task 3: Три поля publish-портов в группе «Хранилища», `ENV_TEMPLATE` и `.env.example`
+
+**Files:**
+- Modify: `reviewer/install.py:252-270` (группа «Хранилища (Postgres / Neo4j)»),
+  `reviewer/install.py:71-77` (секция Postgres/Neo4j в `_ENV_TEMPLATE_BASE`),
+  `.env.example:51-60`
+- Test: `tests/install/test_install_wizard.py`
+
+**Interfaces:**
+- Consumes: `install._port_from_url`, `EnvField.derive_default` из задачи 2; имена переменных и
+  дефолты из задачи 1.
+- Produces: ключи `PARADEDB_PUBLISH_PORT`, `NEO4J_BOLT_PUBLISH_PORT`, `NEO4J_HTTP_PUBLISH_PORT` в
+  `WIZARD_GROUPS`, `ENV_TEMPLATE` и `.env.example` — на них опирается задача 4.
+
+- [ ] **Step 1: Написать падающие тесты**
+
+Добавить в конец `tests/install/test_install_wizard.py`:
+
+```python
+PUBLISH_PORT_DEFAULTS = {
+    "PARADEDB_PUBLISH_PORT": "5433",
+    "NEO4J_BOLT_PUBLISH_PORT": "7687",
+    "NEO4J_HTTP_PUBLISH_PORT": "7474",
+}
+
+
+def test_storage_group_declares_publish_ports_with_compose_defaults():
+    group = next(
+        g for g in inst.WIZARD_GROUPS if g.title == "Хранилища (Postgres / Neo4j)"
+    )
+    declared = {f.key: f.default for f in group.fields}
+
+    for key, default in PUBLISH_PORT_DEFAULTS.items():
+        assert declared[key] == default
+
+
+def test_wizard_yes_derives_publish_ports_from_connection_strings():
+    current = {
+        "PG_DSN": "postgresql://reviewer:reviewer@localhost:6543/reviewer",
+        "NEO4J_URI": "neo4j://localhost:7999",
+    }
+    result = inst.prompt_groups(inst.WIZARD_GROUPS, current=current, yes=True)
+
+    assert result["PARADEDB_PUBLISH_PORT"] == "6543"
+    assert result["NEO4J_BOLT_PUBLISH_PORT"] == "7999"
+    # HTTP-порт неоткуда выводить: в NEO4J_URI только bolt
+    assert result["NEO4J_HTTP_PUBLISH_PORT"] == "7474"
+
+
+def test_wizard_yes_keeps_compose_defaults_without_current_values():
+    result = inst.prompt_groups(inst.WIZARD_GROUPS, current={}, yes=True)
+
+    for key, default in PUBLISH_PORT_DEFAULTS.items():
+        assert result[key] == default
+
+
+def test_render_env_writes_publish_ports():
+    values = {f.key: f.default for g in inst.WIZARD_GROUPS for f in g.fields}
+    rendered = inst.render_env(values, extra={})
+
+    for key, default in PUBLISH_PORT_DEFAULTS.items():
+        assert f"{key}={default}" in rendered
+```
+
+- [ ] **Step 2: Запустить тесты и убедиться, что они падают**
+
+Run: `.venv/bin/pytest tests/install/test_install_wizard.py -q -k "publish_port or storage_group"`
+Expected: FAIL — `KeyError: 'PARADEDB_PUBLISH_PORT'`.
+
+- [ ] **Step 3: Добавить поля в группу wizard**
+
+В `reviewer/install.py` в группе `EnvGroup(title="Хранилища (Postgres / Neo4j)", ...)` дописать
+три поля после `NEO4J_PASSWORD`:
+
+```python
+            EnvField(
+                key="PARADEDB_PUBLISH_PORT",
+                prompt_text="PARADEDB_PUBLISH_PORT (публикуемый порт ParadeDB в docker compose)",
+                default="5433",
+                derive_default=lambda values: _port_from_url(values.get("PG_DSN", ""), "5433"),
+            ),
+            EnvField(
+                key="NEO4J_BOLT_PUBLISH_PORT",
+                prompt_text="NEO4J_BOLT_PUBLISH_PORT (публикуемый bolt-порт Neo4j)",
+                default="7687",
+                derive_default=lambda values: _port_from_url(values.get("NEO4J_URI", ""), "7687"),
+            ),
+            EnvField(
+                key="NEO4J_HTTP_PUBLISH_PORT",
+                prompt_text="NEO4J_HTTP_PUBLISH_PORT (публикуемый порт браузера Neo4j)",
+                default="7474",
+            ),
+```
+
+- [ ] **Step 4: Добавить ключи в `ENV_TEMPLATE`**
+
+В `_ENV_TEMPLATE_BASE` секцию
+`# --- Postgres (ParadeDB :5433) / Neo4j (:7687) — дефолты docker-compose ---` дополнить после
+`NEO4J_PASSWORD=reviewerpass`:
+
+```
+# Публикуемые (хостовые) порты docker compose; контейнерные порты фиксированы.
+PARADEDB_PUBLISH_PORT=5433
+NEO4J_BOLT_PUBLISH_PORT=7687
+NEO4J_HTTP_PUBLISH_PORT=7474
+```
+
+- [ ] **Step 5: Синхронизировать `.env.example`**
+
+В `.env.example` в секции `Postgres (ParadeDB: pgvector + pg_search) / Neo4j` после
+`NEO4J_PASSWORD=reviewerpass` (строка 60) дописать:
+
+```
+# Публикуемые (хостовые) порты docker compose; контейнерные порты (5432/7687/7474) фиксированы.
+# reviewer init выводит первые два из PG_DSN/NEO4J_URI.
+PARADEDB_PUBLISH_PORT=5433
+NEO4J_BOLT_PUBLISH_PORT=7687
+NEO4J_HTTP_PUBLISH_PORT=7474
+```
+
+Блок `TEST_*` (строки 62-71) не трогать.
+
+- [ ] **Step 6: Запустить тесты и убедиться, что они проходят**
+
+Run: `.venv/bin/pytest tests/install/test_install_wizard.py -q`
+Expected: PASS. Особое внимание — два существующих guard-теста паритета: `ENV_TEMPLATE` ↔
+`.env.example` (около строки 521) и «в `ENV_TEMPLATE` есть все ключи wizard» (около строки 535).
+Оба зелёные только если шаги 3-5 внесены согласованно.
+
+- [ ] **Step 7: Линт и коммит**
+
+```bash
+.venv/bin/ruff check reviewer/install.py tests/install/test_install_wizard.py
+git add reviewer/install.py .env.example tests/install/test_install_wizard.py
+git commit -m "feat(install): publish-порты хранилищ в wizard, ENV_TEMPLATE и .env.example"
+```
+
+---
+
+### Task 4: Предупреждение о расхождении publish-порта с DSN/URI
+
+**Files:**
+- Modify: `reviewer/install.py` (новая публичная функция рядом с `_effective_default`),
+  `reviewer/entrypoints/cli.py:1419-1422` (после сбора `values`, до `render_env`)
+- Test: `tests/install/test_install_wizard.py`
+
+**Interfaces:**
+- Consumes: `install._port_from_url` (задача 2), ключи publish-портов (задача 3).
+- Produces: `install.publish_port_warnings(values: Mapping[str, str]) -> list[str]` — список
+  готовых текстов предупреждений (пустой, когда всё согласовано).
+
+- [ ] **Step 1: Написать падающие тесты**
+
+Добавить в конец `tests/install/test_install_wizard.py`:
+
+```python
+def test_publish_port_warnings_reports_local_mismatch():
+    warnings = inst.publish_port_warnings(
+        {
+            "PG_DSN": "postgresql://reviewer:reviewer@localhost:6543/reviewer",
+            "PARADEDB_PUBLISH_PORT": "5433",
+            "NEO4J_URI": "neo4j://localhost:7687",
+            "NEO4J_BOLT_PUBLISH_PORT": "7687",
+        }
+    )
+
+    assert len(warnings) == 1
+    assert "PARADEDB_PUBLISH_PORT" in warnings[0]
+    assert "6543" in warnings[0]
+    assert "5433" in warnings[0]
+
+
+def test_publish_port_warnings_silent_when_ports_agree():
+    assert inst.publish_port_warnings(
+        {
+            "PG_DSN": "postgresql://reviewer:reviewer@localhost:5433/reviewer",
+            "PARADEDB_PUBLISH_PORT": "5433",
+            "NEO4J_URI": "neo4j://localhost:7687",
+            "NEO4J_BOLT_PUBLISH_PORT": "7687",
+        }
+    ) == []
+
+
+def test_publish_port_warnings_ignore_remote_hosts():
+    # Внешнее хранилище: publish-порт compose к этому подключению отношения не имеет
+    assert inst.publish_port_warnings(
+        {
+            "PG_DSN": "postgresql://reviewer:reviewer@db.internal:5432/reviewer",
+            "PARADEDB_PUBLISH_PORT": "5433",
+            "NEO4J_URI": "neo4j://graph.internal:7687",
+            "NEO4J_BOLT_PUBLISH_PORT": "7687",
+        }
+    ) == []
+
+
+def test_publish_port_warnings_ignore_unparsable_or_missing_values():
+    assert inst.publish_port_warnings({}) == []
+    assert inst.publish_port_warnings(
+        {"PG_DSN": "not a url", "PARADEDB_PUBLISH_PORT": "5433"}
+    ) == []
+    assert inst.publish_port_warnings(
+        {"PG_DSN": "postgresql://reviewer@localhost/reviewer", "PARADEDB_PUBLISH_PORT": "5433"}
+    ) == []
+
+
+def test_publish_port_warnings_reports_both_pairs():
+    warnings = inst.publish_port_warnings(
+        {
+            "PG_DSN": "postgresql://reviewer:reviewer@127.0.0.1:6543/reviewer",
+            "PARADEDB_PUBLISH_PORT": "5433",
+            "NEO4J_URI": "neo4j://localhost:7999",
+            "NEO4J_BOLT_PUBLISH_PORT": "7687",
+        }
+    )
+
+    assert len(warnings) == 2
+
+
+def test_init_yes_warns_about_port_mismatch(tmp_path, monkeypatch):
+    dest = tmp_path / ".env"
+    dest.write_text(
+        "VOYAGE_API_KEY=sk-test\n"
+        "PG_DSN=postgresql://reviewer:reviewer@localhost:6543/reviewer\n"
+        "PARADEDB_PUBLISH_PORT=5433\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr("reviewer.install.default_env_path", lambda: dest)
+
+    result = CliRunner().invoke(cli, ["init", "--scope", "global", "--yes"])
+
+    assert result.exit_code == 0, result.output
+    assert "PARADEDB_PUBLISH_PORT" in result.output
+    assert "6543" in result.output
+```
+
+- [ ] **Step 2: Запустить тесты и убедиться, что они падают**
+
+Run: `.venv/bin/pytest tests/install/test_install_wizard.py -q -k "publish_port_warnings or port_mismatch"`
+Expected: FAIL — `AttributeError: module 'reviewer.install' has no attribute
+'publish_port_warnings'`.
+
+- [ ] **Step 3: Реализовать сверку в `install.py`**
+
+Добавить рядом с `_effective_default`:
+
+```python
+# Хосты, для которых publish-порт docker compose и порт клиентской строки — одно и то же.
+_LOCAL_HOSTS = frozenset({"localhost", "127.0.0.1", "::1"})
+
+# Пары «клиентская строка → переменная публикуемого порта». HTTP-порт Neo4j не сверяется:
+# в NEO4J_URI его нет, выводить не из чего.
+_PUBLISH_PORT_PAIRS: tuple[tuple[str, str], ...] = (
+    ("PG_DSN", "PARADEDB_PUBLISH_PORT"),
+    ("NEO4J_URI", "NEO4J_BOLT_PUBLISH_PORT"),
+)
+
+
+def publish_port_warnings(values: Mapping[str, str]) -> list[str]:
+    """Расхождения publish-порта compose с портом локальной строки подключения.
+
+    Сверяем только локальный хост: при внешнем Postgres/Neo4j публикуемый порт
+    контейнера к подключению отношения не имеет, и предупреждение было бы ложным.
+    """
+    warnings: list[str] = []
+    for url_key, port_key in _PUBLISH_PORT_PAIRS:
+        url = (values.get(url_key) or "").strip()
+        published = (values.get(port_key) or "").strip()
+        if not url or not published:
+            continue
+        try:
+            parsed = urlsplit(url)
+            host = (parsed.hostname or "").lower()
+            port = parsed.port
+        except ValueError:
+            continue
+        if host not in _LOCAL_HOSTS or port is None:
+            continue
+        if str(port) != published:
+            warnings.append(
+                f"{url_key} указывает порт {port}, а {port_key}={published}: "
+                f"контейнер опубликует {published}, и подключение не сойдётся."
+            )
+    return warnings
+```
+
+Если `Mapping` ещё не импортирован в `reviewer/install.py`, добавить в шапку
+`from collections.abc import Callable, Mapping` (объединив с импортом из задачи 2).
+
+- [ ] **Step 4: Печатать предупреждения в `reviewer init`**
+
+В `reviewer/entrypoints/cli.py` в команде `init`, сразу после строки
+`extra = {key: value for key, value in current.items() if key not in wizard_keys}` (строка 1421) и
+**до** `content = inst.render_env(values, extra)`:
+
+```python
+            for warning in inst.publish_port_warnings(values):
+                click.echo(f"⚠ {warning}")
+```
+
+Расположение покрывает обе ветки сбора `values` — интерактивную и `--yes`. Код возврата и
+содержимое `.env` не меняются.
+
+- [ ] **Step 5: Запустить тесты и убедиться, что они проходят**
+
+Run: `.venv/bin/pytest tests/install/test_install_wizard.py -q`
+Expected: PASS.
+
+- [ ] **Step 6: Прогнать весь unit-набор**
+
+Run: `.venv/bin/pytest -q`
+Expected: PASS (integration исключены настройкой `addopts` в `pyproject.toml`).
+
+- [ ] **Step 7: Линт и коммит**
+
+```bash
+.venv/bin/ruff check reviewer/install.py reviewer/entrypoints/cli.py tests/install/test_install_wizard.py
+git add reviewer/install.py reviewer/entrypoints/cli.py tests/install/test_install_wizard.py
+git commit -m "feat(install): предупреждение о расхождении publish-порта с DSN/URI"
+```
+
+---
+
+### Task 5: Документация в README.md и README.ru.md
+
+**Files:**
+- Modify: `README.md` (раздел `### Required services and credentials`, строки 311-326),
+  `README.ru.md` (раздел `### Сервисы и credentials`, строки 316-331)
+- Test: `tests/docs/test_readme_onboarding.py` (новый тест рядом с
+  `test_readmes_document_web_container_runtime_ports`, строка 249)
+
+**Interfaces:**
+- Consumes: имена переменных и дефолты из задач 1 и 3; статус `preserved` апдейтера
+  (`reviewer/update_lifecycle.py:189-220`).
+- Produces: ничего (терминальная задача).
+
+- [ ] **Step 1: Написать падающий guard-тест**
+
+Добавить в `tests/docs/test_readme_onboarding.py` после
+`test_readmes_document_web_container_runtime_ports`:
+
+```python
+def test_readmes_document_storage_publish_ports() -> None:
+    for filename, heading in (
+        ("README.md", "### Required services and credentials"),
+        ("README.ru.md", "### Сервисы и credentials"),
+    ):
+        section = _section(_read(filename), heading)
+        for marker in (
+            "PARADEDB_PUBLISH_PORT",
+            "NEO4J_BOLT_PUBLISH_PORT",
+            "NEO4J_HTTP_PUBLISH_PORT",
+            "preserved",
+        ):
+            assert marker in section, (filename, marker)
+```
+
+- [ ] **Step 2: Запустить тест и убедиться, что он падает**
+
+Run: `.venv/bin/pytest tests/docs/test_readme_onboarding.py::test_readmes_document_storage_publish_ports -q`
+Expected: FAIL — маркера `PARADEDB_PUBLISH_PORT` в разделе нет.
+
+- [ ] **Step 3: Дописать абзац в `README.md`**
+
+В `README.md` в разделе `### Required services and credentials` после строки
+`- board credentials: provider-specific env declared in the registry.` и пустой строки вставить:
+
+```markdown
+Published host ports of the Compose storage services are variables, not literals:
+`PARADEDB_PUBLISH_PORT` (default `5433`), `NEO4J_BOLT_PUBLISH_PORT` (default `7687`) and
+`NEO4J_HTTP_PUBLISH_PORT` (default `7474`). Container ports stay fixed. `reviewer init` asks for
+them in the storage group and derives the first two from `PG_DSN` and `NEO4J_URI`, so the client
+string and the published port cannot drift apart silently; a mismatch on a local host prints a
+warning without blocking.
+
+```bash
+PARADEDB_PUBLISH_PORT=6543 NEO4J_BOLT_PUBLISH_PORT=7999 \
+  docker compose -f ~/.config/rag-reviewer/docker-compose.yml up -d
+```
+
+Prefer variables over editing the Compose file: a hand-edited
+`~/.config/rag-reviewer/docker-compose.yml` no longer matches its recorded hash, so `reviewer
+update` treats it as user-modified (status `preserved`) and stops delivering new Compose
+definitions to it.
+```
+
+- [ ] **Step 4: Дописать зеркальный абзац в `README.ru.md`**
+
+В `README.ru.md` в разделе `### Сервисы и credentials` после строки
+`- board credentials: provider-specific env из registry.` и пустой строки вставить:
+
+```markdown
+Публикуемые хостовые порты storage-сервисов Compose заданы переменными, а не литералами:
+`PARADEDB_PUBLISH_PORT` (дефолт `5433`), `NEO4J_BOLT_PUBLISH_PORT` (дефолт `7687`) и
+`NEO4J_HTTP_PUBLISH_PORT` (дефолт `7474`). Контейнерные порты фиксированы. `reviewer init`
+спрашивает их в группе хранилищ и выводит первые два из `PG_DSN` и `NEO4J_URI`, поэтому строка
+подключения и публикуемый порт не разъезжаются молча; расхождение на локальном хосте печатает
+предупреждение, но не блокирует.
+
+```bash
+PARADEDB_PUBLISH_PORT=6543 NEO4J_BOLT_PUBLISH_PORT=7999 \
+  docker compose -f ~/.config/rag-reviewer/docker-compose.yml up -d
+```
+
+Настраивайте переменными, а не правкой Compose-файла: отредактированный вручную
+`~/.config/rag-reviewer/docker-compose.yml` перестаёт совпадать с записанным hash, поэтому
+`reviewer update` считает его изменённым пользователем (статус `preserved`) и больше не доставляет
+в него новые Compose-описания.
+```
+
+- [ ] **Step 5: Запустить тесты документации**
+
+Run: `.venv/bin/pytest tests/docs/ -q`
+Expected: PASS — новый тест и существующие guard-тесты паритета README
+(`test_readmes_share_content_section_order`, `test_all_readme_links_and_local_anchors_resolve`).
+
+- [ ] **Step 6: Прогнать весь unit-набор**
+
+Run: `.venv/bin/pytest -q`
+Expected: PASS.
+
+- [ ] **Step 7: Коммит**
+
+```bash
+git add README.md README.ru.md tests/docs/test_readme_onboarding.py
+git commit -m "docs(readme): настраиваемые publish-порты хранилищ и ограничение preserved"
+```
+
+---
+
+## Ручная приёмка (после всех задач)
+
+Критерии 2 и 3 требуют живого стека и в unit-тесты не выносятся.
+
+- [ ] `docker compose config` без переменных → публикуются `5433`, `7474`, `7687` (критерий 1).
+- [ ] `PARADEDB_PUBLISH_PORT=6543 NEO4J_BOLT_PUBLISH_PORT=7999 docker compose up -d` → порты
+      подняты; `PG_DSN`/`NEO4J_URI` с теми же портами → `reviewer check` проходит (критерий 2).
+- [ ] `reviewer init` с нестандартным портом в `PG_DSN` → мастер предлагает выведенный
+      publish-порт; итоговый `.env` согласован; стек поднимается без правки compose (критерий 3).
+- [ ] Вернуть окружение к дефолтным портам (`docker compose up -d` без переменных).

--- a/docs/superpowers/specs/2026-08-12-pri-241-storage-publish-ports-design.md
+++ b/docs/superpowers/specs/2026-08-12-pri-241-storage-publish-ports-design.md
@@ -54,13 +54,22 @@ neo4j:
 derive_default: Callable[[dict[str, str]], str] | None = None
 ```
 
-`prompt_groups` (`reviewer/install.py:385-...`) вычисляет эффективный дефолт как
+`prompt_groups` (`reviewer/install.py:385-434`) получает общий хелпер
 
 ```python
-effective_default = cur or (
-    field.derive_default(values) if field.derive_default is not None else field.default
-)
+def _effective_default(field, values, current) -> str:
+    cur = current.get(field.key, "")
+    if cur:
+        return cur
+    if field.derive_default is not None:
+        return field.derive_default(values)
+    return field.default
 ```
+
+Хелпер применяется во **всех трёх** местах, где сейчас вычисляется `cur or field.default`:
+в основном цикле опроса и в двух ранних ветках опциональной группы (`yes=True` и отказ от
+`confirm`). Группа «Хранилища» именно опциональная, поэтому без правки коротких веток
+`reviewer init --yes` молча игнорировал бы производный дефолт.
 
 Приоритет существующего значения из `.env` (`cur`) сохраняется без изменений. Порядок полей
 внутри группы гарантирует, что `PG_DSN`/`NEO4J_URI` уже лежат в `values`, когда очередь доходит

--- a/docs/superpowers/specs/2026-08-12-pri-241-storage-publish-ports-design.md
+++ b/docs/superpowers/specs/2026-08-12-pri-241-storage-publish-ports-design.md
@@ -1,0 +1,189 @@
+# PRI-241 — Параметризация хостовых портов Postgres/Neo4j в compose и wizard
+
+Бриф: `docs/superpowers/briefs/2026-08-12-PRI-241-parametrize-storage-publish-ports.md`
+
+## Проблема
+
+Хостовые порты storage-сервисов зашиты в `docker-compose.yml` литералами
+(`docker-compose.yml:9`, `docker-compose.yml:15`), а install-wizard их не знает: он собирает
+только клиентские строки подключения `PG_DSN`/`NEO4J_URI` (`reviewer/install.py:252-270`) и пишет
+их в `.env`. Смена порта в мастере тихо ломает подключение — клиент идёт на новый порт, а
+контейнер продолжает публиковать старый.
+
+Сервис `web` уже параметризован по нужному образцу (`docker-compose.yml:26-30`,
+`"127.0.0.1:${REVIEWER_WEB_PUBLISH_PORT:-8000}:${REVIEWER_WEB_PORT:-8000}"`, прецедент PRI-222 /
+PR #162), но его переменные задаются вручную в shell — wizard их не пишет. PRI-241 впервые
+заводит publish-порт под управление мастера.
+
+Дополнительной проводки переменных не требуется: `.env` (`reviewer/install.py:437-440`) и
+`docker-compose.yml` (`reviewer/update_lifecycle.py:96-99,190`) лежат в одном каталоге
+`$XDG_CONFIG_HOME/rag-reviewer`, поэтому compose подхватывает то, что записал wizard.
+
+## Архитектура
+
+Три новые переменные окружения владеют хостовой стороной port mapping; контейнерные порты
+(5432 / 7687 / 7474) и loopback-биндинг остаются фиксированными — они не предмет настройки.
+
+| Переменная | Дефолт | Источник дефолта в wizard |
+|---|---|---|
+| `PARADEDB_PUBLISH_PORT` | `5433` | порт из `PG_DSN` |
+| `NEO4J_BOLT_PUBLISH_PORT` | `7687` | порт из `NEO4J_URI` |
+| `NEO4J_HTTP_PUBLISH_PORT` | `7474` | статичный (в `NEO4J_URI` только bolt-порт) |
+
+### 1. `docker-compose.yml`
+
+```yaml
+paradedb:
+  ports: ["127.0.0.1:${PARADEDB_PUBLISH_PORT:-5433}:5432"]
+neo4j:
+  ports: ["127.0.0.1:${NEO4J_HTTP_PUBLISH_PORT:-7474}:7474",
+          "127.0.0.1:${NEO4J_BOLT_PUBLISH_PORT:-7687}:7687"]
+```
+
+`${VAR:-default}` даёт обратную совместимость: без переменных `docker compose config`
+разворачивается в прежние `127.0.0.1:5433:5432`, `127.0.0.1:7474:7474`, `127.0.0.1:7687:7687`.
+Сервисы `paradedb-test` / `neo4j-test` (`docker-compose.yml:49,63`) не изменяются: их порты
+изолированы намеренно и не должны совпадать с dev.
+
+### 2. `reviewer/install.py`
+
+**`EnvField.derive_default`** — новое опциональное поле dataclass
+(`reviewer/install.py:105-124`):
+
+```python
+derive_default: Callable[[dict[str, str]], str] | None = None
+```
+
+`prompt_groups` (`reviewer/install.py:385-...`) вычисляет эффективный дефолт как
+
+```python
+effective_default = cur or (
+    field.derive_default(values) if field.derive_default is not None else field.default
+)
+```
+
+Приоритет существующего значения из `.env` (`cur`) сохраняется без изменений. Порядок полей
+внутри группы гарантирует, что `PG_DSN`/`NEO4J_URI` уже лежат в `values`, когда очередь доходит
+до производного поля. Один и тот же путь работает в интерактивном режиме и в `--yes`/CI —
+отдельной ветки не появляется.
+
+**`_port_from_url(value: str, fallback: str) -> str`** — чистая функция на уже импортированном
+`urlsplit` (`reviewer/install.py:23`). Возвращает `fallback`, если URL не разбирается
+(`ValueError`), порт отсутствует или значение пустое. Fail-soft: мастер не должен падать на
+кривом DSN, который пользователь как раз пришёл исправлять.
+
+**`publish_port_warnings(values: dict[str, str]) -> list[str]`** — чистая сверка, возвращающая
+готовые тексты предупреждений (без I/O и без `click`). Правила:
+
+- Сверяются только две пары: `PG_DSN` ↔ `PARADEDB_PUBLISH_PORT` и
+  `NEO4J_URI` ↔ `NEO4J_BOLT_PUBLISH_PORT`.
+- `NEO4J_HTTP_PUBLISH_PORT` в сверку не входит — у него нет источника вывода.
+- **Сверка выполняется только когда хост в DSN/URI локальный** (`localhost`, `127.0.0.1`, `::1`).
+  Внешний Postgres/Neo4j означает, что publish-порт compose-контейнера к этому подключению
+  отношения не имеет, и предупреждение было бы ложным шумом.
+- Неразбираемый URL → предупреждения нет (сверять нечего).
+
+### 3. Группа wizard «Хранилища (Postgres / Neo4j)»
+
+Три новых `EnvField` добавляются в группу (`reviewer/install.py:252-270`) после `PG_DSN` и
+`NEO4J_URI`. Группа остаётся `optional=True`, то есть в интерактивном мастере предваряется
+вопросом «Настроить Хранилища (Postgres / Neo4j)?» с дефолтом «нет» — прежний путь онбординга
+не удлиняется для тех, кому дефолты подходят.
+
+`render_env` (`reviewer/install.py:313-334`) печатает новые ключи автоматически, поскольку они
+поля группы; заголовок секции (`_GROUP_HEADERS`, `reviewer/install.py:296-298`) не меняется.
+
+`ENV_TEMPLATE` (`_ENV_TEMPLATE_BASE`, секция
+`# --- Postgres (ParadeDB :5433) / Neo4j (:7687) — дефолты docker-compose ---`) и `.env.example`
+(строки 52-60) получают те же три ключа с теми же дефолтами. Существующий тест
+`test_env_template_contains_all_wizard_keys` (`tests/install/test_install_wizard.py:187-191`)
+удерживает этот паритет.
+
+### 4. `reviewer/entrypoints/cli.py::init`
+
+После сбора `values` (обе ветки — интерактивная `prompt_groups(...)` и `--yes`, см.
+`reviewer/entrypoints/cli.py:1356` и `:1419`) и перед формированием `_GlobalInitPlan` команда
+печатает каждое предупреждение из `inst.publish_port_warnings(values)` строкой вида
+`⚠ <текст>`. Поведение не блокирующее: код возврата и содержимое `.env` не меняются.
+
+Расположение сверки в конце покрывает три случая одной проверкой: интерактивный ввод, `--yes`/CI
+и унаследованный `.env`, в котором значения разъехались до этой задачи.
+
+## Поток данных
+
+```
+reviewer init → .env ($XDG_CONFIG_HOME/rag-reviewer/.env)
+                  ↓ (общий каталог, тот же compose project)
+        docker-compose.yml ${PARADEDB_PUBLISH_PORT:-5433} → публикуемый порт
+                  ↓
+        PG_DSN / NEO4J_URI из того же .env → reviewer check / index / MCP
+```
+
+Новой проводки не появляется: единственная связь — общий каталог `.env` и `docker-compose.yml`,
+который compose читает сам.
+
+## Обработка ошибок
+
+| Ситуация | Поведение |
+|---|---|
+| `PG_DSN`/`NEO4J_URI` не разбирается или без порта | `_port_from_url` возвращает статичный fallback; мастер продолжает |
+| Publish-порт разошёлся с портом локального DSN | предупреждение в `init`, запись `.env` выполняется |
+| DSN указывает на внешний хост | предупреждения нет |
+| Пользователь пропустил группу «Хранилища» | значения = существующие из `.env` или дефолты (прежнее поведение `prompt_groups`) |
+
+## Тестирование
+
+**`tests/test_infrastructure_policy.py`** (паттерн
+`test_compose_web_service_is_opt_in_with_separate_runtime_ports`, `:350`): `yaml.safe_load`
+`docker-compose.yml`, сверка литералов `ports` у `paradedb` и `neo4j` с
+`${VAR:-default}`-шаблонами. Отдельным ассертом фиксируется, что порты `paradedb-test` /
+`neo4j-test` остались прежними литералами (`55433`, `17474`/`17687`) — критерий 5. Без Docker и
+сети, идёт в обычном `pytest`.
+
+Живой `docker compose config` (буквальная формулировка критериев 1 и 2) остаётся ручной
+приёмкой: юнит-проверка шаблона вместе с `:-default` подстановкой доказывает обратную
+совместимость, а поднимать Docker в unit-прогоне запрещено конвенцией репозитория.
+
+**`tests/install/test_install_wizard.py`** (паттерны `:62-75`, `:346-401`):
+
+1. `render_env` со значениями по умолчанию содержит все три новых ключа.
+2. `derive_default` выводит порт из нестандартного `PG_DSN` (`...@localhost:6543/reviewer` → `6543`)
+   и из нестандартного `NEO4J_URI` (`neo4j://localhost:7999` → `7999`).
+3. Невалидный/беспортовый DSN → статичный fallback (`5433` / `7687`).
+4. Существующее значение в `.env` перебивает производный дефолт.
+5. `publish_port_warnings` возвращает предупреждение при расхождении на локальном хосте, пустой
+   список — при совпадении, при внешнем хосте и при неразбираемом URL.
+
+## Документация
+
+README.md и README.ru.md обновляются синхронно, абзацем рядом с существующим примером
+`REVIEWER_WEB_PORT` / `REVIEWER_WEB_PUBLISH_PORT` (`README.md:797`, `README.ru.md:786`):
+
+- публикуемые порты storage-сервисов настраиваются переменными `PARADEDB_PUBLISH_PORT`,
+  `NEO4J_BOLT_PUBLISH_PORT`, `NEO4J_HTTP_PUBLISH_PORT`, и `reviewer init` записывает их в `.env`
+  согласованно с `PG_DSN`/`NEO4J_URI`;
+- вручную отредактированный `docker-compose.yml` апдейтер не перезаписывает: сравнение SHA256
+  всего файла переводит его в статус `preserved` (`reviewer/update_lifecycle.py:189-220`), и
+  обновления шаблона из репозитория перестают применяться. Это аргумент за настройку
+  переменными вместо правки файла руками.
+
+## Вне скоупа
+
+- Новые переменные не добавляются в `Settings` (`reviewer/config/settings.py`): их читает только
+  compose, не Python-код.
+- `reviewer check` не расширяется сверкой портов — диагностика живёт в `init`.
+- Поведение `preserved` у апдейтера не меняется, только документируется.
+- Тестовый профиль compose не трогается.
+
+## Критерии приёмки
+
+1. `docker compose config` без переменных даёт прежние `127.0.0.1:5433:5432`,
+   `127.0.0.1:7687:7687`, `127.0.0.1:7474:7474`.
+2. С заданными `PARADEDB_PUBLISH_PORT` / `NEO4J_BOLT_PUBLISH_PORT` compose публикует указанные
+   порты, и `reviewer check` проходит против них.
+3. После прогона wizard с нестандартным портом `.env` содержит согласованные publish-порт и
+   DSN/URI, стек поднимается без ручной правки compose.
+4. Unit-тесты в `tests/install/test_install_wizard.py` фиксируют новые поля, вывод дефолта из
+   DSN/URI и поведение сверки.
+5. Тестовый профиль в compose не изменён; порты test-сервисов по-прежнему отличаются от dev.
+6. README.md и README.ru.md обновлены синхронно.

--- a/reviewer/entrypoints/cli.py
+++ b/reviewer/entrypoints/cli.py
@@ -1419,6 +1419,8 @@ def init(
                 values = inst.prompt_groups(groups, current=current, yes=True)
 
             extra = {key: value for key, value in current.items() if key not in wizard_keys}
+            for warning in inst.publish_port_warnings(values):
+                click.echo(f"⚠ {warning}")
             content = inst.render_env(values, extra)
             if dest.is_file() and dest.read_text(encoding="utf-8") == content:
                 action = "noop"

--- a/reviewer/install.py
+++ b/reviewer/install.py
@@ -122,6 +122,9 @@ class EnvField:
     default: str = ""
     secret: bool = False
     required: bool = False
+    # Дефолт, выводимый из уже собранных значений (напр. порт из PG_DSN).
+    # None — статичный default.
+    derive_default: Callable[[dict[str, str]], str] | None = None
 
 
 @dataclass
@@ -382,6 +385,29 @@ def render_env_preview(values: dict[str, str], extra: dict[str, str]) -> str:
     return render_env(safe_values, safe_extra)
 
 
+def _port_from_url(value: str, fallback: str) -> str:
+    """Порт из URL (DSN/URI) строкой; fallback при пустом/кривом URL или URL без порта."""
+    try:
+        port = urlsplit((value or "").strip()).port
+    except ValueError:
+        return fallback
+    return str(port) if port else fallback
+
+
+def _effective_default(
+    field: EnvField,
+    values: dict[str, str],
+    current: dict[str, str],
+) -> str:
+    """Дефолт поля: значение из .env → производный (derive_default) → статичный."""
+    cur = current.get(field.key, "")
+    if cur:
+        return cur
+    if field.derive_default is not None:
+        return field.derive_default(values)
+    return field.default
+
+
 def prompt_groups(
     groups: list[EnvGroup],
     current: dict[str, str],
@@ -402,18 +428,18 @@ def prompt_groups(
             if yes:
                 # CI: сохраняем текущее или дефолт, не спрашиваем
                 for f in group.fields:
-                    values[f.key] = current.get(f.key, "") or f.default
+                    values[f.key] = _effective_default(f, values, current)
                 continue
             if not click.confirm(f"\nНастроить {group.title}?", default=False):
                 for f in group.fields:
-                    values[f.key] = current.get(f.key, "") or f.default
+                    values[f.key] = _effective_default(f, values, current)
                 continue
         elif not yes:
             click.echo(f"\n[{group.title}]")
 
         for field in group.fields:
             cur = current.get(field.key, "")
-            effective_default = cur or field.default
+            effective_default = _effective_default(field, values, current)
 
             if yes:
                 values[field.key] = effective_default

--- a/reviewer/install.py
+++ b/reviewer/install.py
@@ -75,6 +75,10 @@ PG_POOL_MAX_SIZE=4
 NEO4J_URI=neo4j://localhost:7687
 NEO4J_USER=neo4j
 NEO4J_PASSWORD=reviewerpass
+# Публикуемые (хостовые) порты docker compose; контейнерные порты фиксированы.
+PARADEDB_PUBLISH_PORT=5433
+NEO4J_BOLT_PUBLISH_PORT=7687
+NEO4J_HTTP_PUBLISH_PORT=7474
 
 # --- Граф кода: auto|scip|treesitter ---
 GRAPH_BACKEND=auto
@@ -268,6 +272,23 @@ WIZARD_GROUPS: list[EnvGroup] = [
                 prompt_text="NEO4J_PASSWORD",
                 default="reviewerpass",
                 secret=True,
+            ),
+            EnvField(
+                key="PARADEDB_PUBLISH_PORT",
+                prompt_text="PARADEDB_PUBLISH_PORT (публикуемый порт ParadeDB в docker compose)",
+                default="5433",
+                derive_default=lambda values: _port_from_url(values.get("PG_DSN", ""), "5433"),
+            ),
+            EnvField(
+                key="NEO4J_BOLT_PUBLISH_PORT",
+                prompt_text="NEO4J_BOLT_PUBLISH_PORT (публикуемый bolt-порт Neo4j)",
+                default="7687",
+                derive_default=lambda values: _port_from_url(values.get("NEO4J_URI", ""), "7687"),
+            ),
+            EnvField(
+                key="NEO4J_HTTP_PUBLISH_PORT",
+                prompt_text="NEO4J_HTTP_PUBLISH_PORT (публикуемый порт браузера Neo4j)",
+                default="7474",
             ),
         ],
     ),

--- a/reviewer/install.py
+++ b/reviewer/install.py
@@ -19,7 +19,7 @@ import shutil
 import tomllib
 from dataclasses import dataclass, field as _field
 from pathlib import Path, PureWindowsPath
-from typing import Callable
+from typing import Callable, Mapping
 from urllib.parse import urlsplit
 
 from reviewer.config.provider_access import ProviderAccessSpec
@@ -427,6 +427,45 @@ def _effective_default(
     if field.derive_default is not None:
         return field.derive_default(values)
     return field.default
+
+
+# Хосты, для которых publish-порт docker compose и порт клиентской строки — одно и то же.
+_LOCAL_HOSTS = frozenset({"localhost", "127.0.0.1", "::1"})
+
+# Пары «клиентская строка → переменная публикуемого порта». HTTP-порт Neo4j не сверяется:
+# в NEO4J_URI его нет, выводить не из чего.
+_PUBLISH_PORT_PAIRS: tuple[tuple[str, str], ...] = (
+    ("PG_DSN", "PARADEDB_PUBLISH_PORT"),
+    ("NEO4J_URI", "NEO4J_BOLT_PUBLISH_PORT"),
+)
+
+
+def publish_port_warnings(values: Mapping[str, str]) -> list[str]:
+    """Расхождения publish-порта compose с портом локальной строки подключения.
+
+    Сверяем только локальный хост: при внешнем Postgres/Neo4j публикуемый порт
+    контейнера к подключению отношения не имеет, и предупреждение было бы ложным.
+    """
+    warnings: list[str] = []
+    for url_key, port_key in _PUBLISH_PORT_PAIRS:
+        url = (values.get(url_key) or "").strip()
+        published = (values.get(port_key) or "").strip()
+        if not url or not published:
+            continue
+        try:
+            parsed = urlsplit(url)
+            host = (parsed.hostname or "").lower()
+            port = parsed.port
+        except ValueError:
+            continue
+        if host not in _LOCAL_HOSTS or port is None:
+            continue
+        if str(port) != published:
+            warnings.append(
+                f"{url_key} указывает порт {port}, а {port_key}={published}: "
+                f"контейнер опубликует {published}, и подключение не сойдётся."
+            )
+    return warnings
 
 
 def prompt_groups(

--- a/tests/docs/test_readme_onboarding.py
+++ b/tests/docs/test_readme_onboarding.py
@@ -263,6 +263,21 @@ def test_readmes_document_web_container_runtime_ports() -> None:
             assert marker in section, (filename, marker)
 
 
+def test_readmes_document_storage_publish_ports() -> None:
+    for filename, heading in (
+        ("README.md", "### Required services and credentials"),
+        ("README.ru.md", "### Сервисы и credentials"),
+    ):
+        section = _section(_read(filename), heading)
+        for marker in (
+            "PARADEDB_PUBLISH_PORT",
+            "NEO4J_BOLT_PUBLISH_PORT",
+            "NEO4J_HTTP_PUBLISH_PORT",
+            "preserved",
+        ):
+            assert marker in section, (filename, marker)
+
+
 def test_readmes_document_configuration_ownership_and_scenarios():
     cases = (
         (

--- a/tests/install/test_install_wizard.py
+++ b/tests/install/test_install_wizard.py
@@ -609,3 +609,48 @@ def test_prompt_groups_derive_default_falls_back_to_static_default():
         yes=True,
     )
     assert result["PROBE_PORT"] == "7687"
+
+
+PUBLISH_PORT_DEFAULTS = {
+    "PARADEDB_PUBLISH_PORT": "5433",
+    "NEO4J_BOLT_PUBLISH_PORT": "7687",
+    "NEO4J_HTTP_PUBLISH_PORT": "7474",
+}
+
+
+def test_storage_group_declares_publish_ports_with_compose_defaults():
+    group = next(
+        g for g in inst.WIZARD_GROUPS if g.title == "Хранилища (Postgres / Neo4j)"
+    )
+    declared = {f.key: f.default for f in group.fields}
+
+    for key, default in PUBLISH_PORT_DEFAULTS.items():
+        assert declared[key] == default
+
+
+def test_wizard_yes_derives_publish_ports_from_connection_strings():
+    current = {
+        "PG_DSN": "postgresql://reviewer:reviewer@localhost:6543/reviewer",
+        "NEO4J_URI": "neo4j://localhost:7999",
+    }
+    result = inst.prompt_groups(inst.WIZARD_GROUPS, current=current, yes=True)
+
+    assert result["PARADEDB_PUBLISH_PORT"] == "6543"
+    assert result["NEO4J_BOLT_PUBLISH_PORT"] == "7999"
+    # HTTP-порт неоткуда выводить: в NEO4J_URI только bolt
+    assert result["NEO4J_HTTP_PUBLISH_PORT"] == "7474"
+
+
+def test_wizard_yes_keeps_compose_defaults_without_current_values():
+    result = inst.prompt_groups(inst.WIZARD_GROUPS, current={}, yes=True)
+
+    for key, default in PUBLISH_PORT_DEFAULTS.items():
+        assert result[key] == default
+
+
+def test_render_env_writes_publish_ports():
+    values = {f.key: f.default for g in inst.WIZARD_GROUPS for f in g.fields}
+    rendered = inst.render_env(values, extra={})
+
+    for key, default in PUBLISH_PORT_DEFAULTS.items():
+        assert f"{key}={default}" in rendered

--- a/tests/install/test_install_wizard.py
+++ b/tests/install/test_install_wizard.py
@@ -654,3 +654,82 @@ def test_render_env_writes_publish_ports():
 
     for key, default in PUBLISH_PORT_DEFAULTS.items():
         assert f"{key}={default}" in rendered
+
+
+def test_publish_port_warnings_reports_local_mismatch():
+    warnings = inst.publish_port_warnings(
+        {
+            "PG_DSN": "postgresql://reviewer:reviewer@localhost:6543/reviewer",
+            "PARADEDB_PUBLISH_PORT": "5433",
+            "NEO4J_URI": "neo4j://localhost:7687",
+            "NEO4J_BOLT_PUBLISH_PORT": "7687",
+        }
+    )
+
+    assert len(warnings) == 1
+    assert "PARADEDB_PUBLISH_PORT" in warnings[0]
+    assert "6543" in warnings[0]
+    assert "5433" in warnings[0]
+
+
+def test_publish_port_warnings_silent_when_ports_agree():
+    assert inst.publish_port_warnings(
+        {
+            "PG_DSN": "postgresql://reviewer:reviewer@localhost:5433/reviewer",
+            "PARADEDB_PUBLISH_PORT": "5433",
+            "NEO4J_URI": "neo4j://localhost:7687",
+            "NEO4J_BOLT_PUBLISH_PORT": "7687",
+        }
+    ) == []
+
+
+def test_publish_port_warnings_ignore_remote_hosts():
+    # Внешнее хранилище: publish-порт compose к этому подключению отношения не имеет
+    assert inst.publish_port_warnings(
+        {
+            "PG_DSN": "postgresql://reviewer:reviewer@db.internal:5432/reviewer",
+            "PARADEDB_PUBLISH_PORT": "5433",
+            "NEO4J_URI": "neo4j://graph.internal:7687",
+            "NEO4J_BOLT_PUBLISH_PORT": "7687",
+        }
+    ) == []
+
+
+def test_publish_port_warnings_ignore_unparsable_or_missing_values():
+    assert inst.publish_port_warnings({}) == []
+    assert inst.publish_port_warnings(
+        {"PG_DSN": "not a url", "PARADEDB_PUBLISH_PORT": "5433"}
+    ) == []
+    assert inst.publish_port_warnings(
+        {"PG_DSN": "postgresql://reviewer@localhost/reviewer", "PARADEDB_PUBLISH_PORT": "5433"}
+    ) == []
+
+
+def test_publish_port_warnings_reports_both_pairs():
+    warnings = inst.publish_port_warnings(
+        {
+            "PG_DSN": "postgresql://reviewer:reviewer@127.0.0.1:6543/reviewer",
+            "PARADEDB_PUBLISH_PORT": "5433",
+            "NEO4J_URI": "neo4j://localhost:7999",
+            "NEO4J_BOLT_PUBLISH_PORT": "7687",
+        }
+    )
+
+    assert len(warnings) == 2
+
+
+def test_init_yes_warns_about_port_mismatch(tmp_path, monkeypatch):
+    dest = tmp_path / ".env"
+    dest.write_text(
+        "VOYAGE_API_KEY=sk-test\n"
+        "PG_DSN=postgresql://reviewer:reviewer@localhost:6543/reviewer\n"
+        "PARADEDB_PUBLISH_PORT=5433\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr("reviewer.install.default_env_path", lambda: dest)
+
+    result = CliRunner().invoke(cli, ["init", "--scope", "global", "--yes"])
+
+    assert result.exit_code == 0, result.output
+    assert "PARADEDB_PUBLISH_PORT" in result.output
+    assert "6543" in result.output

--- a/tests/install/test_install_wizard.py
+++ b/tests/install/test_install_wizard.py
@@ -536,3 +536,76 @@ def test_env_template_contains_all_wizard_keys():
     wizard_keys = {f.key for g in inst.WIZARD_GROUPS for f in g.fields}
     missing = wizard_keys - template_keys
     assert not missing, f"в ENV_TEMPLATE нет ключей wizard: {sorted(missing)}"
+
+
+def test_port_from_url_reads_explicit_port():
+    dsn = "postgresql://reviewer:reviewer@localhost:6543/reviewer"
+    assert inst._port_from_url(dsn, "5433") == "6543"
+    assert inst._port_from_url("neo4j://localhost:7999", "7687") == "7999"
+
+
+def test_port_from_url_falls_back_when_port_missing_or_broken():
+    assert inst._port_from_url("postgresql://reviewer@localhost/reviewer", "5433") == "5433"
+    assert inst._port_from_url("neo4j://localhost:not-a-port", "7687") == "7687"
+    assert inst._port_from_url("", "5433") == "5433"
+    assert inst._port_from_url("   ", "5433") == "5433"
+
+
+def _derived_probe_group(optional: bool) -> inst.EnvGroup:
+    """Группа из источника и производного от него поля — для проверки derive_default."""
+    return inst.EnvGroup(
+        title="Проба",
+        optional=optional,
+        fields=[
+            inst.EnvField(
+                key="PROBE_URI",
+                prompt_text="PROBE_URI",
+                default="neo4j://localhost:7687",
+            ),
+            inst.EnvField(
+                key="PROBE_PORT",
+                prompt_text="PROBE_PORT",
+                default="7687",
+                derive_default=lambda values: inst._port_from_url(
+                    values.get("PROBE_URI", ""), "7687"
+                ),
+            ),
+        ],
+    )
+
+
+def test_prompt_groups_derives_default_from_earlier_field():
+    result = inst.prompt_groups(
+        [_derived_probe_group(optional=False)],
+        current={"PROBE_URI": "neo4j://localhost:7999"},
+        yes=True,
+    )
+    assert result["PROBE_PORT"] == "7999"
+
+
+def test_prompt_groups_derives_default_in_optional_group():
+    # Опциональная группа при yes=True идёт коротким путём — derive_default обязан работать и там
+    result = inst.prompt_groups(
+        [_derived_probe_group(optional=True)],
+        current={"PROBE_URI": "neo4j://localhost:7999"},
+        yes=True,
+    )
+    assert result["PROBE_PORT"] == "7999"
+
+
+def test_prompt_groups_existing_value_beats_derived_default():
+    result = inst.prompt_groups(
+        [_derived_probe_group(optional=False)],
+        current={"PROBE_URI": "neo4j://localhost:7999", "PROBE_PORT": "7000"},
+        yes=True,
+    )
+    assert result["PROBE_PORT"] == "7000"
+
+
+def test_prompt_groups_derive_default_falls_back_to_static_default():
+    result = inst.prompt_groups(
+        [_derived_probe_group(optional=False)],
+        current={"PROBE_URI": "neo4j://localhost"},
+        yes=True,
+    )
+    assert result["PROBE_PORT"] == "7687"

--- a/tests/test_infrastructure_policy.py
+++ b/tests/test_infrastructure_policy.py
@@ -367,6 +367,20 @@ def test_compose_web_service_is_opt_in_with_separate_runtime_ports() -> None:
     assert web["depends_on"] == ["paradedb"]
 
 
+def test_compose_publishes_storage_ports_through_overridable_variables() -> None:
+    """Хостовые порты dev-хранилищ параметризованы, контейнерные — фиксированы."""
+    root = Path(__file__).parents[1]
+    compose = yaml.safe_load((root / "docker-compose.yml").read_text(encoding="utf-8"))
+
+    assert compose["services"]["paradedb"]["ports"] == [
+        "127.0.0.1:${PARADEDB_PUBLISH_PORT:-5433}:5432"
+    ]
+    assert compose["services"]["neo4j"]["ports"] == [
+        "127.0.0.1:${NEO4J_HTTP_PUBLISH_PORT:-7474}:7474",
+        "127.0.0.1:${NEO4J_BOLT_PUBLISH_PORT:-7687}:7687",
+    ]
+
+
 def test_env_example_documents_exact_test_endpoint_defaults() -> None:
     root = Path(__file__).parents[1]
     values = {


### PR DESCRIPTION
Задача: [PRI-241](https://ru.yougile.com/team/686c049c8af8/#PRI-241)

## Проблема

Хостовые порты storage-сервисов были зашиты в `docker-compose.yml` литералами, а install-wizard о них не знал — он собирал только клиентские строки `PG_DSN`/`NEO4J_URI`. Смена порта в мастере тихо ломала подключение: клиент шёл на новый порт, а контейнер продолжал публиковать старый.

## Что сделано

- **compose**: публикуемые порты `paradedb` и `neo4j` параметризованы по образцу сервиса `web` — `${PARADEDB_PUBLISH_PORT:-5433}`, `${NEO4J_BOLT_PUBLISH_PORT:-7687}`, `${NEO4J_HTTP_PUBLISH_PORT:-7474}`. Контейнерные порты и loopback-биндинг фиксированы; тестовый профиль не тронут.
- **wizard**: `EnvField` получил опциональный `derive_default`, а `prompt_groups` — общий хелпер `_effective_default`. Хелпер применён во **всех трёх** ветках вычисления дефолта, включая два коротких пути опциональной группы: без этого `reviewer init --yes` молча игнорировал бы производный дефолт (группа «Хранилища» именно опциональная).
- Три новых ключа добавлены в группу «Хранилища», `ENV_TEMPLATE` и `.env.example`; первые два выводят дефолт из `PG_DSN`/`NEO4J_URI`, у HTTP-порта Neo4j дефолт статичный (в URI его нет).
- **сверка**: чистая `publish_port_warnings(values)` печатает `⚠` в конце `reviewer init` — покрывает интерактив, `--yes`/CI и унаследованный разъехавшийся `.env`. Не блокирует запись.
- **README.md / README.ru.md** синхронно: как настраивать порты и почему предпочтительнее переменные, а не правка Compose-файла (ручная правка переводит файл в статус `preserved`, и обновления перестают доставляться).

### Почему сверка ограничена локальным хостом

Если `PG_DSN` смотрит на внешний Postgres (`db.internal:5432`), publish-порт контейнера к этому подключению отношения не имеет — безусловная сверка давала бы ложный шум. Поэтому предупреждение возникает только для `localhost`/`127.0.0.1`/`::1`.

## Проверка

Автотесты: 15 новых юнитов (`tests/install/test_install_wizard.py`, `tests/test_infrastructure_policy.py`, `tests/docs/test_readme_onboarding.py`). Полный прогон — 3877 passed.

Ручная приёмка на живом стеке:

| Критерий | Результат |
|---|---|
| 1. `docker compose config` без переменных | публикуются прежние `5433`/`7474`/`7687` |
| 2. Стек на `6543`/`7999` + `reviewer check` | контейнеры подняты на заданных портах, check полностью зелёный |
| 3. Wizard с нестандартным DSN | `.env` согласован: `PARADEDB_PUBLISH_PORT=6543`, `NEO4J_BOLT_PUBLISH_PORT=7999` |
| 5. Тестовый профиль | не изменён (`55433`, `17474`/`17687`) |

Расхождение проверено отдельно: локальная пара даёт предупреждение, внешний хост молчит, запись `.env` не блокируется. Окружение возвращено к дефолтным портам.

## Вне скоупа

Новые переменные не заводятся в `Settings` (их читает только compose), `reviewer check` не расширяется, поведение `preserved` у апдейтера не меняется — только документируется.

Спека: `docs/superpowers/specs/2026-08-12-pri-241-storage-publish-ports-design.md`
