### PR TITLE
fix(ci): сканер плагина смотрит на plugin/, а не на весь репозиторий

### DIFF
--- a/.github/workflows/hol-plugin-scanner.yml
+++ b/.github/workflows/hol-plugin-scanner.yml
@@ -18,7 +18,10 @@ jobs:
       - name: HOL Plugin Scanner
         uses: hashgraph-online/ai-plugin-scanner-action@8f0a503ca2a70c1968a9a883e11fdff5737b7909  # v1
         with:
-          plugin_dir: "."
+          # Сканируем сам плагин, а не весь репозиторий: при plugin_dir "." в скан
+          # попадали eval-репорты, и энтропийная эвристика принимала имена файлов
+          # планов в markdown-таблицах за секреты (high → падение по fail_on_severity).
+          plugin_dir: "plugin"
           mode: scan
           min_score: 80
           fail_on_severity: high


### PR DESCRIPTION
Мерж `dev` → `main` с единственным изменением — фиксом упавшей на 0.5.0 джобы `HOL Plugin Scanner` (PR #206).

## Проблема

После релиза 0.5.0 джоба упала: `Findings met or exceeded the "high" severity threshold` (run 31882660000). SARIF-аплоад при этом пропускается, поэтому находок ни в логах, ни в Security не видно.

## Причина

Экшен и сканер запинены (`@8f0a503…`, `plugin-scanner==2.0.1116`), конфиг не менялся — регрессия от контента 0.5.0. Воспроизведено локально тем же запиненным сканером по чистому дереву `main`:

| скоуп | score | grade | high |
|---|---|---|---|
| весь репозиторий (`plugin_dir: "."`) | 91 | A | 8 |
| `plugin/` | 94 | A | 0 |

Все 8 high — `HARDCODED_SECRET` ровно в двух местах: `eval/solve_task_metrics_report.md:88` и `eval/pri246_report.md:143`. Оба файла появились в 0.5.0 (в `v0.4.11` их в дереве нет). Это строки markdown-таблиц вида `| PRI-221 | 2026-07-30-PRI-221-home-repository-config-layer.md | 34 | 9 | 0 | 0 | 0% |` — энтропийная эвристика приняла длинное имя файла плана за секрет. Секретов там нет.

## Решение

`plugin_dir: "plugin"` — сканер плагинов смотрит на плагин. Хуки и скиллы остаются в скоупе, уходит шум от эвал-артефактов.

## Без бампа версии

Меняется только workflow: ни пакет, ни `plugin/` не затронуты, payload-digest манифестов тот же. Публикация идемпотентна — `skip-existing: true` у PyPI-шага и пропуск релиза при существующем теге `v0.5.0`.

Проверку даёт сам этот PR: `HOL Plugin Scanner` триггерится на PR в `main`, так что джоба отработает здесь.