### PR TITLE
fix(ci): сканер плагина смотрит на plugin/, а не на весь репозиторий

### DIFF
--- a/.github/workflows/hol-plugin-scanner.yml
+++ b/.github/workflows/hol-plugin-scanner.yml
@@ -18,7 +18,10 @@ jobs:
       - name: HOL Plugin Scanner
         uses: hashgraph-online/ai-plugin-scanner-action@8f0a503ca2a70c1968a9a883e11fdff5737b7909  # v1
         with:
-          plugin_dir: "."
+          # Сканируем сам плагин, а не весь репозиторий: при plugin_dir "." в скан
+          # попадали eval-репорты, и энтропийная эвристика принимала имена файлов
+          # планов в markdown-таблицах за секреты (high → падение по fail_on_severity).
+          plugin_dir: "plugin"
           mode: scan
           min_score: 80
           fail_on_severity: high


### PR DESCRIPTION
## Проблема

Джоба `HOL Plugin Scanner` на main упала после релиза 0.5.0: `Findings met or exceeded the "high" severity threshold` (run 31882660000). SARIF-аплоад при этом пропускается, поэтому находок ни в логах, ни в Security нет.

## Причина

Экшен и сам сканер запинены (`@8f0a503…`, `plugin-scanner==2.0.1116`), конфиг не менялся — регрессия от контента 0.5.0. Воспроизвёл локально тем же запиненным сканером по чистому `git archive origin/main`:

| скоуп | score | grade | high |
|---|---|---|---|
| весь репозиторий (`plugin_dir: "."`) | 91 | A | 8 |
| `plugin/` | 94 | A | 0 |

Все 8 high — один тип `HARDCODED_SECRET`, ровно в двух местах: `eval/solve_task_metrics_report.md:88` и `eval/pri246_report.md:143`. Оба файла появились в 0.5.0 (в `v0.4.11` их в дереве нет). Это строки markdown-таблиц вида `| PRI-221 | 2026-07-30-PRI-221-home-repository-config-layer.md | 34 | 9 | 0 | 0 | 0% |` — энтропийная эвристика приняла длинное имя файла плана за секрет. Реальных секретов там нет.

## Решение

`plugin_dir: "plugin"` — сканер плагинов смотрит на плагин. Побочно уходит шум от эвал-артефактов и прочего, что к поставляемому плагину отношения не имеет; хуки и скиллы (`plugin/hooks`, `plugin/skills`) остаются в скоупе, как и `README.md`/`SECURITY.md`/`LICENSE` внутри `plugin/`.

`policy_pass` и `min_score: 80` выполнялись в обоих случаях — падение было только по `fail_on_severity: high`.