### PR TITLE
fix(tests): убрать отставание детектора рендера в тестах лаунчера

### DIFF
--- a/tests/launcher/test_app.py
+++ b/tests/launcher/test_app.py
@@ -201,10 +201,21 @@ class _TrackingOutput(PlainTextOutput):
         self._frame = ""
         super().__init__(self.stream)
 
+    def _rendered(self) -> str:
+        """Всё выведенное к этому моменту: сброшенный поток плюс ещё не сброшенный буфер.
+
+        ``PlainTextOutput.write`` только копит данные в ``_buffer`` и переливает их
+        в поток лишь во ``flush``, поэтому один ``stream.getvalue()`` отстаёт на
+        кадр: текст последнего кадра, после которого записей не будет, не виден
+        вовсе. Склеивать полезную нагрузку ``write`` тоже нельзя — пробелы
+        частичной перерисовки идут мимо неё, через ``cursor_forward``.
+        """
+        return self.stream.getvalue() + "".join(self._buffer)
+
     def write(self, data: str) -> None:
         super().write(data)
         self._frame += data
-        rendered = self.stream.getvalue()
+        rendered = self._rendered()
         if "Проверяем способ установки" in rendered:
             self.progress_rendered.set()
         if (
@@ -296,6 +307,36 @@ class _SmallTerminalOutput(_TrackingOutput):
         if "[✓] --dry-run" in focused_text:
             self.focused_frames["dry_run_toggled"] = frame
             self.dry_run_toggled.set()
+
+
+def test_tracking_output_sees_last_frame_without_further_writes():
+    """Детектор обязан увидеть текст кадра, после которого записей больше не будет.
+
+    ``PlainTextOutput`` копит вывод в буфере и переливает его в поток только в
+    ``flush``; проверка одного ``stream.getvalue()`` отстаёт на кадр, и текст
+    последнего кадра не виден вовсе.
+    """
+    output = _TrackingOutput()
+
+    output.write("Доступна новая версия: 0.4.0 → 0.5.0")
+
+    assert output.update_result_rendered.is_set()
+
+
+def test_tracking_output_does_not_glue_over_cursor_forward_gap():
+    """Пробел диффового рендера разрывает строку, и детектор обязан это видеть.
+
+    При частичной перерисовке неизменённая ячейка выводится через
+    ``cursor_forward``, то есть пробелом мимо ``write``; склейка только полезной
+    нагрузки ``write`` дала бы ложное срабатывание на «вер сия».
+    """
+    output = _TrackingOutput()
+
+    output.write("Доступна новая вер")
+    output.cursor_forward(1)
+    output.write("сия: 0.4.0 → 0.5.0")
+
+    assert not output.update_result_rendered.is_set()
 
 
 def test_escape_from_palette_returns_clean_cancel():


### PR DESCRIPTION
## Что упало

Прогон Tests на `dev` после мержа #227 — [run 33208006069](https://github.com/mimfort/rag_for_git/actions/runs/33208006069): `tests/launcher/test_app.py::test_completed_update_result_reopens_without_second_network_call`, `assert output.update_result_rendered.is_set()`. Тот же код в PR-прогоне прошёл — тест флаки, а не регрессия.

## Корневая причина

`_TrackingOutput.write` сверялся с `self.stream.getvalue()`. `PlainTextOutput.write` только копит данные в `_buffer` и переливает их в поток лишь во `flush`, поэтому проверка отставала ровно на кадр: текст последнего кадра, после которого записей больше нет, не был виден вовсе.

Измерено на живом прогоне лаунчера: маркер появляется в буфере на записи №401, а в потоке — только на №623.

Почему отставание оказалось фатальным именно там: первый рендер экрана обновления пришёл частичной перерисовкой, а неизменённые ячейки `PlainTextOutput` выводит через `cursor_forward`, то есть пробелами — в логе видно `Доступна новая вер ия: 0.4.0 → 0.5.0`. Целая строка попала только во второй, финальный кадр, после которого записей уже не было.

## Фикс

Детектор смотрит на сброшенный поток плюс ещё не сброшенный буфер — ровно то, что реально выведено. Склейка полезной нагрузки `write` не подошла бы: пробелы частичной перерисовки идут мимо неё и дали бы ложное срабатывание на «вер сия».

Правка только в тестовом хелпере, продовый код не тронут.

## Проверка

- Последовательность из упавшего прогона (мятый кадр → `flush` → целый кадр без записей после) проиграна на обеих версиях детектора: до фикса `False`, после `True`.
- Оба свойства закреплены тестами: видимость последнего кадра и отсутствие склейки через пробел `cursor_forward`.
- `pytest -q` — 4591 passed, 137 deselected; `ruff check` и `ruff format --check` чисты.